### PR TITLE
Add test for Swaps in LidoFixedPriceMultiLpARM.sol.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,9 @@ remappings = [
   "@openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.0.2/",
 ]
 
+[fuzz]
+runs = 1_000
+
 [dependencies]
 forge-std = "1.9.2"
 "@openzeppelin-contracts" = "5.0.2"

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -44,6 +44,7 @@ abstract contract Base_Test_ is Test {
     IERC20 public weth;
     IERC20 public steth;
     IERC20 public wsteth;
+    IERC20 public badToken;
     IOETHVault public vault;
 
     //////////////////////////////////////////////////////

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -37,7 +37,7 @@ abstract contract Base_Test_ is Test {
     Proxy public lidoOwnerProxy;
     OethARM public oethARM;
     LidoOwnerLpARM public lidoOwnerLpARM;
-    LidoFixedPriceMultiLpARM public lidoARM;
+    LidoFixedPriceMultiLpARM public lidoFixedPriceMulltiLpARM;
     LiquidityProviderController public liquidityProviderController;
 
     IERC20 public oeth;

--- a/test/fork/LidoFixedPriceMultiLpARM/Constructor.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/Constructor.t.sol
@@ -16,18 +16,18 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_Constructor_Test is Fork_Shared_
     /// --- PASSING TESTS
     //////////////////////////////////////////////////////
     function test_Initial_State() public {
-        assertEq(lidoARM.name(), "Lido ARM");
-        assertEq(lidoARM.symbol(), "ARM-ST");
-        assertEq(lidoARM.owner(), address(this));
-        assertEq(lidoARM.operator(), operator);
-        assertEq(lidoARM.feeCollector(), feeCollector);
-        assertEq(lidoARM.fee(), 2000);
-        assertEq(lidoARM.lastTotalAssets(), 1e12);
-        assertEq(lidoARM.feesAccrued(), 0);
+        assertEq(lidoFixedPriceMulltiLpARM.name(), "Lido ARM");
+        assertEq(lidoFixedPriceMulltiLpARM.symbol(), "ARM-ST");
+        assertEq(lidoFixedPriceMulltiLpARM.owner(), address(this));
+        assertEq(lidoFixedPriceMulltiLpARM.operator(), operator);
+        assertEq(lidoFixedPriceMulltiLpARM.feeCollector(), feeCollector);
+        assertEq(lidoFixedPriceMulltiLpARM.fee(), 2000);
+        assertEq(lidoFixedPriceMulltiLpARM.lastTotalAssets(), 1e12);
+        assertEq(lidoFixedPriceMulltiLpARM.feesAccrued(), 0);
         // the 20% performance fee is removed on initialization
-        assertEq(lidoARM.totalAssets(), 1e12);
-        assertEq(lidoARM.totalSupply(), 1e12);
-        assertEq(weth.balanceOf(address(lidoARM)), 1e12);
+        assertEq(lidoFixedPriceMulltiLpARM.totalAssets(), 1e12);
+        assertEq(lidoFixedPriceMulltiLpARM.totalSupply(), 1e12);
+        assertEq(weth.balanceOf(address(lidoFixedPriceMulltiLpARM)), 1e12);
         assertEq(liquidityProviderController.totalAssetsCap(), 100 ether);
     }
 }

--- a/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
@@ -29,12 +29,12 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_Deposit_Test_ is Fork_Shared_Tes
 
     function _snapData() internal view returns (AssertData memory data) {
         return AssertData({
-            totalAssets: lidoARM.totalAssets(),
-            totalSupply: lidoARM.totalSupply(),
+            totalAssets: lidoFixedPriceMulltiLpARM.totalAssets(),
+            totalSupply: lidoFixedPriceMulltiLpARM.totalSupply(),
             totalAssetsCap: liquidityProviderController.totalAssetsCap(),
-            armWeth: weth.balanceOf(address(lidoARM)),
-            armSteth: steth.balanceOf(address(lidoARM)),
-            feesAccrued: lidoARM.feesAccrued()
+            armWeth: weth.balanceOf(address(lidoFixedPriceMulltiLpARM)),
+            armSteth: steth.balanceOf(address(lidoFixedPriceMulltiLpARM)),
+            feesAccrued: lidoFixedPriceMulltiLpARM.feesAccrued()
         });
     }
 
@@ -69,7 +69,7 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_Deposit_Test_ is Fork_Shared_Tes
         deal(address(weth), address(this), 10 ether);
         beforeData = _snapData();
 
-        lidoARM.deposit(10 ether);
+        lidoFixedPriceMulltiLpARM.deposit(10 ether);
 
         DeltaData memory delta = noChangeDeltaData;
         delta.totalAssets = 10 ether;

--- a/test/fork/LidoFixedPriceMultiLpARM/RequestRedeem.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/RequestRedeem.t.sol
@@ -22,7 +22,7 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_RequestRedeem_Test_ is Fork_Shar
     {
         deal(address(weth), address(this), 10 ether);
 
-        lidoARM.deposit(10 ether);
-        lidoARM.requestRedeem(8 ether);
+        lidoFixedPriceMulltiLpARM.deposit(10 ether);
+        lidoFixedPriceMulltiLpARM.requestRedeem(8 ether);
     }
 }

