### PR TITLE
Pre launch changes

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -418,7 +418,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // before the cross price was lowered.
         if (newCrossPrice < crossPrice) {
             // Check there is not a significant amount of base assets in the ARM
-            require(IERC20(baseAsset).balanceOf(address(this)) < MIN_TOTAL_SUPPLY, "ARM: too many base assets");
+            require(IERC20(baseAsset).balanceOf(address(this)) <= MIN_TOTAL_SUPPLY, "ARM: too many base assets");
         }
 
         // Save the new cross price to storage

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -418,7 +418,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // before the cross price was lowered.
         if (newCrossPrice < crossPrice) {
             // Check there is not a significant amount of base assets in the ARM
-            require(IERC20(baseAsset).balanceOf(address(this)) <= MIN_TOTAL_SUPPLY, "ARM: too many base assets");
+            require(IERC20(baseAsset).balanceOf(address(this)) < MIN_TOTAL_SUPPLY, "ARM: too many base assets");
         }
 
         // Save the new cross price to storage

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -409,7 +409,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         require(newCrossPrice >= PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION, "ARM: cross price too low");
         require(newCrossPrice <= PRICE_SCALE, "ARM: cross price too high");
         // The exiting sell price must be greater than or equal to the new cross price
-        require(PRICE_SCALE * PRICE_SCALE / traderate0 >= crossPrice, "ARM: sell price too low");
+        require(PRICE_SCALE * PRICE_SCALE / traderate0 >= newCrossPrice, "ARM: sell price too low");
         // The existing buy price must be less than the new cross price
         require(traderate1 < newCrossPrice, "ARM: buy price too high");
 

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -93,7 +93,7 @@ contract LidoARM is Initializable, AbstractARM {
      * @notice Claim the ETH owed from the redemption requests and convert it to WETH.
      * Before calling this method, caller should check on the request NFTs to ensure the withdrawal was processed.
      */
-    function claimLidoWithdrawals(uint256[] memory requestIds) external onlyOperatorOrOwner {
+    function claimLidoWithdrawals(uint256[] memory requestIds) external {
         uint256 etherBefore = address(this).balance;
 
         // Claim the NFTs for ETH.

--- a/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
@@ -305,13 +305,9 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         lidoARM.setCrossPrice(1e36);
         lidoARM.setPrices(1e36 - 1, 1e36);
 
-        //assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY), "last available assets before Ahhhh");
-
         // User Swap stETH for 3/4 of WETH in the ARM
         deal(address(steth), address(this), DEFAULT_AMOUNT);
         lidoARM.swapTokensForExactTokens(steth, weth, 3 * DEFAULT_AMOUNT / 4, DEFAULT_AMOUNT, address(this));
-        emit log_named_uint("WETH balance after swap", weth.balanceOf(address(lidoARM)));
-        emit log_named_uint("stETH balance after swap", steth.balanceOf(address(lidoARM)));
 
         // First user requests a full withdrawal
         uint256 firstUserShares = lidoARM.balanceOf(address(this));

--- a/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
@@ -305,9 +305,13 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         lidoARM.setCrossPrice(1e36);
         lidoARM.setPrices(1e36 - 1, 1e36);
 
+        //assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY), "last available assets before Ahhhh");
+
         // User Swap stETH for 3/4 of WETH in the ARM
         deal(address(steth), address(this), DEFAULT_AMOUNT);
         lidoARM.swapTokensForExactTokens(steth, weth, 3 * DEFAULT_AMOUNT / 4, DEFAULT_AMOUNT, address(this));
+        emit log_named_uint("WETH balance after swap", weth.balanceOf(address(lidoARM)));
+        emit log_named_uint("stETH balance after swap", steth.balanceOf(address(lidoARM)));
 
         // First user requests a full withdrawal
         uint256 firstUserShares = lidoARM.balanceOf(address(this));
@@ -322,7 +326,12 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), wethBalanceBefore, "WETH ARM balance before");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether before");
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued before");
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY), "last available assets before");
+        assertApproxEqAbs(
+            lidoARM.lastAvailableAssets(),
+            int256(MIN_TOTAL_SUPPLY),
+            STETH_ERROR_ROUNDING,
+            "last available assets before"
+        );
         assertEq(lidoARM.balanceOf(alice), 0, "alice shares before");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply before");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, "total assets before");
@@ -351,7 +360,12 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), wethBalanceBefore + amount, "WETH ARM balance after");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether after");
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued after"); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + amount), "last available assets after");
+        assertApproxEqAbs(
+            lidoARM.lastAvailableAssets(),
+            int256(MIN_TOTAL_SUPPLY + amount),
+            STETH_ERROR_ROUNDING,
+            "last available assets after"
+        );
         assertEq(lidoARM.balanceOf(alice), shares, "alice shares after");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount, "total supply after");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount, "total assets after");

--- a/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
@@ -69,14 +69,27 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
     //////////////////////////////////////////////////////
     /// --- PASSING TESTS
     //////////////////////////////////////////////////////
