### PR TITLE
Upgrade LidoARM and Lido register withdrawal requests

### DIFF
--- a/script/deploy/DeployManager.sol
+++ b/script/deploy/DeployManager.sol
@@ -9,6 +9,7 @@ import {DeployCoreMainnetScript} from "./mainnet/001_DeployCoreScript.sol";
 import {UpgradeMainnetScript} from "./mainnet/002_UpgradeScript.sol";
 import {UpgradeLidoARMMainnetScript} from "./mainnet/003_UpgradeLidoARMScript.sol";
 import {UpdateCrossPriceMainnetScript} from "./mainnet/004_UpdateCrossPriceScript.sol";
+import {RegisterLidoWithdrawalsScript} from "./mainnet/005_RegisterLidoWithdrawalsScript.sol";
 import {DeployCoreHoleskyScript} from "./holesky/001_DeployCoreScript.sol";
 import {UpgradeHoleskyScript} from "./holesky/002_UpgradeScript.sol";
 
@@ -62,6 +63,7 @@ contract DeployManager is Script {
             _runDeployFile(new UpgradeMainnetScript(this));
             _runDeployFile(new UpgradeLidoARMMainnetScript());
             _runDeployFile(new UpdateCrossPriceMainnetScript());
+            _runDeployFile(new RegisterLidoWithdrawalsScript());
         } else if (block.chainid == 17000) {
             _runDeployFile(new DeployCoreHoleskyScript());
             _runDeployFile(new UpgradeHoleskyScript(this));

--- a/script/deploy/mainnet/005_RegisterLidoWithdrawalsScript.sol
+++ b/script/deploy/mainnet/005_RegisterLidoWithdrawalsScript.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import "forge-std/console.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {IERC20, IWETH, LegacyAMM} from "contracts/Interfaces.sol";
+import {LidoARM} from "contracts/LidoARM.sol";
+import {CapManager} from "contracts/CapManager.sol";
+import {Proxy} from "contracts/Proxy.sol";
+import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+import {GovProposal, GovSixHelper} from "contracts/utils/GovSixHelper.sol";
+import {AbstractDeployScript} from "../AbstractDeployScript.sol";
+
+contract RegisterLidoWithdrawalsScript is AbstractDeployScript {
+    using GovSixHelper for GovProposal;
+
+    GovProposal public govProposal;
+
+    string public constant override DEPLOY_NAME = "005_RegisterLidoWithdrawalsScript";
+    bool public constant override proposalExecuted = false;
+
+    Proxy lidoARMProxy;
+    Proxy capManProxy;
+    LidoARM lidoARMImpl;
+    LidoARM lidoARM;
+    CapManager capManager;
+    ZapperLidoARM zapper;
+
+    function _execute() internal override {
+        console.log("Deploy:", DEPLOY_NAME);
+        console.log("------------");
+
+        // 1. Deploy new Lido ARM implementation
+        uint256 claimDelay = tenderlyTestnet ? 1 minutes : 10 minutes;
+        lidoARMImpl = new LidoARM(Mainnet.STETH, Mainnet.WETH, Mainnet.LIDO_WITHDRAWAL, claimDelay);
+        _recordDeploy("LIDO_ARM_IMPL", address(lidoARMImpl));
+
+        console.log("Finished deploying", DEPLOY_NAME);
+    }
+
+    function _buildGovernanceProposal() internal override {
+        govProposal.setDescription("Upgrade Lido ARM and register Lido withdrawal requests");
+
+        bytes memory callData = abi.encodeWithSignature("registerLidoWithdrawalRequests()");
+        console.log("registerLidoWithdrawalRequests data:");
+        console.logBytes(callData);
+
+        bytes memory proxyData = abi.encode(address(lidoARMImpl), callData);
+        console.log("proxy upgradeToAndCall encoded params:");
+        console.logBytes(proxyData);
+
+        govProposal.action(deployedContracts["LIDO_ARM"], "upgradeToAndCall(address,bytes)", proxyData);
+
+        _fork();
+    }
+
+    function _fork() internal override {
+        if (this.isForked()) {
+            govProposal.simulate();
+        }
+    }
+}

--- a/script/deploy/mainnet/005_RegisterLidoWithdrawalsScript.sol
+++ b/script/deploy/mainnet/005_RegisterLidoWithdrawalsScript.sol
@@ -5,11 +5,7 @@ pragma solidity 0.8.23;
 import "forge-std/console.sol";
 import {Vm} from "forge-std/Vm.sol";
 
-import {IERC20, IWETH, LegacyAMM} from "contracts/Interfaces.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
-import {CapManager} from "contracts/CapManager.sol";
-import {Proxy} from "contracts/Proxy.sol";
-import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
 import {Mainnet} from "contracts/utils/Addresses.sol";
 import {GovProposal, GovSixHelper} from "contracts/utils/GovSixHelper.sol";
 import {AbstractDeployScript} from "../AbstractDeployScript.sol";
@@ -22,12 +18,7 @@ contract RegisterLidoWithdrawalsScript is AbstractDeployScript {
     string public constant override DEPLOY_NAME = "005_RegisterLidoWithdrawalsScript";
     bool public constant override proposalExecuted = false;
 
-    Proxy lidoARMProxy;
-    Proxy capManProxy;
     LidoARM lidoARMImpl;
-    LidoARM lidoARM;
-    CapManager capManager;
-    ZapperLidoARM zapper;
 
     function _execute() internal override {
         console.log("Deploy:", DEPLOY_NAME);

--- a/script/deploy/mainnet/005_RegisterLidoWithdrawalsScript.sol
+++ b/script/deploy/mainnet/005_RegisterLidoWithdrawalsScript.sol
@@ -44,8 +44,6 @@ contract RegisterLidoWithdrawalsScript is AbstractDeployScript {
         console.logBytes(proxyData);
 
         govProposal.action(deployedContracts["LIDO_ARM"], "upgradeToAndCall(address,bytes)", proxyData);
-
-        _fork();
     }
 
     function _fork() internal override {

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -214,7 +214,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         lidoARM.registerLidoWithdrawalRequests();
     }
 
-    function test_lidoWithdrawalRequests() external {
+    function test_lidoWithdrawalRequests() external view {
         uint256 totalAmountRequested = 0;
         uint256[] memory requestIds = IStETHWithdrawal(Mainnet.LIDO_WITHDRAWAL).getWithdrawalRequests(address(lidoARM));
         // Get the status of all the withdrawal requests. eg amount, owner, claimed status

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -5,7 +5,7 @@ import {Test, console2} from "forge-std/Test.sol";
 
 import {AbstractSmokeTest} from "./AbstractSmokeTest.sol";
 
-import {IERC20} from "contracts/Interfaces.sol";
+import {IERC20, IStETHWithdrawal} from "contracts/Interfaces.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
 import {CapManager} from "contracts/CapManager.sol";
 import {Proxy} from "contracts/Proxy.sol";
@@ -203,5 +203,31 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         vm.expectRevert("ARM: Only owner can call this function.");
         vm.prank(operator);
         lidoARM.setOperator(operator);
+    }
+
+    error InvalidInitialization();
+
+    // Can not be called again after reinitialized by the deploy script
+    function test_registerLidoWithdrawalRequests() external {
+        vm.expectRevert(InvalidInitialization.selector);
+        vm.prank(operator);
+        lidoARM.registerLidoWithdrawalRequests();
+    }
+
+    function test_lidoWithdrawalRequests() external {
+        uint256 totalAmountRequested = 0;
+        uint256[] memory requestIds = IStETHWithdrawal(Mainnet.LIDO_WITHDRAWAL).getWithdrawalRequests(address(lidoARM));
+        // Get the status of all the withdrawal requests. eg amount, owner, claimed status
+        IStETHWithdrawal.WithdrawalRequestStatus[] memory statuses =
+            IStETHWithdrawal(Mainnet.LIDO_WITHDRAWAL).getWithdrawalStatus(requestIds);
+
+        console.log("Got %d withdrawal requests", requestIds.length);
+
+        for (uint256 i = 0; i < requestIds.length; i++) {
+            assertEq(lidoARM.lidoWithdrawalRequests(requestIds[i]), statuses[i].amountOfStETH);
+            totalAmountRequested += statuses[i].amountOfStETH;
+        }
+
+        assertEq(totalAmountRequested, lidoARM.lidoWithdrawalQueueAmount());
     }
 }


### PR DESCRIPTION
The following fixes will be deployed with this upgrade
* https://github.com/OriginProtocol/arm-oeth/pull/52
* https://github.com/OriginProtocol/arm-oeth/pull/53
* https://github.com/OriginProtocol/arm-oeth/pull/58
* https://github.com/OriginProtocol/arm-oeth/pull/50

The update also calls `registerLidoWithdrawalRequests` in the Lido ARM that initializes the new `lidoWithdrawalRequests` mapping of Lido request ids to withdrawal amounts. This can only be executed once by the contract Owner, which is the Timelock.