### PR TITLE
Add Zapper for LidoARM

### DIFF
--- a/script/deploy/mainnet/003_UpgradeLidoARMScript.sol
+++ b/script/deploy/mainnet/003_UpgradeLidoARMScript.sol
@@ -25,6 +25,7 @@ contract UpgradeLidoARMMainnetScript is AbstractDeployScript {
     Proxy lidoARMProxy;
     Proxy capManProxy;
     LidoARM lidoARMImpl;
+    CapManager capManager;
 
     function _execute() internal override {
         console.log("Deploy:", DEPLOY_NAME);
@@ -45,13 +46,13 @@ contract UpgradeLidoARMMainnetScript is AbstractDeployScript {
         // 4. Initialize Proxy with CapManager implementation and set the owner to the deployer for now
         bytes memory data = abi.encodeWithSignature("initialize(address)", Mainnet.ARM_RELAYER);
         capManProxy.initialize(address(capManagerImpl), deployer, data);
-        CapManager capManager = CapManager(address(capManProxy));
+        capManager = CapManager(address(capManProxy));
 
         // 5. Set the liquidity Provider caps
-        capManager.setTotalAssetsCap(1000 ether);
+        capManager.setTotalAssetsCap(100 ether);
         address[] memory liquidityProviders = new address[](1);
         liquidityProviders[0] = Mainnet.TREASURY;
-        capManager.setLiquidityProviderCaps(liquidityProviders, 10 ether);
+        capManager.setLiquidityProviderCaps(liquidityProviders, 100 ether);
 
         // 6. Deploy Lido implementation
         lidoARMImpl = new LidoARM(Mainnet.STETH, Mainnet.WETH, Mainnet.LIDO_WITHDRAWAL);
@@ -126,12 +127,30 @@ contract UpgradeLidoARMMainnetScript is AbstractDeployScript {
         lidoARMProxy.upgradeToAndCall(address(lidoARMImpl), data);
 
         // Set the buy price with a 8 basis point discount. The sell price is 1.0
-        LidoARM(payable(Mainnet.LIDO_ARM)).setPrices(9994e32, 1e36);
+        LidoARM(payable(Mainnet.LIDO_ARM)).setPrices(0.9994e36, 0.9998e36);
 
         // transfer ownership of the Lido ARM proxy to the mainnet 5/8 multisig
         lidoARMProxy.setOwner(Mainnet.GOV_MULTISIG);
 
         console.log("Finished running initializing Lido ARM as ARM_MULTISIG");
+
+        if (tenderlyTestnet) {
+            vm.stopBroadcast();
+        } else {
+            vm.stopPrank();
+        }
+
+        if (tenderlyTestnet) {
+            console.log("Broadcasting fork script to Tenderly as: %s", Mainnet.ARM_RELAYER);
+            vm.startBroadcast(Mainnet.ARM_RELAYER);
+        } else {
+            vm.startPrank(Mainnet.ARM_RELAYER);
+        }
+
+        // Add some test liquidity providers
+        address[] memory testProviders = new address[](1);
+        testProviders[0] = 0x3bB354a1E0621F454c5D5CE98f6ea21a53bf2d7d;
+        capManager.setLiquidityProviderCaps(testProviders, 100 ether);
 
         if (tenderlyTestnet) {
             vm.stopBroadcast();

--- a/script/deploy/mainnet/003_UpgradeLidoARMScript.sol
+++ b/script/deploy/mainnet/003_UpgradeLidoARMScript.sol
@@ -9,6 +9,7 @@ import {IERC20, IWETH, LegacyAMM} from "contracts/Interfaces.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
 import {CapManager} from "contracts/CapManager.sol";
 import {Proxy} from "contracts/Proxy.sol";
+import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
 import {Mainnet} from "contracts/utils/Addresses.sol";
 import {GovProposal, GovSixHelper} from "contracts/utils/GovSixHelper.sol";
 import {AbstractDeployScript} from "../AbstractDeployScript.sol";
@@ -58,6 +59,11 @@ contract UpgradeLidoARMMainnetScript is AbstractDeployScript {
 
         // 7. Transfer ownership of CapManager to the mainnet 5/8 multisig
         capManProxy.setOwner(Mainnet.GOV_MULTISIG);
+
+        // 8. Deploy the Zapper
+        ZapperLidoARM zapper = new ZapperLidoARM(Mainnet.WETH, Mainnet.LIDO_ARM);
+        zapper.setOwner(Mainnet.STRATEGIST);
+        _recordDeploy("LIDO_ARM_ZAPPER", address(zapper));
 
         console.log("Finished deploying", DEPLOY_NAME);
 

--- a/src/contracts/Interfaces.sol
+++ b/src/contracts/Interfaces.sol
@@ -107,7 +107,7 @@ interface IOethARM {
     function claimWithdrawals(uint256[] calldata requestIds) external;
 }
 
-interface ILiquidityProviderARM {
+interface ILiquidityProviderARM is IERC20 {
     function previewDeposit(uint256 assets) external returns (uint256 shares);
     function deposit(uint256 assets) external returns (uint256 shares);
 
@@ -256,7 +256,3 @@ interface IStETHWithdrawal {
     function getLastRequestId() external view returns (uint256);
 }
 
-interface ILidoARM {
-    function deposit(uint256 assets) external returns (uint256 shares);
-    function transfer(address to, uint256 shares) external returns (bool);
-}

--- a/src/contracts/Interfaces.sol
+++ b/src/contracts/Interfaces.sol
@@ -255,3 +255,8 @@ interface IStETHWithdrawal {
     function getWithdrawalRequests(address _owner) external view returns (uint256[] memory requestsIds);
     function getLastRequestId() external view returns (uint256);
 }
+
+interface ILidoARM {
+    function deposit(uint256 assets) external returns (uint256 shares);
+    function transfer(address to, uint256 shares) external returns (bool);
+}

--- a/src/contracts/Interfaces.sol
+++ b/src/contracts/Interfaces.sol
@@ -255,4 +255,3 @@ interface IStETHWithdrawal {
     function getWithdrawalRequests(address _owner) external view returns (uint256[] memory requestsIds);
     function getLastRequestId() external view returns (uint256);
 }
-

--- a/src/contracts/ZapperLidoARM.sol
+++ b/src/contracts/ZapperLidoARM.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+// Contracts
+import {Ownable} from "./Ownable.sol";
+
+// Interfaces
 import {IWETH} from "./Interfaces.sol";
 import {IERC20} from "./Interfaces.sol";
 import {ILidoARM} from "./Interfaces.sol";
-
-import {Ownable} from "./Ownable.sol";
 
 contract ZapperLidoARM is Ownable {
     IWETH public immutable weth;

--- a/src/contracts/ZapperLidoARM.sol
+++ b/src/contracts/ZapperLidoARM.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {IWETH} from "./Interfaces.sol";
+import {IERC20} from "./Interfaces.sol";
+import {ILidoARM} from "./Interfaces.sol";
+
+import {Ownable} from "./Ownable.sol";
+
+contract ZapperLidoARM is Ownable {
+    IWETH public immutable weth;
+    ILidoARM public immutable lidoArm;
+
+    event Zap(address indexed sender, uint256 shares);
+
+    constructor(address _weth, address _lidoArm) {
+        weth = IWETH(_weth);
+        lidoArm = ILidoARM(_lidoArm);
+
+        weth.approve(_lidoArm, type(uint256).max);
+    }
+
+    /// @notice Deposit ETH to LidoARM and receive shares
+    receive() external payable {
+        deposit();
+    }
+
+    /// @notice Deposit ETH to LidoARM and receive shares
+    function deposit() public payable returns (uint256 shares) {
+        // Wrap all ETH to WETH
+        uint256 balance = address(this).balance;
+        weth.deposit{value: balance}();
+
+        // Deposit all WETH to LidoARM
+        shares = lidoArm.deposit(balance);
+
+        // Transfer received shares to msg.sender
+        lidoArm.transfer(msg.sender, shares);
+
+        // Emit event
+        emit Zap(msg.sender, shares);
+    }
+
+    /// @notice Rescue ERC20 tokens
+    /// @param token The address of the ERC20 token
+    function rescueERC20(address token, uint256 amount) external onlyOwner {
+        IERC20(token).transfer(msg.sender, amount);
+    }
+}

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -9,6 +9,7 @@ import {Proxy} from "contracts/Proxy.sol";
 import {OethARM} from "contracts/OethARM.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
 import {CapManager} from "contracts/CapManager.sol";
+import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
 
 // Interfaces
 import {IERC20} from "contracts/Interfaces.sol";
@@ -37,6 +38,7 @@ abstract contract Base_Test_ is Test {
     OethARM public oethARM;
     LidoARM public lidoARM;
     CapManager public capManager;
+    ZapperLidoARM public zapperLidoARM;
 
     IERC20 public oeth;
     IERC20 public weth;

--- a/test/fork/Zapper/Deposit.t.sol
+++ b/test/fork/Zapper/Deposit.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// Test imports
+import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+
+// Contracts
+import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
+
+contract Fork_Concrete_ZapperLidoARM_Deposit_Test_ is Fork_Shared_Test_ {
+    function setUp() public override {
+        super.setUp();
+
+        vm.deal(address(this), DEFAULT_AMOUNT);
+    }
+
+    function test_Deposit_ViaFunction() public setLiquidityProviderCap(address(zapperLidoARM), DEFAULT_AMOUNT) {
+        assertEq(lidoARM.balanceOf(address(this)), 0);
+        uint256 expectedShares = lidoARM.previewDeposit(DEFAULT_AMOUNT);
+
+        vm.expectEmit({emitter: address(zapperLidoARM)});
+        emit ZapperLidoARM.Zap(address(this), expectedShares);
+        // Deposit
+        zapperLidoARM.deposit{value: DEFAULT_AMOUNT}();
+
+        // Check balance
+        assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT);
+    }
+
+    function test_Deposit_ViaCall() public setLiquidityProviderCap(address(zapperLidoARM), DEFAULT_AMOUNT) {
+        assertEq(lidoARM.balanceOf(address(this)), 0);
+        uint256 expectedShares = lidoARM.previewDeposit(DEFAULT_AMOUNT);
+
+        vm.expectEmit({emitter: address(zapperLidoARM)});
+        emit ZapperLidoARM.Zap(address(this), expectedShares);
+        // Deposit
+        (bool success,) = address(zapperLidoARM).call{value: DEFAULT_AMOUNT}("");
+        assertTrue(success);
+
+        // Check balance
+        assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT);
+    }
+}

--- a/test/fork/Zapper/Deposit.t.sol
+++ b/test/fork/Zapper/Deposit.t.sol
@@ -19,7 +19,7 @@ contract Fork_Concrete_ZapperLidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         uint256 expectedShares = lidoARM.previewDeposit(DEFAULT_AMOUNT);
 
         vm.expectEmit({emitter: address(zapperLidoARM)});
-        emit ZapperLidoARM.Zap(address(this), expectedShares);
+        emit ZapperLidoARM.Zap(address(this), DEFAULT_AMOUNT, expectedShares);
         // Deposit
         zapperLidoARM.deposit{value: DEFAULT_AMOUNT}();
 
@@ -32,7 +32,7 @@ contract Fork_Concrete_ZapperLidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         uint256 expectedShares = lidoARM.previewDeposit(DEFAULT_AMOUNT);
 
         vm.expectEmit({emitter: address(zapperLidoARM)});
-        emit ZapperLidoARM.Zap(address(this), expectedShares);
+        emit ZapperLidoARM.Zap(address(this), DEFAULT_AMOUNT, expectedShares);
         // Deposit
         (bool success,) = address(zapperLidoARM).call{value: DEFAULT_AMOUNT}("");
         assertTrue(success);

--- a/test/fork/Zapper/RescueToken.sol
+++ b/test/fork/Zapper/RescueToken.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// Test imports
+import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+
+// Contracts
+import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
+
+contract Fork_Concrete_ZapperLidoARM_RescueToken_Test_ is Fork_Shared_Test_ {
+    function test_RevertWhen_RescueToken_CalledByNonOwner() public asRandomAddress {
+        vm.expectRevert("ARM: Only owner can call this function.");
+        zapperLidoARM.rescueERC20(address(badToken), DEFAULT_AMOUNT);
+    }
+
+    function test_RescueToken() public {
+        deal(address(weth), address(zapperLidoARM), DEFAULT_AMOUNT);
+        assertEq(weth.balanceOf(address(zapperLidoARM)), DEFAULT_AMOUNT);
+        assertEq(weth.balanceOf(address(this)), 0);
+
+        // Rescue the tokens
+        vm.prank(zapperLidoARM.owner());
+        zapperLidoARM.rescueERC20(address(weth), DEFAULT_AMOUNT);
+
+        // Check balance
+        assertEq(weth.balanceOf(address(zapperLidoARM)), 0);
+        assertEq(weth.balanceOf(address(this)), DEFAULT_AMOUNT);
+    }
+}

--- a/test/fork/shared/Shared.sol
+++ b/test/fork/shared/Shared.sol
@@ -12,6 +12,7 @@ import {Proxy} from "contracts/Proxy.sol";
 import {OethARM} from "contracts/OethARM.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
 import {CapManager} from "contracts/CapManager.sol";
+import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
 
 // Interfaces
 import {IERC20} from "contracts/Interfaces.sol";
@@ -165,6 +166,9 @@ abstract contract Fork_Shared_Test_ is Modifiers {
 
         // set prices
         lidoARM.setPrices(992 * 1e33, 1001 * 1e33);
+
+        // --- Deploy ZapperLidoARM ---
+        zapperLidoARM = new ZapperLidoARM(address(weth), address(lidoProxy));
     }
 
     function _label() internal {
@@ -178,6 +182,7 @@ abstract contract Fork_Shared_Test_ is Modifiers {
         vm.label(address(lidoARM), "LIDO ARM");
         vm.label(address(lidoProxy), "LIDO ARM PROXY");
         vm.label(address(capManager), "LIQUIDITY PROVIDER CONTROLLER");
+        vm.label(address(zapperLidoARM), "ZAPPER LIDO ARM");
         vm.label(operator, "OPERATOR");
         vm.label(oethWhale, "WHALE OETH");
         vm.label(governor, "GOVERNOR");


### PR DESCRIPTION
## General

Zapper to deposit liquidity in ARM with raw ETH instead of wETH in a single transaction.

## Constraint for `claimRedeem`

At the moment, as only the msg.sender can be the withdrawer, it is not possible for the zapper to withdraw for someone and then unwrap wETH for ETH. 