+    function test_SetCrossPrice_No_StETH_Owner() public {
+        deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY - 1);
 
-    function test_SetCrossPrice() public {
-        assertEq(lidoARM.crossPrice(), 1e36);
-
+        // at 1.0
         vm.expectEmit({emitter: address(lidoARM)});
-        emit AbstractARM.CrossPriceUpdated(1e36 - 1);
-        lidoARM.setCrossPrice(1e36 - 1);
+        emit AbstractARM.CrossPriceUpdated(1e36);
+        lidoARM.setCrossPrice(1e36);
 
-        assertEq(lidoARM.crossPrice(), 1e36 - 1);
+        // 20 basis points lower than 1.0
+        vm.expectEmit({emitter: address(lidoARM)});
+        emit AbstractARM.CrossPriceUpdated(0.998e36);
+        lidoARM.setCrossPrice(0.998e36);
+    }
+
+    function test_SetCrossPrice_With_StETH_PriceUp_Owner() public {
+        // 2 basis points lower than 1.0
+        lidoARM.setCrossPrice(0.9998e36);
+
+        deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY + 1);
+
+        // 1 basis points lower than 1.0
+        lidoARM.setCrossPrice(0.9999e36);
     }
 }

--- a/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.23;
 import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
 
 // Contracts
+import {AbstractARM} from "contracts/AbstractARM.sol";
 
 contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
     //////////////////////////////////////////////////////
@@ -17,6 +18,16 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
     //////////////////////////////////////////////////////
     /// --- REVERTING TESTS
     //////////////////////////////////////////////////////
+    function test_RevertWhen_SetCrossPrice_Because_NotOwner() public asRandomAddress {
+        vm.expectRevert("ARM: Only owner can call this function.");
+        lidoARM.setCrossPrice(0.9998e36);
+    }
+
+    function test_RevertWhen_SetCrossPrice_Because_Operator() public asOperator {
+        vm.expectRevert("ARM: Only owner can call this function.");
+        lidoARM.setCrossPrice(0.9998e36);
+    }
+
     function test_RevertWhen_SetCrossPrice_Because_CrossPriceTooLow() public {
         vm.expectRevert("ARM: cross price too low");
         lidoARM.setCrossPrice(0);
@@ -50,7 +61,7 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
     }
 
     function test_RevertWhen_SetCrossPrice_Because_TooManyBaseAssets() public {
-        deal(address(steth), address(lidoARM), 1e18);
+        deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY + 1);
         vm.expectRevert("ARM: too many base assets");
         lidoARM.setCrossPrice(1e36 - 1);
     }
@@ -58,4 +69,14 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
     //////////////////////////////////////////////////////
     /// --- PASSING TESTS
     //////////////////////////////////////////////////////
+
+    function test_SetCrossPrice() public {
+        assertEq(lidoARM.crossPrice(), 1e36);
+
+        vm.expectEmit({emitter: address(lidoARM)});
+        emit AbstractARM.CrossPriceUpdated(1e36 - 1);
+        lidoARM.setCrossPrice(1e36 - 1);
+
+        assertEq(lidoARM.crossPrice(), 1e36 - 1);
+    }
 }

