### PR TITLE
Allow setCrossPrice to be called by Operator

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -408,7 +408,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
      * The cross price can be increased with assets in the ARM.
      * @param newCrossPrice The new cross price scaled to 36 decimals.
      */
-    function setCrossPrice(uint256 newCrossPrice) external onlyOwner {
+    function setCrossPrice(uint256 newCrossPrice) external onlyOperatorOrOwner {
         require(newCrossPrice >= PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION, "ARM: cross price too low");
         require(newCrossPrice <= PRICE_SCALE, "ARM: cross price too high");
         // The exiting sell price must be greater than or equal to the new cross price

--- a/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/SetCrossPrice.t.sol
@@ -19,12 +19,7 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
     /// --- REVERTING TESTS
     //////////////////////////////////////////////////////
     function test_RevertWhen_SetCrossPrice_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
-        lidoARM.setCrossPrice(0.9998e36);
-    }
-
-    function test_RevertWhen_SetCrossPrice_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert("ARM: Only operator or owner can call this function.");
         lidoARM.setCrossPrice(0.9998e36);
     }
 
@@ -91,5 +86,28 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
 
         // 1 basis points lower than 1.0
         lidoARM.setCrossPrice(0.9999e36);
+    }
+}
+
+contract Fork_Concrete_LidoARM_SetCrossPrice_Operator_Test_ is Fork_Shared_Test_ {
+    //////////////////////////////////////////////////////
+    /// --- SETUP
+    //////////////////////////////////////////////////////
+    function setUp() public override {
+        super.setUp();
+
+        deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY - 1);
+    }
+
+    function test_SetCrossPrice_No_StETH_Operator() public asOperator {
+        // at 1.0
+        vm.expectEmit({emitter: address(lidoARM)});
+        emit AbstractARM.CrossPriceUpdated(1e36);
+        lidoARM.setCrossPrice(1e36);
+
+        // 20 basis points lower than 1.0
+        vm.expectEmit({emitter: address(lidoARM)});
+        emit AbstractARM.CrossPriceUpdated(0.998e36);
+        lidoARM.setCrossPrice(0.998e36);
     }
 }


### PR DESCRIPTION

* Currently only the Owner can call `setCrossPrice` which is a 5/8 Safe. The allows the Operator to also call `setCrossPrice`. There are already protections in `setCrossPrice` so the cross price can not be lowered when there is  stETH in the ARM. This prevents stETH being sold for less than it was purchased for.