--- a/test/fork/LidoFixedPriceMultiLpARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SwapExactTokensForTokens.t.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Test imports
+import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+
+import {IERC20} from "contracts/Interfaces.sol";
+
+contract Fork_Concrete_LidoFixedPriceMultiLpARM_SwapExactTokensForTokens_Test is Fork_Shared_Test_ {
+    //////////////////////////////////////////////////////
+    /// --- CONSTANTS
+    //////////////////////////////////////////////////////
+    uint256 private constant MIN_PRICE0 = 980e33; // 0.98
+    uint256 private constant MAX_PRICE0 = 1_000e33; // 1.00
+    uint256 private constant MIN_PRICE1 = 1_000e33; // 1.00
+    uint256 private constant MAX_PRICE1 = 1_020e33; // 1.02
+    uint256 private constant MAX_WETH_RESERVE = 1_000_000 ether; // 1M WETH, no limit, but need to be consistent.
+    uint256 private constant MAX_STETH_RESERVE = 2_000_000 ether; // 2M stETH, limited by wsteth balance of steth.
+
+    //////////////////////////////////////////////////////
+    /// --- SETUP
+    //////////////////////////////////////////////////////
+    function setUp() public override {
+        super.setUp();
+
+        deal(address(weth), address(this), 1_000 ether);
+        deal(address(steth), address(this), 1_000 ether);
+
+        deal(address(weth), address(lidoFixedPriceMulltiLpARM), 1_000 ether);
+        deal(address(steth), address(lidoFixedPriceMulltiLpARM), 1_000 ether);
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- REVERTING TESTS
+    //////////////////////////////////////////////////////
+    function test_RevertWhen_SwapExactTokensForTokens_Because_InvalidTokenOut1() public {
+        lidoFixedPriceMulltiLpARM.token0();
+        vm.expectRevert("ARM: Invalid token");
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            steth, // inToken
+            badToken, // outToken
+            1, // amountIn
+            1, // amountOutMin
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapExactTokensForTokens_Because_InvalidTokenOut0() public {
+        vm.expectRevert("ARM: Invalid token");
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            weth, // inToken
+            badToken, // outToken
+            1, // amountIn
+            1, // amountOutMin
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapExactTokensForTokens_Because_InvalidTokenIn() public {
+        vm.expectRevert("ARM: Invalid token");
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            badToken, // inToken
+            steth, // outToken
+            1, // amountIn
+            1, // amountOutMin
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapExactTokensForTokens_Because_NotEnoughTokenIn() public {
+        uint256 initialBalance = weth.balanceOf(address(this));
+
+        vm.expectRevert();
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            weth, // inToken
+            steth, // outToken
+            initialBalance + 1, // amountIn
+            0, // amountOutMin
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapExactTokensForTokens_Because_NotEnoughTokenOut() public {
+        uint256 initialBalance = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        deal(address(weth), address(this), initialBalance * 2);
+
+        vm.expectRevert("BALANCE_EXCEEDED"); // Lido error
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            weth, // inToken
+            steth, // outToken
+            initialBalance * 2, // amountIn
+            0, // amountOutMin
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapExactTokensForTokens_Because_InsufficientOutputAmount() public {
+        deal(address(steth), address(lidoFixedPriceMulltiLpARM), 100 wei);
+
+        // Test for this function signature: swapExactTokensForTokens(IERC20,IERC20,uint56,uint256,address)
+        vm.expectRevert("ARM: Insufficient output amount");
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            weth, // inToken
+            steth, // outToken
+            1, // amountIn
+            1_000 ether, // amountOutMin
+            address(this) // to
+        );
+
+        // Test for this function signature: swapExactTokensForTokens(uint256,uint256,address[],address,uint256)
+        address[] memory path = new address[](2);
+        path[0] = address(weth);
+        path[1] = address(steth);
+        vm.expectRevert("ARM: Insufficient output amount");
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            1, // amountIn
+            1_000 ether, // amountOutMin
+            path, // path
+            address(this), // to
+            block.timestamp // deadline
+        );
+    }
+
+    function test_RevertWhen_SwapExactTokensForTokens_Because_InvalidePathLength() public {
+        vm.expectRevert("ARM: Invalid path length");
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            1, // amountIn
+            1, // amountOutMin
+            new address[](3), // path
+            address(this), // to
+            0 // deadline
+        );
+    }
+
+    function test_RevertWhen_SwapExactTokensForTokens_Because_DeadlineExpired() public {
+        vm.expectRevert("ARM: Deadline expired");
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            1, // amountIn
+            1, // amountOutMin
+            new address[](2), // path
+            address(this), // to
+            block.timestamp - 1 // deadline
+        );
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- FUZZING TESTS
+    //////////////////////////////////////////////////////
+    /// @notice Fuzz test for swapExactTokensForTokens(IERC20,IERC20,uint256,uint256,address), with WETH to stETH.
+    /// @param amountIn Amount of WETH to swap. Fuzzed between 0 and steth in the ARM.
+    /// @param stethReserve Amount of stETH in the ARM. Fuzzed between 0 and MAX_STETH_RESERVE.
+    /// @param price Price of the stETH in WETH. Fuzzed between 0.98 and 1.
+    function test_SwapExactTokensForTokens_Weth_To_Steth(uint256 amountIn, uint256 stethReserve, uint256 price)
+        public
+    {
+        // Use random price between 0.98 and 1 for traderate1,
+        // Traderate0 value doesn't matter as it is not used in this test.
+        price = _bound(price, MIN_PRICE0, MAX_PRICE0);
+        lidoFixedPriceMulltiLpARM.setPrices(price, MAX_PRICE1);
+
+        // Set random amount of stETH in the ARM
+        stethReserve = _bound(stethReserve, 0, MAX_STETH_RESERVE);
+        deal(address(steth), address(lidoFixedPriceMulltiLpARM), stethReserve);
+
+        // Calculate maximum amount of WETH to swap
+        // It is ok to take 100% of the balance of stETH of the ARM as the price is below 1.
+        amountIn = _bound(amountIn, 0, stethReserve);
+        deal(address(weth), address(this), amountIn);
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of STETH to receive
+        uint256 traderates1 = lidoFixedPriceMulltiLpARM.traderate1();
+        uint256 minAmount = amountIn * traderates1 / 1e36;
+
+        // Expected events
+        vm.expectEmit({emitter: address(weth)});
+        emit IERC20.Transfer(address(this), address(lidoFixedPriceMulltiLpARM), amountIn);
+        vm.expectEmit({emitter: address(steth)});
+        emit IERC20.Transfer(address(lidoFixedPriceMulltiLpARM), address(this), minAmount + STETH_ERROR_ROUNDING);
+        // Main call
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            weth, // inToken
+            steth, // outToken
+            amountIn, // amountIn
+            minAmount, // amountOutMin
+            address(this) // to
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis, balanceWETHAfterThis + amountIn);
+        assertLt(balanceSTETHBeforeThis + minAmount, balanceSTETHAfterThis);
+        assertEq(balanceWETHBeforeARM + amountIn, balanceWETHAfterARM);
+        assertApproxEqAbs(balanceSTETHBeforeARM, balanceSTETHAfterARM + minAmount, STETH_ERROR_ROUNDING);
+    }
+
+    /// @notice Fuzz test for swapExactTokensForTokens(IERC20,IERC20,uint256,uint256,address), with stETH to WETH.
+    /// @param amountIn Amount of stETH to swap. Fuzzed between 0 and weth in the ARM.
+    /// @param wethReserve Amount of WETH in the ARM. Fuzzed between 0 and MAX_WETH_RESERVE.
+    /// @param price Price of the stETH in WETH. Fuzzed between 1 and 1.02.
+    function test_SwapExactTokensForTokens_Steth_To_Weth(uint256 amountIn, uint256 wethReserve, uint256 price) public {
+        // Use random price between MIN_PRICE1 and MAX_PRICE1 for traderate1,
+        // Traderate0 value doesn't matter as it is not used in this test.
+        price = _bound(price, MIN_PRICE1, MAX_PRICE1);
+        lidoFixedPriceMulltiLpARM.setPrices(MIN_PRICE0, price);
+
+        // Set random amount of WETH in the ARM
+        wethReserve = _bound(wethReserve, 0, MAX_WETH_RESERVE);
+        deal(address(weth), address(lidoFixedPriceMulltiLpARM), wethReserve);
+
+        // Calculate maximum amount of stETH to swap
+        // As the price is below 1, we can take 100% of the balance of WETH of the ARM.
+        amountIn = _bound(amountIn, 0, wethReserve);
+        deal(address(steth), address(this), amountIn);
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of WETH to receive
+        uint256 traderates0 = lidoFixedPriceMulltiLpARM.traderate0();
+        uint256 minAmount = amountIn * traderates0 / 1e36;
+
+        // Expected events
+        vm.expectEmit({emitter: address(steth)});
+        emit IERC20.Transfer(address(this), address(lidoFixedPriceMulltiLpARM), amountIn);
+        vm.expectEmit({emitter: address(weth)});
+        emit IERC20.Transfer(address(lidoFixedPriceMulltiLpARM), address(this), minAmount);
+
+        // Main call
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            steth, // inToken
+            weth, // outToken
+            amountIn, // amountIn
+            minAmount, // amountOutMin
+            address(this) // to
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis + minAmount, balanceWETHAfterThis);
+        assertApproxEqAbs(balanceSTETHBeforeThis, balanceSTETHAfterThis + amountIn, STETH_ERROR_ROUNDING);
+        assertEq(balanceWETHBeforeARM, balanceWETHAfterARM + minAmount);
+        assertApproxEqAbs(balanceSTETHBeforeARM + amountIn, balanceSTETHAfterARM, STETH_ERROR_ROUNDING);
+    }
+}

--- a/test/fork/LidoFixedPriceMultiLpARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SwapExactTokensForTokens.t.sol
@@ -144,6 +144,95 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_SwapExactTokensForTokens_Test is
     }
 
     //////////////////////////////////////////////////////
