### PR TITLE
Gas saving when claiming Lido withdrawals

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,7 +6,7 @@ verbosity = 3
 sender = "0x0165C55EF814dEFdd658532A48Bd17B2c8356322"
 tx_origin = "0x0165C55EF814dEFdd658532A48Bd17B2c8356322"
 auto_detect_remappings = false
-gas_reports = ["OethARM", "Proxy"]
+gas_reports = ["OethARM", "Proxy", "LidoARM"]
 fs_permissions = [{ access = "read-write", path = "./build" }]
 extra_output_files = ["metadata"]
 ignored_warnings_from = ["src/contracts/Proxy.sol"]

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -70,7 +70,7 @@ contract LidoARM is Initializable, AbstractARM {
      * Reference: https://docs.lido.fi/contracts/withdrawal-queue-erc721/
      * Note: There is a 1k amount limit. Caller should split large withdrawals in chunks of less or equal to 1k each.)
      */
-    function requestLidoWithdrawals(uint256[] memory amounts)
+    function requestLidoWithdrawals(uint256[] calldata amounts)
         external
         onlyOperatorOrOwner
         returns (uint256[] memory requestIds)

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -104,7 +104,7 @@ contract LidoARM is Initializable, AbstractARM {
      * @param hintIds The hint IDs of the withdrawal requests.
      * Call `findCheckpointHints` on the Lido withdrawal queue contract to get the hint IDs.
      */
-    function claimLidoWithdrawals(uint256[] calldata requestIds) external {
+    function claimLidoWithdrawals(uint256[] calldata requestIds, uint256[] calldata hintIds) external {
         // Claim the NFTs for ETH.
         lidoWithdrawalQueue.claimWithdrawals(requestIds, hintIds);
 

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -92,13 +92,14 @@ contract LidoARM is Initializable, AbstractARM {
     /**
      * @notice Claim the ETH owed from the redemption requests and convert it to WETH.
      * Before calling this method, caller should check on the request NFTs to ensure the withdrawal was processed.
+     * @param requestIds The request IDs of the withdrawal requests.
+     * @param hintIds The hint IDs of the withdrawal requests.
+     * Call `findCheckpointHints` on the Lido withdrawal queue contract to get the hint IDs.
      */
-    function claimLidoWithdrawals(uint256[] memory requestIds) external {
+    function claimLidoWithdrawals(uint256[] calldata requestIds, uint256[] calldata hintIds) external {
         uint256 etherBefore = address(this).balance;
 
         // Claim the NFTs for ETH.
-        uint256 lastIndex = lidoWithdrawalQueue.getLastCheckpointIndex();
-        uint256[] memory hintIds = lidoWithdrawalQueue.findCheckpointHints(requestIds, 1, lastIndex);
         lidoWithdrawalQueue.claimWithdrawals(requestIds, hintIds);
 
         uint256 etherAfter = address(this).balance;

--- a/test/fork/LidoFixedPriceMultiLpARM/ClaimStETHWithdrawalForWETH.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/ClaimStETHWithdrawalForWETH.t.sol
@@ -52,7 +52,7 @@ contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_
         emit LidoARM.ClaimLidoWithdrawals(emptyList);
 
         // Main call
-        lidoARM.claimLidoWithdrawals(new uint256[](0));
+        lidoARM.claimLidoWithdrawals(emptyList, emptyList);
 
         assertEq(address(lidoARM).balance, 0);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
@@ -72,12 +72,15 @@ contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_
         uint256[] memory requests = new uint256[](1);
         requests[0] = stETHWithdrawal.getLastRequestId();
 
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
+
         // Expected events
         vm.expectEmit({emitter: address(lidoARM)});
         emit LidoARM.ClaimLidoWithdrawals(requests);
 
         // Main call
-        lidoARM.claimLidoWithdrawals(requests);
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
 
         // Assertions after
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
@@ -100,12 +103,15 @@ contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_
         requests[0] = stETHWithdrawal.getLastRequestId() - 1;
         requests[1] = stETHWithdrawal.getLastRequestId();
 
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
+
         // Expected events
         vm.expectEmit({emitter: address(lidoARM)});
         emit LidoARM.ClaimLidoWithdrawals(requests);
 
         // Main call
-        lidoARM.claimLidoWithdrawals(requests);
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
 
         // Assertions after
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);

--- a/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/Deposit.t.sol
@@ -465,8 +465,10 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         _mockFunctionClaimWithdrawOnLidoARM(DEFAULT_AMOUNT);
 
         // 4. Operator claim withdrawal on lido
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
         lidoARM.totalAssets();
-        lidoARM.claimLidoWithdrawals(requests);
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
 
         // 5. User burn shares
         (, uint256 receivedAssets) = lidoARM.requestRedeem(shares);
@@ -532,7 +534,9 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         uint256[] memory requests = new uint256[](1);
         requests[0] = requestId;
         // 4. Operator claim the withdrawal on lido
-        lidoARM.claimLidoWithdrawals(requests);
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
         // 5. User burn shares
         (, uint256 receivedAssets) = lidoARM.requestRedeem(shares);
 
@@ -592,7 +596,9 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         requests[0] = requestId;
 
         // 4. Operator claim the withdrawal on lido
-        lidoARM.claimLidoWithdrawals(requests);
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
 
         // 5. User burn shares
         (, uint256 receivedAssets) = lidoARM.requestRedeem(shares);

--- a/test/fork/utils/MockCall.sol
+++ b/test/fork/utils/MockCall.sol
@@ -46,6 +46,25 @@ contract MockLidoWithdraw {
     function claimWithdrawals(uint256[] memory, uint256[] memory) external {
         ethSender.sendETH(lidoARM);
     }
+
+    /// @notice Mock the call to the Lido contract's `getLastCheckpointIndex` function.
+    function getLastCheckpointIndex() public pure returns (uint256) {
+        // hardcoded as this is not used by the Lido ARM
+        return 300;
+    }
+
+    /// @notice Mock the call to the Lido contract's `findCheckpointHints` function.
+    function findCheckpointHints(uint256[] calldata _requestIds, uint256, uint256)
+        external
+        pure
+        returns (uint256[] memory hintIds)
+    {
+        hintIds = new uint256[](_requestIds.length);
+        for (uint256 i = 0; i < _requestIds.length; ++i) {
+            // hardcoded as this is not used by the Lido ARM
+            hintIds[i] = 300;
+        }
+    }
 }
 
 contract ETHSender {

--- a/test/invariants/BasicInvariants.sol
+++ b/test/invariants/BasicInvariants.sol
@@ -70,7 +70,7 @@ contract Invariant_Basic_Test_ is Invariant_Base_Test_ {
         swapHandler = new SwapHandler(address(lidoARM), address(weth), address(steth), swaps);
         ownerHandler =
             new OwnerHandler(address(lidoARM), address(weth), address(steth), MIN_BUY_T1, MAX_SELL_T1, MAX_FEES);
-        llmHandler = new LLMHandler(address(lidoARM), address(steth));
+        llmHandler = new LLMHandler(address(lidoARM), address(steth), address(lidoWithdraw));
         donationHandler = new DonationHandler(address(lidoARM), address(weth), address(steth));
 
         lpHandler.setSelectorWeight(lpHandler.deposit.selector, 5_000); // 50%


### PR DESCRIPTION
* Moved calculating the Lido claim withdrawal hints off-chain when calling `claimLidoWithdrawals`

Before
```
| Function Name                                                       | min             | avg    | median | max     | # calls |
| claimLidoWithdrawals                                                | 20456           | 36554  | 37265  | 52297   | 10      |
```


After
```
| Function Name                                                       | min             | avg    | median | max     | # calls |
| claimLidoWithdrawals                                                | 15983           | 27233  | 28897  | 39693   | 10      |
```