### PR TITLE
No-04 Disable initializer in LidoARM's constructor

### DIFF
--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -39,6 +39,8 @@ contract LidoARM is Initializable, AbstractARM {
         steth = IERC20(_steth);
         weth = IWETH(_weth);
         lidoWithdrawalQueue = IStETHWithdrawal(_lidoWithdrawalQueue);
+
+        _disableInitializers();
     }
 
     /// @notice Initialize the storage variables stored in the proxy contract.


### PR DESCRIPTION
The `LidoARM` contract was written to be an implementation contract for a proxy contract. A best practice with this pattern is to disable as much as possible in the implementation contract to minimize the attack surface area.

Consider calling `_disableInitializers()` in `Initializable` contract constructors to prevent malicious actors from front-running initialization.