--- a/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Test imports
+import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+
+// Contracts
+
+contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
+    //////////////////////////////////////////////////////
+    /// --- SETUP
+    //////////////////////////////////////////////////////
+    function setUp() public override {
+        super.setUp();
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- REVERTING TESTS
+    //////////////////////////////////////////////////////
+    function test_RevertWhen_SetCrossPrice_Because_CrossPriceTooLow() public {
+        vm.expectRevert("ARM: cross price too low");
+        lidoARM.setCrossPrice(0);
+    }
+
+    function test_RevertWhen_SetCrossPrice_Because_CrossPriceTooHigh() public {
+        uint256 priceScale = 10 ** 36;
+        vm.expectRevert("ARM: cross price too high");
+        lidoARM.setCrossPrice(priceScale + 1);
+    }
+
+    function test_RevertWhen_SetCrossPrice_Because_BuyPriceTooHigh() public {
+        lidoARM.setPrices(1e36 - 20e32 + 1, 1000 * 1e33 + 1);
+        vm.expectRevert("ARM: buy price too high");
+        lidoARM.setCrossPrice(1e36 - 20e32);
+    }
+
+    function test_RevertWhen_SetCrossPrice_Because_SellPriceTooLow() public {
+        // To make it revert we need to try to make cross price above the sell1.
+        // But we need to keep cross price below 1e36!
+        // So first we reduce buy and sell price to minimum values
+        lidoARM.setPrices(1e36 - 20e32, 1000 * 1e33 + 1);
+        // This allow us to set a cross price below 1e36
+        lidoARM.setCrossPrice(1e36 - 20e32 + 1);
+        // Then we make both buy and sell price below the 1e36
+        lidoARM.setPrices(1e36 - 20e32, 1e36 - 20e32 + 1);
+
+        // Then we try to set cross price above the sell price
+        vm.expectRevert("ARM: sell price too low");
+        lidoARM.setCrossPrice(1e36 - 20e32 + 2);
+    }
+
+    function test_RevertWhen_SetCrossPrice_Because_TooManyBaseAssets() public {
+        deal(address(steth), address(lidoARM), 1e18);
+        vm.expectRevert("ARM: too many base assets");
+        lidoARM.setCrossPrice(1e36 - 1);
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- PASSING TESTS
+    //////////////////////////////////////////////////////
+}

--- a/test/fork/LidoFixedPriceMultiLpARM/Setters.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/Setters.t.sol
@@ -150,32 +150,6 @@ contract Fork_Concrete_lidoARM_Setters_Test_ is Fork_Shared_Test_ {
     /// --- Set Cross Price - PASSING TESTS
     //////////////////////////////////////////////////////
 
-    function test_SetCrossPrice_No_StETH_Owner() public {
-        deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY - 1);
-
-        // at 1.0
-        vm.expectEmit({emitter: address(lidoARM)});
-        emit AbstractARM.CrossPriceUpdated(1e36);
-        lidoARM.setCrossPrice(1e36);
-
-        // 20 basis points lower than 1.0
-        vm.expectEmit({emitter: address(lidoARM)});
-        emit AbstractARM.CrossPriceUpdated(0.998e36);
-        lidoARM.setCrossPrice(0.998e36);
-    }
-
-    function test_SetCrossPrice_With_StETH_PriceUp_Owner() public {
-        // 2 basis points lower than 1.0
-        lidoARM.setCrossPrice(0.9998e36);
-
-        deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY + 1);
-
-        // 4 basis points lower than 1.0
-        // vm.expectEmit({emitter: address(lidoARM)});
-        // emit AbstractARM.CrossPriceUpdated(0.9996e36);
-        lidoARM.setCrossPrice(0.9999e36);
-    }
-
     //////////////////////////////////////////////////////
     /// --- OWNABLE - REVERTING TESTS
     //////////////////////////////////////////////////////

--- a/test/fork/LidoFixedPriceMultiLpARM/Setters.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/Setters.t.sol
@@ -118,12 +118,12 @@ contract Fork_Concrete_lidoARM_Setters_Test_ is Fork_Shared_Test_ {
         lidoARM.setPrices(0, 0);
     }
 
-    function test_SellPriceCannotCrossOneByMoreThanTenBps() public asOperator {
+    function test_RevertWhen_SetPrices_Because_SellPriceCannotCrossOneByMoreThanTenBps() public asOperator {
         vm.expectRevert("ARM: sell price too low");
         lidoARM.setPrices(0.998 * 1e36, 0.9989 * 1e36);
     }
 
-    function test_BuyPriceCannotCrossOneByMoreThanTenBps() public asOperator {
+    function test_RevertWhen_SetPrices_Because_BuyPriceCannotCrossOneByMoreThanTenBps() public asOperator {
         vm.expectRevert("ARM: buy price too high");
         lidoARM.setPrices(1.0011 * 1e36, 1.002 * 1e36);
     }
@@ -144,36 +144,6 @@ contract Fork_Concrete_lidoARM_Setters_Test_ is Fork_Shared_Test_ {
         // Check the traderates
         assertEq(lidoARM.traderate0(), 500 * 1e33);
         assertEq(lidoARM.traderate1(), 992 * 1e33);
-    }
-
-    //////////////////////////////////////////////////////
-    /// --- Set Cross Price - REVERTING TESTS
-    //////////////////////////////////////////////////////
-    function test_RevertWhen_SetCrossPrice_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
-        lidoARM.setCrossPrice(0.9998e36);
-    }
-
-    function test_RevertWhen_SetCrossPrice_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
-        lidoARM.setCrossPrice(0.9998e36);
-    }
-
-    function test_RevertWhen_SetCrossPrice_Because_PriceRange() public asLidoARMOwner {
-        // 21 basis points lower than 1.0
-        vm.expectRevert("ARM: cross price too low");
-        lidoARM.setCrossPrice(0.9979e36);
-
-        // 1 basis points higher than 1.0
-        vm.expectRevert("ARM: cross price too high");
-        lidoARM.setCrossPrice(1.0001e36);
-    }
-
-    function test_RevertWhen_SetCrossPrice_With_stETH_Because_PriceDrop() public {
-        deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY + 1);
-
-        vm.expectRevert("ARM: too many base assets");
-        lidoARM.setCrossPrice(0.9998e36);
     }
 
     //////////////////////////////////////////////////////


### PR DESCRIPTION
* Set buy and sell prices in `initialize` function
* `setCrossPrice` now validates buy and sell prices against the new cross price

TODO

- [x] Add tests for new buy and sell price checks in `setCrossPrice`
- [x] Address is in failing `test_Deposit_NoFeesAccrued_WithdrawalRequestsOutstanding_SecondDepositDiffUser_NoPerfs` test
- [x] Allow anyone to call `claimLidoWithdrawals`