### PR TITLE
Hardhat tasks and Defender Actions

### DIFF
--- a/src/contracts/utils/Addresses.sol
+++ b/src/contracts/utils/Addresses.sol
@@ -36,6 +36,8 @@ library Mainnet {
 
     // Lido
     address public constant LIDO_WITHDRAWAL = 0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1;
+    address public constant LIDO_EL_VAULT = 0x388C818CA8B9251b393131C08a736A67ccB19297;
+    address public constant LIDO_WITHDRAWAL_MANAGER = 0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f;
 }
 
 library Holesky {

--- a/src/js/actions/autoClaimLidoWithdraw.js
+++ b/src/js/actions/autoClaimLidoWithdraw.js
@@ -28,15 +28,11 @@ const handler = async (event) => {
     signer
   );
 
-  try {
-    await claimLidoWithdrawals({
-      signer,
-      arm,
-      withdrawalQueue,
-    });
-  } catch (error) {
-    console.error(error);
-  }
+  await claimLidoWithdrawals({
+    signer,
+    arm,
+    withdrawalQueue,
+  });
 };
 
 module.exports = { handler };

--- a/src/js/actions/autoClaimWithdraw.js
+++ b/src/js/actions/autoClaimWithdraw.js
@@ -26,17 +26,13 @@ const handler = async (event) => {
   const vault = new ethers.Contract(mainnet.OETHVaultProxy, vaultAbi, signer);
   const oethARM = new ethers.Contract(mainnet.OethARM, oethARMAbi, signer);
 
-  try {
-    await autoClaimWithdraw({
-      signer,
-      weth,
-      oethARM,
-      vault,
-      confirm: true,
-    });
-  } catch (error) {
-    console.error(error);
-  }
+  await autoClaimWithdraw({
+    signer,
+    weth,
+    oethARM,
+    vault,
+    confirm: true,
+  });
 };
 
 module.exports = { handler };

--- a/src/js/actions/autoRequestLidoWithdraw.js
+++ b/src/js/actions/autoRequestLidoWithdraw.js
@@ -24,16 +24,12 @@ const handler = async (event) => {
   const steth = new ethers.Contract(mainnet.stETH, erc20Abi, signer);
   const arm = new ethers.Contract(mainnet.lidoARM, lidoARMAbi, signer);
 
-  try {
-    await requestLidoWithdrawals({
-      signer,
-      steth,
-      arm,
-      minAmount: 1,
-    });
-  } catch (error) {
-    console.error(error);
-  }
+  await requestLidoWithdrawals({
+    signer,
+    steth,
+    arm,
+    minAmount: 1,
+  });
 };
 
 module.exports = { handler };

--- a/src/js/actions/autoRequestWithdraw.js
+++ b/src/js/actions/autoRequestWithdraw.js
@@ -24,17 +24,13 @@ const handler = async (event) => {
   const oeth = new ethers.Contract(mainnet.OETHProxy, erc20Abi, signer);
   const oethARM = new ethers.Contract(mainnet.OethARM, oethARMAbi, signer);
 
-  try {
-    await autoRequestWithdraw({
-      signer,
-      oeth,
-      oethARM,
-      minAmount: 1,
-      confirm: true,
-    });
-  } catch (error) {
-    console.error(error);
-  }
+  await autoRequestWithdraw({
+    signer,
+    oeth,
+    oethARM,
+    minAmount: 1,
+    confirm: true,
+  });
 };
 
 module.exports = { handler };