+    /// --- PASSING TESTS
+    //////////////////////////////////////////////////////
+    function test_SwapExactTokensForTokens_WithDeadLine_Weth_To_Steth() public {
+        uint256 amountIn = 1 ether;
+        address[] memory path = new address[](2);
+        path[0] = address(weth);
+        path[1] = address(steth);
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of STETH to receive
+        uint256 traderates1 = lidoFixedPriceMulltiLpARM.traderate1();
+        uint256 minAmount = amountIn * traderates1 / 1e36;
+
+        // Expected events: Already checked in fuzz tests
+
+        uint256[] memory outputs = new uint256[](2);
+        // Main call
+        outputs = lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            amountIn, // amountIn
+            minAmount, // amountOutMin
+            path, // path
+            address(this), // to
+            block.timestamp // deadline
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis, balanceWETHAfterThis + amountIn);
+        assertLt(balanceSTETHBeforeThis + minAmount, balanceSTETHAfterThis);
+        assertEq(balanceWETHBeforeARM + amountIn, balanceWETHAfterARM);
+        assertApproxEqAbs(balanceSTETHBeforeARM, balanceSTETHAfterARM + minAmount, STETH_ERROR_ROUNDING);
+        assertEq(outputs[0], amountIn);
+        assertEq(outputs[1], minAmount);
+    }
+
+    function test_SwapExactTokensForTokens_WithDeadLine_Steth_To_Weth() public {
+        uint256 amountIn = 1 ether;
+        address[] memory path = new address[](2);
+        path[0] = address(steth);
+        path[1] = address(weth);
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of WETH to receive
+        uint256 traderates0 = lidoFixedPriceMulltiLpARM.traderate0();
+        uint256 minAmount = amountIn * traderates0 / 1e36;
+
+        // Expected events: Already checked in fuzz tests
+
+        uint256[] memory outputs = new uint256[](2);
+        // Main call
+        outputs = lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            amountIn, // amountIn
+            minAmount, // amountOutMin
+            path, // path
+            address(this), // to
+            block.timestamp // deadline
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis + minAmount, balanceWETHAfterThis);
+        assertApproxEqAbs(balanceSTETHBeforeThis, balanceSTETHAfterThis + amountIn, STETH_ERROR_ROUNDING);
+        assertEq(balanceWETHBeforeARM, balanceWETHAfterARM + minAmount);
+        assertApproxEqAbs(balanceSTETHBeforeARM + amountIn, balanceSTETHAfterARM, STETH_ERROR_ROUNDING);
+        assertEq(outputs[0], amountIn);
+        assertEq(outputs[1], minAmount);
+    }
+
+    //////////////////////////////////////////////////////
     /// --- FUZZING TESTS
     //////////////////////////////////////////////////////
     /// @notice Fuzz test for swapExactTokensForTokens(IERC20,IERC20,uint256,uint256,address), with WETH to stETH.

