### PR TITLE
Quick fix for failing invariant.

### DIFF
--- a/test/invariants/handlers/LLMHandler.sol
+++ b/test/invariants/handlers/LLMHandler.sol
@@ -52,11 +52,11 @@ contract LLMHandler is BaseHandler {
         uint256 totalAmount = _bound(_seed, 0, min(MAX_AMOUNT * 3, steth.balanceOf(address(arm))));
 
         // We can only request only 1k amount at a time
-        uint256 batch = (totalAmount / MAX_AMOUNT) + 1;
+        uint256 batch = ((totalAmount + MAX_AMOUNT - 1) / MAX_AMOUNT);
         uint256[] memory amounts = new uint256[](batch);
         uint256 totalAmount_ = totalAmount;
         for (uint256 i = 0; i < batch; i++) {
-            if (totalAmount_ >= MAX_AMOUNT) {
+            if (totalAmount_ > MAX_AMOUNT) {
                 amounts[i] = MAX_AMOUNT;
                 totalAmount_ -= MAX_AMOUNT;
             } else {

--- a/test/invariants/mocks/MockSTETH.sol
+++ b/test/invariants/mocks/MockSTETH.sol
@@ -11,6 +11,8 @@ contract MockSTETH is ERC20 {
     //////////////////////////////////////////////////////
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
+    bool public enableBrutalizeAmount = false;
+
     //////////////////////////////////////////////////////
     /// --- VARIABLES
     //////////////////////////////////////////////////////
@@ -34,7 +36,7 @@ contract MockSTETH is ERC20 {
 
     function brutalizeAmount(uint256 amount) public returns (uint256) {
         // Only brutalize the sender doesn't sent all of their balance
-        if (balanceOf[msg.sender] != amount && amount > 0) {
+        if (balanceOf[msg.sender] != amount && amount > 0 && enableBrutalizeAmount) {
             // Get a random number between 0 and 1
             uint256 randomUint = vm.randomUint(0, 1);
             // If the amount is greater than the random number, subtract the random number from the amount


### PR DESCRIPTION
Invariant testing is failing, with this quick fix it should be fixed. 
- Prevent requesting 0 amount withdrawal on Lido.
- Stop stETH from losing one wei on transfer. 

However, I'm currently refactoring the invariant setup, stopping custom-probability distribution, and using a more classical approach. This should improve debugging and try to resolve why user shares are not up only all the time.