--- a/src/js/actions/setPrices.js
+++ b/src/js/actions/setPrices.js
@@ -27,11 +27,12 @@ const handler = async (event) => {
       signer,
       arm,
       curve: true,
-      amount: 50,
-      tolerance: 0.2,
+      amount: 100,
+      tolerance: 0.1,
       maxBuyPrice: 0.9997,
-      minSellPrice: 0.9999,
-      fee: 1,
+      minSellPrice: 0.9998,
+      fee: 0.8,
+      offset: 0.2,
       blockTag: "latest",
     });
   } catch (error) {

--- a/src/js/tasks/lido.js
+++ b/src/js/tasks/lido.js
@@ -146,9 +146,7 @@ const logLidoQueue = async (signer, blockTag) => {
   } = await getLidoQueueData(signer, blockTag);
 
   console.log(`\nLido withdrawal queue`);
-  console.log(
-    `${formatUnits(withdrawals, 18).padEnd(24)} requested withdrawals`
-  );
+  console.log(`${formatUnits(withdrawals, 18).padEnd(24)} stETH withdrawals`);
   console.log(`${formatUnits(deposits, 18).padEnd(24)} ETH from deposits`);
   console.log(
     `${formatUnits(elRewards, 18).padEnd(24)} ETH from execution rewards`

--- a/src/js/tasks/lido.js
+++ b/src/js/tasks/lido.js
@@ -249,30 +249,30 @@ const logAssets = async (arm, blockTag) => {
 
   console.log(`\nAssets`);
   console.log(
-    `${formatUnits(liquidityWeth, 18).padEnd(23)} WETH  ${formatUnits(
+    `${formatUnits(liquidityWeth, 18).padEnd(24)} WETH  ${formatUnits(
       wethPercent,
       2
     )}%`
   );
   console.log(
-    `${formatUnits(liquiditySteth, 18).padEnd(23)} stETH ${formatUnits(
+    `${formatUnits(liquiditySteth, 18).padEnd(24)} stETH ${formatUnits(
       oethPercent,
       2
     )}%`
   );
   console.log(
     `${formatUnits(liquidityLidoWithdraws, 18).padEnd(
-      23
+      24
     )} Lido withdraw ${formatUnits(stethWithdrawsPercent, 2)}%`
   );
-  console.log(`${formatUnits(total, 18).padEnd(23)} total WETH and stETH`);
-  console.log(`${formatUnits(totalAssets, 18).padEnd(23)} total assets`);
-  console.log(`${formatUnits(totalSupply, 18).padEnd(23)} total supply`);
-  console.log(`${formatUnits(assetPerShare, 18).padEnd(23)} asset per share`);
+  console.log(`${formatUnits(total, 18).padEnd(24)} total WETH and stETH`);
+  console.log(`${formatUnits(totalAssets, 18).padEnd(24)} total assets`);
+  console.log(`${formatUnits(totalSupply, 18).padEnd(24)} total supply`);
+  console.log(`${formatUnits(assetPerShare, 18).padEnd(24)} asset per share`);
   console.log(
-    `${formatUnits(feesAccrued, 18).padEnd(23)} accrued performance fees`
+    `${formatUnits(feesAccrued, 18).padEnd(24)} accrued performance fees`
   );
-  console.log(`${formatUnits(armBuybackWeth, 18).padEnd(23)} WETH in Buyback`);
+  console.log(`${formatUnits(armBuybackWeth, 18).padEnd(24)} WETH in Buyback`);
 
   return { totalAssets, totalSupply, liquidityWeth };
 };

--- a/src/js/tasks/liquidity.js
+++ b/src/js/tasks/liquidity.js
@@ -6,7 +6,7 @@ const { resolveAsset } = require("../utils/assets");
 const {
   claimableRequests,
   outstandingWithdrawalAmount,
-} = require("../utils/queue");
+} = require("../utils/armQueue");
 const { logTxDetails } = require("../utils/txLogger");
 
 const log = require("../utils/logger")("task:liquidity");

--- a/src/js/tasks/liquidity.js
+++ b/src/js/tasks/liquidity.js
@@ -78,12 +78,15 @@ const autoClaimWithdraw = async ({ signer, weth, oethARM, vault, confirm }) => {
     queuedAmountClaimable,
   });
 
+  if (requestIds.length === 0) {
+    log("No claimable requests");
+    return;
+  }
+
   log(`About to claim requests: ${requestIds} `);
 
-  if (requestIds.length > 0) {
-    const tx = await oethARM.connect(signer).claimWithdrawals(requestIds);
-    await logTxDetails(tx, "claimWithdrawals", confirm);
-  }
+  const tx = await oethARM.connect(signer).claimWithdrawals(requestIds);
+  await logTxDetails(tx, "claimWithdrawals", confirm);
 };
 
 const withdrawRequestStatus = async ({ id, oethARM, vault }) => {

--- a/src/js/tasks/tasks.js
+++ b/src/js/tasks/tasks.js
@@ -744,7 +744,11 @@ subtask("snapLido", "Take a snapshot of the Lido ARM")
   .addOptionalParam("oneInch", "Include 1Inch prices", true, types.boolean)
   .addOptionalParam("curve", "Include Curve prices", true, types.boolean)
   .addOptionalParam("uniswap", "Include Uniswap V3 prices", true, types.boolean)
-  .addOptionalParam("gas", "Include gas costs", true, types.boolean)
+  .addOptionalParam("queue", "Include ARM withdrawal queue data", true, types.boolean)
+  .addOptionalParam("lido", "Include Lido withdrawal queue data", true, types.boolean)
+  .addOptionalParam("user", "Include user data", false, types.boolean)
+  .addOptionalParam("cap", "Include cap limit data", false, types.boolean)
+  .addOptionalParam("gas", "Include gas costs", false, types.boolean)
   .setAction(snapLido);
 task("snapLido").setAction(async (_, __, runSuper) => {
   return runSuper();

--- a/src/js/tasks/tasks.js
+++ b/src/js/tasks/tasks.js
@@ -613,6 +613,12 @@ subtask("setPrices", "Update Lido ARM's swap prices")
     types.float
   )
   .addOptionalParam(
+    "offset",
+    "Adds extra basis points to the discount if using the mid price. A positive number will lower the prices. A negative number will increase the prices.",
+    0,
+    types.float
+  )
+  .addOptionalParam(
     "tolerance",
     "Allowed difference in basis points. eg 1 = 0.0001%",
     0.1,
@@ -744,8 +750,18 @@ subtask("snapLido", "Take a snapshot of the Lido ARM")
   .addOptionalParam("oneInch", "Include 1Inch prices", true, types.boolean)
   .addOptionalParam("curve", "Include Curve prices", true, types.boolean)
   .addOptionalParam("uniswap", "Include Uniswap V3 prices", true, types.boolean)
-  .addOptionalParam("queue", "Include ARM withdrawal queue data", true, types.boolean)
-  .addOptionalParam("lido", "Include Lido withdrawal queue data", true, types.boolean)
+  .addOptionalParam(
+    "queue",
+    "Include ARM withdrawal queue data",
+    true,
+    types.boolean
+  )
+  .addOptionalParam(
+    "lido",
+    "Include Lido withdrawal queue data",
+    true,
+    types.boolean
+  )
   .addOptionalParam("user", "Include user data", false, types.boolean)
   .addOptionalParam("cap", "Include cap limit data", false, types.boolean)
   .addOptionalParam("gas", "Include gas costs", false, types.boolean)

--- a/src/js/utils/addresses.js
+++ b/src/js/utils/addresses.js
@@ -26,6 +26,10 @@ addresses.mainnet.lidoARM = "0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6";
 // Lido
 addresses.mainnet.lidoWithdrawalQueue =
   "0x889edc2edab5f40e902b864ad4d7ade8e412f9b1";
+addresses.mainnet.lidoExecutionLayerVault =
+  "0x388C818CA8B9251b393131C08a736A67ccB19297";
+addresses.mainnet.lidoWithdrawalManager =
+  "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f";
 
 // AMMs
 addresses.mainnet.CurveStEthPool = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022";

--- a/src/js/utils/armQueue.js
+++ b/src/js/utils/armQueue.js
@@ -6,7 +6,7 @@ const { formatUnits } = require("ethers");
 // Extend Day.js with the UTC plugin
 dayjs.extend(utc);
 
-const log = require("../utils/logger")("utils:queue");
+const log = require("./logger")("utils:queue");
 
 const uri = "https://origin.squids.live/origin-squid/graphql";
 

--- a/src/js/utils/armQueue.js
+++ b/src/js/utils/armQueue.js
@@ -83,6 +83,7 @@ const claimableRequests = async ({ withdrawer, queuedAmountClaimable }) => {
           queued_lte: $liquidity
           timestamp_lt: $tenMinutesAgo
         }
+        limit: 100
       ) {
         id
         amount

--- a/src/js/utils/block.js
+++ b/src/js/utils/block.js
@@ -1,4 +1,4 @@
-const log = require("../utils/logger")("task:block");
+const log = require("../utils/logger")("utils:block");
 
 // Get the block number
 const getBlock = async (block) => {

--- a/src/js/utils/curve.js
+++ b/src/js/utils/curve.js
@@ -3,7 +3,7 @@ const { ethers } = require("ethers");
 
 const curvePoolAbi = require("../../abis/CurveStEthPool.json");
 
-const log = require("../utils/logger")("task:curve");
+const log = require("../utils/logger")("utils:curve");
 
 const getCurvePrices = async ({
   amount,

--- a/src/js/utils/lido.js
+++ b/src/js/utils/lido.js
@@ -1,0 +1,45 @@
+const { ethers } = require("ethers");
+const { mainnet } = require("./addresses");
+const erc20Abi = require("../../abis/ERC20.json");
+
+const getLidoQueueData = async (signer, blockTag) => {
+  // This needs to work in a Defender Action so can't use resolveAsset which uses Hardhat's getContractAt
+  const stETH = new ethers.Contract(mainnet.stETH, erc20Abi, signer);
+
+  // get stETH in the withdrawal queue
+  const withdrawals = await stETH.balanceOf(mainnet.lidoWithdrawalQueue, {
+    blockTag,
+  });
+
+  // Get Lido deposits
+  const deposits = await signer.provider.getBalance(
+    stETH.getAddress(),
+    blockTag
+  );
+
+  // Get execution rewards
+  const elRewards = await signer.provider.getBalance(
+    mainnet.lidoExecutionLayerVault,
+    blockTag
+  );
+
+  // Get ETH swept from exited validators
+  const ethFromValidators = await signer.provider.getBalance(
+    mainnet.lidoWithdrawalManager,
+    blockTag
+  );
+
+  const finalization = deposits + elRewards + ethFromValidators;
+  const outstanding = withdrawals - finalization;
+
+  return {
+    withdrawals,
+    deposits,
+    elRewards,
+    ethFromValidators,
+    finalization,
+    outstanding,
+  };
+};
+
+module.exports = { getLidoQueueData };

--- a/src/js/utils/queue.js
+++ b/src/js/utils/queue.js
@@ -22,6 +22,7 @@ const outstandingWithdrawalAmount = async ({ withdrawer }) => {
     query OutstandingRequestsQuery($withdrawer: String!) {
       oethWithdrawalRequests(
         where: { withdrawer_eq: $withdrawer, claimed_eq: false }
+        limit: 100
       ) {
         id
         amount

--- a/src/js/utils/queue.js
+++ b/src/js/utils/queue.js
@@ -6,7 +6,7 @@ const { formatUnits } = require("ethers");
 // Extend Day.js with the UTC plugin
 dayjs.extend(utc);
 
-const log = require("../utils/logger")("task:queue");
+const log = require("../utils/logger")("utils:queue");
 
 const uri = "https://origin.squids.live/origin-squid/graphql";
 

--- a/src/js/utils/uniswap.js
+++ b/src/js/utils/uniswap.js
@@ -6,7 +6,7 @@ const wstEthAbi = require("../../abis/wstETH.json");
 const addresses = require("./addresses");
 const { getSigner } = require("./signers");
 
-const log = require("../utils/logger")("task:uniswap");
+const log = require("../utils/logger")("utils:uniswap");
 
 const getUniswapV3SpotPrices = async ({ amount, blockTag, gas }) => {
   const signer = await getSigner();


### PR DESCRIPTION
* Fix the Hardhat task `snap` task for the OETH ARM
* Added an `offset` to the `setPrices` Hardhat task for the Lido ARM
* Fix `autoClaimWithdraw` Defender Action by adding limit to graphQL call in `claimableRequests`
* Stopped swallowing errors in Defender Actions 
* Added Lido withdrawal queue data to the `snapLido` Hardhat task eg
```
Lido withdrawal queue
19482.915608538620550706 stETH withdrawals
5405.526192315276507261  ETH from deposits
110.613985549906069785   ETH from execution rewards
793.777218526            ETH from validators
6309.917396391182577046  ETH to be finalized
13172.99821214743797366  ETH outstanding
```