--- a/test/fork/LidoFixedPriceMultiLpARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SwapExactTokensForTokens.t.sol
@@ -78,6 +78,16 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_SwapExactTokensForTokens_Test is
             0, // amountOutMin
             address(this) // to
         );
+
+        initialBalance = steth.balanceOf(address(this));
+        vm.expectRevert("BALANCE_EXCEEDED"); // Lido error
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            steth, // inToken
+            weth, // outToken
+            initialBalance + 3, // amountIn
+            0, // amountOutMin
+            address(this) // to
+        );
     }
 
     function test_RevertWhen_SwapExactTokensForTokens_Because_NotEnoughTokenOut() public {
@@ -88,6 +98,17 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_SwapExactTokensForTokens_Test is
         lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
             weth, // inToken
             steth, // outToken
+            initialBalance * 2, // amountIn
+            0, // amountOutMin
+            address(this) // to
+        );
+
+        initialBalance = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        deal(address(steth), address(this), initialBalance * 2);
+        vm.expectRevert(); // Lido error
+        lidoFixedPriceMulltiLpARM.swapExactTokensForTokens(
+            steth, // inToken
+            weth, // outToken
             initialBalance * 2, // amountIn
             0, // amountOutMin
             address(this) // to
@@ -182,7 +203,7 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_SwapExactTokensForTokens_Test is
 
         // Assertions
         assertEq(balanceWETHBeforeThis, balanceWETHAfterThis + amountIn);
-        assertLt(balanceSTETHBeforeThis + minAmount, balanceSTETHAfterThis);
+        assertApproxEqAbs(balanceSTETHBeforeThis + minAmount, balanceSTETHAfterThis, STETH_ERROR_ROUNDING);
         assertEq(balanceWETHBeforeARM + amountIn, balanceWETHAfterARM);
         assertApproxEqAbs(balanceSTETHBeforeARM, balanceSTETHAfterARM + minAmount, STETH_ERROR_ROUNDING);
         assertEq(outputs[0], amountIn);
@@ -288,7 +309,7 @@ contract Fork_Concrete_LidoFixedPriceMultiLpARM_SwapExactTokensForTokens_Test is
 
         // Assertions
         assertEq(balanceWETHBeforeThis, balanceWETHAfterThis + amountIn);
-        assertLt(balanceSTETHBeforeThis + minAmount, balanceSTETHAfterThis);
+        assertApproxEqAbs(balanceSTETHBeforeThis + minAmount, balanceSTETHAfterThis, STETH_ERROR_ROUNDING);
         assertEq(balanceWETHBeforeARM + amountIn, balanceWETHAfterARM);
         assertApproxEqAbs(balanceSTETHBeforeARM, balanceSTETHAfterARM + minAmount, STETH_ERROR_ROUNDING);
     }

