### PR TITLE
Handle donation attack of Lido withdrawal NFTs

### DIFF
--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -104,7 +104,14 @@ contract LidoARM is Initializable, AbstractARM {
         uint256 etherAfter = address(this).balance;
 
         // Reduce the Ether outstanding from the Lido Withdrawal Queue
-        lidoWithdrawalQueueAmount -= etherAfter - etherBefore;
+        uint256 etherClaimed = etherAfter - etherBefore;
+        if (etherClaimed > lidoWithdrawalQueueAmount) {
+            // This is a very unlikely scenario, but can happen if a Lido withdrawal NFT was transferred to the ARM contract
+            // and then claimed using `claimLidoWithdrawals`.
+            lidoWithdrawalQueueAmount = 0;
+        } else {
+            lidoWithdrawalQueueAmount -= etherClaimed;
+        }
 
         // Wrap all the received ETH to WETH.
         weth.deposit{value: etherAfter}();

--- a/test/fork/LidoFixedPriceMultiLpARM/ClaimStETHWithdrawalForWETH.t.sol
+++ b/test/fork/LidoFixedPriceMultiLpARM/ClaimStETHWithdrawalForWETH.t.sol
@@ -111,4 +111,30 @@ contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + amounts2[0] + amounts2[1]);
     }
+
+    function test_ClaimLidoWithdrawals_BiggerClaim()
+        public
+        asOperator
+        requestLidoWithdrawalsOnLidoARM(amounts1)
+        mockFunctionClaimWithdrawOnLidoARM(DEFAULT_AMOUNT + 5)
+    {
+        // Assertions before
+        uint256 balanceBefore = weth.balanceOf(address(lidoARM));
+        assertEq(lidoARM.lidoWithdrawalQueueAmount(), DEFAULT_AMOUNT);
+
+        stETHWithdrawal.getLastRequestId();
+        uint256[] memory requests = new uint256[](1);
+        requests[0] = stETHWithdrawal.getLastRequestId();
+
+        // Expected events
+        vm.expectEmit({emitter: address(lidoARM)});
+        emit LidoARM.ClaimLidoWithdrawals(requests);
+
+        // Main call
+        lidoARM.claimLidoWithdrawals(requests);
+
+        // Assertions after
+        assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
+        assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + DEFAULT_AMOUNT + 5);
+    }
 }


### PR DESCRIPTION
# Changes

* Someone can temporarily freeze withdrawals from the Lido queue by transferring a Lido withdrawal NFT and then claiming it via the Lido ARM. As the withdrawal request was not done through the Lido ARM, the `lidoWithdrawalQueue` amount will be smaller than the ETH received by the claim process. This will cause and underflow if all withdrawal requests are claimed.
* The avoid underflows, `lidoWithdrawalQueue` is set to zero if its going to underflow.
