### PR TITLE
Fix contract verification & update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,20 @@ snapshot:
 	@forge snapshot
 
 # Tests
+test-std:
+	forge test --summary --fail-fast --show-progress
+
 test:
-	@forge test --summary --fail-fast --show-progress
+	@FOUNDRY_NO_MATCH_CONTRACT=Invariant make test-std
 
 test-f-%:
-	@FOUNDRY_MATCH_TEST=$* make test
+	@FOUNDRY_MATCH_TEST=$* make test-std
 
 test-c-%:
-	@FOUNDRY_MATCH_CONTRACT=$* make test
+	@FOUNDRY_MATCH_CONTRACT=$* make test-std
+
+test-all:
+	@make test-std
 
 # Coverage
 coverage:

--- a/foundry.toml
+++ b/foundry.toml
@@ -47,7 +47,4 @@ remappings_location = "config"
 [rpc_endpoints]
 mainnet = "${PROVIDER_URL}"
 
-[etherscan]
-mainnet = { key = "${ETHERSCAN_API_KEY}", url = "https://etherscan.io/", chain = "mainnet" }
-
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,7 @@ remappings = [
   "script/=./script",
   "test/=./test",
   "utils/=./src/contracts/utils",
-  "forge-std/=dependencies/forge-std-1.9.2/src/",
+  "forge-std/=dependencies/forge-std-1.9.3/src/",
   "@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.0.2/",
   "@openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.0.2/",
   "@solmate/=dependencies/solmate-6.7.0/src/",
@@ -33,8 +33,8 @@ shrink_run_limit = 5_000
 [dependencies]
 "@openzeppelin-contracts" = "5.0.2"
 "@openzeppelin-contracts-upgradeable" = "5.0.2"
-forge-std = { version = "1.9.2", git = "https://github.com/foundry-rs/forge-std.git", rev = "5a802d7c10abb4bbfb3e7214c75052ef9e6a06f8" }
 solmate = "6.7.0"
+forge-std = "1.9.3"
 
 [soldeer]
 recursive_deps = false


### PR DESCRIPTION
- Remove [etherscan] sections from Makefile as it was making contract verification fail.
- Update forge-std to 1.9.3
- Improve Makefile to exclude invariant test when running `make test`.
- Add `make test-all` to include invariant to test.