--- a/test/fork/LidoFixedPriceMultiLpARM/SwapTokensForExactTokens.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SwapTokensForExactTokens.t.sol
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Test imports
+import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+
+import {IERC20} from "contracts/Interfaces.sol";
+
+contract Fork_Concrete_LidoFixedPriceMultiLpARM_SwapTokensForExactTokens_Test is Fork_Shared_Test_ {
+    //////////////////////////////////////////////////////
+    /// --- CONSTANTS
+    //////////////////////////////////////////////////////
+    uint256 private constant MIN_PRICE0 = 980e33; // 0.98
+    uint256 private constant MAX_PRICE0 = 1_000e33; // 1.00
+    uint256 private constant MIN_PRICE1 = 1_000e33; // 1.00
+    uint256 private constant MAX_PRICE1 = 1_020e33; // 1.02
+    uint256 private constant MAX_WETH_RESERVE = 1_000_000 ether; // 1M WETH, no limit, but need to be consistent.
+    uint256 private constant MAX_STETH_RESERVE = 2_000_000 ether; // 2M stETH, limited by wsteth balance of steth.
+
+    //////////////////////////////////////////////////////
+    /// --- SETUP
+    //////////////////////////////////////////////////////
+    function setUp() public override {
+        super.setUp();
+
+        deal(address(weth), address(this), 1_000 ether);
+        deal(address(steth), address(this), 1_000 ether);
+
+        deal(address(weth), address(lidoFixedPriceMulltiLpARM), 1_000 ether);
+        deal(address(steth), address(lidoFixedPriceMulltiLpARM), 1_000 ether);
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- REVERTING TESTS
+    //////////////////////////////////////////////////////
+    function test_RevertWhen_SwapTokensForExactTokens_Because_InvalidTokenOut1() public {
+        lidoFixedPriceMulltiLpARM.token0();
+        vm.expectRevert("ARM: Invalid token");
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            steth, // inToken
+            badToken, // outToken
+            1, // amountOut
+            1, // amountOutMax
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapTokensForExactTokens_Because_InvalidTokenOut0() public {
+        vm.expectRevert("ARM: Invalid token");
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            weth, // inToken
+            badToken, // outToken
+            1, // amountOut
+            1, // amountOutMax
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapTokensForExactTokens_Because_InvalidTokenIn() public {
+        vm.expectRevert("ARM: Invalid token");
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            badToken, // inToken
+            steth, // outToken
+            1, // amountOut
+            1, // amountOutMax
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapTokensForExactTokens_Because_NotEnoughTokenIn() public {
+        deal(address(weth), address(this), 0);
+
+        vm.expectRevert();
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            weth, // inToken
+            steth, // outToken
+            1, // amountOut
+            type(uint256).max, // amountOutMax
+            address(this) // to
+        );
+
+        deal(address(steth), address(this), 0);
+        vm.expectRevert();
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            steth, // inToken
+            weth, // outToken
+            STETH_ERROR_ROUNDING + 1, // amountOut *
+            type(uint256).max, // amountOutMax
+            address(this) // to
+        );
+        // Note*: As deal can sometimes leave STETH_ERROR_ROUNDING to `to`, we need to try to transfer more.
+    }
+
+    function test_RevertWhen_SwapTokensForExactTokens_Because_NotEnoughTokenOut() public {
+        deal(address(weth), address(this), 0);
+
+        vm.expectRevert();
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            weth, // inToken
+            steth, // outToken
+            1 ether, // amountOut
+            type(uint256).max, // amountInMax
+            address(this) // to
+        );
+
+        deal(address(steth), address(this), 0);
+        vm.expectRevert("BALANCE_EXCEEDED"); // Lido error
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            steth, // inToken
+            weth, // outToken
+            1 ether, // amountOut
+            type(uint256).max, // amountInMax
+            address(this) // to
+        );
+    }
+
+    function test_RevertWhen_SwapTokensForExactTokens_Because_InsufficientOutputAmount() public {
+        deal(address(steth), address(lidoFixedPriceMulltiLpARM), 100 wei);
+
+        // Test for this function signature: swapTokensForExactTokens(IERC20,IERC20,uint56,uint256,address)
+        vm.expectRevert("ARM: Excess input amount");
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            weth, // inToken
+            steth, // outToken
+            1, // amountOut
+            0, // amountInMax
+            address(this) // to
+        );
+
+        // Test for this function signature: swapTokensForExactTokens(uint256,uint256,address[],address,uint256)
+        address[] memory path = new address[](2);
+        path[0] = address(weth);
+        path[1] = address(steth);
+        vm.expectRevert("ARM: Excess input amount");
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            1, // amountOut
+            0, // amountInMax
+            path, // path
+            address(this), // to
+            block.timestamp // deadline
+        );
+    }
+
+    function test_RevertWhen_SwapTokensForExactTokens_Because_InvalidePathLength() public {
+        vm.expectRevert("ARM: Invalid path length");
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            1, // amountOut
+            1, // amountInMax
+            new address[](3), // path
+            address(this), // to
+            0 // deadline
+        );
+    }
+
+    function test_RevertWhen_SwapTokensForExactTokens_Because_DeadlineExpired() public {
+        vm.expectRevert("ARM: Deadline expired");
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            1, // amountOut
+            1, // amountInMax
+            new address[](2), // path
+            address(this), // to
+            block.timestamp - 1 // deadline
+        );
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- PASSING TESTS
+    //////////////////////////////////////////////////////
+    function test_SwapTokensForExactTokens_WithDeadLine_Weth_To_Steth() public {
+        uint256 amountOut = 1 ether;
+        address[] memory path = new address[](2);
+        path[0] = address(weth);
+        path[1] = address(steth);
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of STETH to receive
+        uint256 traderates1 = lidoFixedPriceMulltiLpARM.traderate1();
+        uint256 amountIn = (amountOut * 1e36 / traderates1) + 1;
+
+        // Expected events: Already checked in fuzz tests
+
+        uint256[] memory outputs = new uint256[](2);
+        // Main call
+        outputs = lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            amountOut, // amountOut
+            amountIn, // amountInMax
+            path, // path
+            address(this), // to
+            block.timestamp // deadline
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis, balanceWETHAfterThis + amountIn);
+        assertApproxEqAbs(balanceSTETHBeforeThis + amountOut, balanceSTETHAfterThis, STETH_ERROR_ROUNDING);
+        assertEq(balanceWETHBeforeARM + amountIn, balanceWETHAfterARM);
+        assertApproxEqAbs(balanceSTETHBeforeARM, balanceSTETHAfterARM + amountOut, STETH_ERROR_ROUNDING);
+        assertEq(outputs[0], amountIn);
+        assertEq(outputs[1], amountOut);
+    }
+
+    function test_SwapTokensForExactTokens_WithDeadLine_Steth_To_Weth() public {
+        uint256 amountOut = 1 ether;
+        address[] memory path = new address[](2);
+        path[0] = address(steth);
+        path[1] = address(weth);
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of WETH to receive
+        uint256 traderates0 = lidoFixedPriceMulltiLpARM.traderate0();
+        uint256 amountIn = (amountOut * 1e36 / traderates0) + 1;
+
+        // Expected events: Already checked in fuzz tests
+
+        uint256[] memory outputs = new uint256[](2);
+        // Main call
+        outputs = lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            amountOut, // amountOut
+            amountIn, // amountInMax
+            path, // path
+            address(this), // to
+            block.timestamp // deadline
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis + amountOut, balanceWETHAfterThis);
+        assertApproxEqAbs(balanceSTETHBeforeThis, balanceSTETHAfterThis + amountIn, STETH_ERROR_ROUNDING);
+        assertEq(balanceWETHBeforeARM, balanceWETHAfterARM + amountOut);
+        assertApproxEqAbs(balanceSTETHBeforeARM + amountIn, balanceSTETHAfterARM, STETH_ERROR_ROUNDING);
+        assertEq(outputs[0], amountIn);
+        assertEq(outputs[1], amountOut);
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- FUZZING TESTS
+    //////////////////////////////////////////////////////
+    /// @notice Fuzz test for swapTokensForExactTokens(IERC20,IERC20,uint256,uint256,address), with WETH to stETH.
+    /// @param amountOut Amount of WETH to swap. Fuzzed between 0 and steth in the ARM.
+    /// @param stethReserve Amount of stETH in the ARM. Fuzzed between 0 and MAX_STETH_RESERVE.
+    /// @param price Price of the stETH in WETH. Fuzzed between 0.98 and 1.
+    function test_SwapTokensForExactTokens_Weth_To_Steth(uint256 amountOut, uint256 stethReserve, uint256 price)
+        public
+    {
+        // Use random price between 0.98 and 1 for traderate1,
+        // Traderate0 value doesn't matter as it is not used in this test.
+        price = _bound(price, MIN_PRICE0, MAX_PRICE0);
+        lidoFixedPriceMulltiLpARM.setPrices(price, MAX_PRICE1);
+
+        // Set random amount of stETH in the ARM
+        stethReserve = _bound(stethReserve, 0, MAX_STETH_RESERVE);
+        deal(address(steth), address(lidoFixedPriceMulltiLpARM), stethReserve);
+
+        // Calculate maximum amount of WETH to swap
+        // It is ok to take 100% of the balance of stETH of the ARM as the price is below 1.
+        amountOut = _bound(amountOut, 0, stethReserve);
+        deal(address(weth), address(this), amountOut * 2 + 1); // // Deal more as AmountIn is greater than AmountOut
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of STETH to receive
+        uint256 traderates1 = lidoFixedPriceMulltiLpARM.traderate1();
+        uint256 amountIn = (amountOut * 1e36 / traderates1) + 1;
+
+        // Expected events
+        vm.expectEmit({emitter: address(weth)});
+        emit IERC20.Transfer(address(this), address(lidoFixedPriceMulltiLpARM), amountIn);
+        vm.expectEmit({emitter: address(steth)});
+        emit IERC20.Transfer(address(lidoFixedPriceMulltiLpARM), address(this), amountOut + STETH_ERROR_ROUNDING);
+        // Main call
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            weth, // inToken
+            steth, // outToken
+            amountOut, // amountOut
+            amountIn, // amountInMax
+            address(this) // to
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis, balanceWETHAfterThis + amountIn);
+        assertApproxEqAbs(balanceSTETHBeforeThis + amountOut, balanceSTETHAfterThis, STETH_ERROR_ROUNDING);
+        assertEq(balanceWETHBeforeARM + amountIn, balanceWETHAfterARM);
+        assertApproxEqAbs(balanceSTETHBeforeARM, balanceSTETHAfterARM + amountOut, STETH_ERROR_ROUNDING);
+    }
+
+    /// @notice Fuzz test for swapTokensForExactTokens(IERC20,IERC20,uint256,uint256,address), with stETH to WETH.
+    /// @param amountOut Amount of stETH to swap. Fuzzed between 0 and weth in the ARM.
+    /// @param wethReserve Amount of WETH in the ARM. Fuzzed between 0 and MAX_WETH_RESERVE.
+    /// @param price Price of the stETH in WETH. Fuzzed between 1 and 1.02.
+    function test_SwapTokensForExactTokens_Steth_To_Weth(uint256 amountOut, uint256 wethReserve, uint256 price)
+        public
+    {
+        // Use random price between MIN_PRICE1 and MAX_PRICE1 for traderate1,
+        // Traderate0 value doesn't matter as it is not used in this test.
+        price = _bound(price, MIN_PRICE1, MAX_PRICE1);
+        lidoFixedPriceMulltiLpARM.setPrices(MIN_PRICE0, price);
+
+        // Set random amount of WETH in the ARM
+        wethReserve = _bound(wethReserve, 0, MAX_WETH_RESERVE);
+        deal(address(weth), address(lidoFixedPriceMulltiLpARM), wethReserve);
+
+        // Calculate maximum amount of stETH to swap
+        // As the price is below 1, we can take 100% of the balance of WETH of the ARM.
+        amountOut = _bound(amountOut, 0, wethReserve);
+        deal(address(steth), address(this), amountOut * 2 + 1); // Deal more as AmountIn is greater than AmountOut
+
+        // State before
+        uint256 balanceWETHBeforeThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHBeforeThis = steth.balanceOf(address(this));
+        uint256 balanceWETHBeforeARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHBeforeARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Get minimum amount of WETH to receive
+        uint256 traderates0 = lidoFixedPriceMulltiLpARM.traderate0();
+        uint256 amountIn = (amountOut * 1e36 / traderates0) + 1;
+
+        // Expected events
+        vm.expectEmit({emitter: address(steth)});
+        emit IERC20.Transfer(address(this), address(lidoFixedPriceMulltiLpARM), amountIn);
+        vm.expectEmit({emitter: address(weth)});
+        emit IERC20.Transfer(address(lidoFixedPriceMulltiLpARM), address(this), amountOut);
+
+        // Main call
+        lidoFixedPriceMulltiLpARM.swapTokensForExactTokens(
+            steth, // inToken
+            weth, // outToken
+            amountOut, // amountOut
+            amountIn, // amountInMax
+            address(this) // to
+        );
+
+        // State after
+        uint256 balanceWETHAfterThis = weth.balanceOf(address(this));
+        uint256 balanceSTETHAfterThis = steth.balanceOf(address(this));
+        uint256 balanceWETHAfterARM = weth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+        uint256 balanceSTETHAfterARM = steth.balanceOf(address(lidoFixedPriceMulltiLpARM));
+
+        // Assertions
+        assertEq(balanceWETHBeforeThis + amountOut, balanceWETHAfterThis);
+        assertApproxEqAbs(balanceSTETHBeforeThis, balanceSTETHAfterThis + amountIn, STETH_ERROR_ROUNDING);
+        assertEq(balanceWETHBeforeARM, balanceWETHAfterARM + amountOut);
+        assertApproxEqAbs(balanceSTETHBeforeARM + amountIn, balanceSTETHAfterARM, STETH_ERROR_ROUNDING);
+    }
+}

--- a/test/fork/shared/Shared.sol
+++ b/test/fork/shared/Shared.sol
@@ -78,7 +78,11 @@ abstract contract Fork_Shared_Test_ is Modifiers {
         require(vm.envExists("PROVIDER_URL"), "PROVIDER_URL not set");
 
         // Create and select a fork.
-        forkId = vm.createSelectFork("mainnet");
+        if (vm.envExists("FORK_BLOCK_NUMBER_MAINNET")) {
+            forkId = vm.createSelectFork("mainnet", vm.envUint("FORK_BLOCK_NUMBER_MAINNET"));
+        } else {
+            forkId = vm.createSelectFork("mainnet");
+        }
     }
 
     function _generateAddresses() internal {
@@ -97,6 +101,7 @@ abstract contract Fork_Shared_Test_ is Modifiers {
         steth = IERC20(resolver.resolve("STETH"));
         wsteth = IERC20(resolver.resolve("WSTETH"));
         vault = IOETHVault(resolver.resolve("OETH_VAULT"));
+        badToken = IERC20(vm.randomAddress());
     }
 
     function _deployContracts() internal {
@@ -185,6 +190,7 @@ abstract contract Fork_Shared_Test_ is Modifiers {
         vm.label(address(oeth), "OETH");
         vm.label(address(weth), "WETH");
         vm.label(address(steth), "stETH");
+        vm.label(address(badToken), "BAD TOKEN");
         vm.label(address(vault), "OETH VAULT");
         vm.label(address(oethARM), "OETH ARM");
         vm.label(address(proxy), "OETH ARM PROXY");

--- a/test/fork/shared/Shared.sol
+++ b/test/fork/shared/Shared.sol
@@ -158,10 +158,10 @@ abstract contract Fork_Shared_Test_ is Modifiers {
         lidoProxy.initialize(address(lidoImpl), address(this), data);
 
         // Set the Proxy as the LidoARM.
-        lidoARM = LidoFixedPriceMultiLpARM(payable(address(lidoProxy)));
+        lidoFixedPriceMulltiLpARM = LidoFixedPriceMultiLpARM(payable(address(lidoProxy)));
 
         // set prices
-        lidoARM.setPrices(992 * 1e33, 1001 * 1e33);
+        lidoFixedPriceMulltiLpARM.setPrices(992 * 1e33, 1001 * 1e33);
 
         // --- Deploy LidoOwnerLpARM implementation ---
         // Deploy LidoOwnerLpARM implementation.
@@ -188,7 +188,7 @@ abstract contract Fork_Shared_Test_ is Modifiers {
         vm.label(address(vault), "OETH VAULT");
         vm.label(address(oethARM), "OETH ARM");
         vm.label(address(proxy), "OETH ARM PROXY");
-        vm.label(address(lidoARM), "LIDO ARM");
+        vm.label(address(lidoFixedPriceMulltiLpARM), "LIDO ARM");
         vm.label(address(lidoProxy), "LIDO ARM PROXY");
         vm.label(address(lidoOwnerLpARM), "LIDO OWNER LP ARM");
         vm.label(address(lidoOwnerProxy), "LIDO OWNER LP ARM PROXY");

--- a/test/fork/utils/Helpers.sol
+++ b/test/fork/utils/Helpers.sol
@@ -19,9 +19,14 @@ abstract contract Helpers is Base_Test_ {
             // Check than whale as enough stETH. Whale is wsteth contract.
             require(steth.balanceOf(address(wsteth)) >= amount, "Fork_Shared_Test_: Not enough stETH in WHALE_stETH");
 
-            // Transfer stETH from WHALE_stETH to the user.
-            vm.prank(address(wsteth));
-            steth.transfer(to, amount);
+            if (amount == 0) {
+                vm.prank(to);
+                steth.transfer(address(0x1), steth.balanceOf(to));
+            } else {
+                // Transfer stETH from WHALE_stETH to the user.
+                vm.prank(address(wsteth));
+                steth.transfer(to, amount);
+            }
         } else {
             super.deal(token, to, amount);
         }

--- a/test/fork/utils/Modifiers.sol
+++ b/test/fork/utils/Modifiers.sol
@@ -36,7 +36,7 @@ abstract contract Modifiers is Helpers {
 
     /// @notice Impersonate the owner of LidoFixedPriceMultiLpARM contract.
     modifier asLidoFixedPriceMultiLpARMOwner() {
-        vm.startPrank(lidoARM.owner());
+        vm.startPrank(lidoFixedPriceMulltiLpARM.owner());
         _;
         vm.stopPrank();
     }


### PR DESCRIPTION
Add concrete and fuzz test for two external functions in `LidoFixedPriceMultiLpARM.sol`:
- `swapExactTokensForTokens()`
- `swapTokensForExactTokens()`

For fuzzing:
- Put a random price for one token.
- Put random liquidity for the other in the ARM.
- Swap a random amount.

Coverage 100% for these 2 functions.