### PR TITLE
Refactor Invariant setup.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -28,8 +28,8 @@ ffi = true
 runs = 1_000
 
 [invariant]
-runs = 1
-depth = 50
+runs = 256
+depth = 500
 shrink_run_limit = 5_000
 show_metrics = true
 fail_on_revert = true

--- a/foundry.toml
+++ b/foundry.toml
@@ -28,8 +28,8 @@ ffi = true
 runs = 1_000
 
 [invariant]
-runs = 256
-depth = 500
+runs = 1
+depth = 50
 shrink_run_limit = 5_000
 show_metrics = true
 fail_on_revert = true

--- a/test/invariants/OriginARM/FuzzerFoundry.sol
+++ b/test/invariants/OriginARM/FuzzerFoundry.sol
@@ -5,74 +5,11 @@ pragma solidity 0.8.23;
 import {TargetFunction} from "test/invariants/OriginARM/TargetFunction.sol";
 
 contract FuzzerFoundry_OriginARM is TargetFunction {
-    uint256 private constant NUM_LPS = 4;
-    uint256 private constant NUM_SWAPS = 3;
-
     //////////////////////////////////////////////////////
     /// --- SETUP
     //////////////////////////////////////////////////////
     function setUp() public override {
         super.setUp();
-
-        // --- Assigns to Categories ---
-        // In this configuration, an user is either a LP or a Swap, but not both.
-        require(NUM_LPS + NUM_SWAPS <= users.length, "IBT: NOT_ENOUGH_USERS");
-
-        // LPs
-        for (uint256 i; i < NUM_LPS; i++) {
-            address user = users[i];
-            require(user != address(0), "IBT: INVALID_USER");
-            lps.push(user);
-
-            // Give them a lot of WS
-            deal(address(ws), user, INITIAL_AMOUNT_LPS);
-
-            // Approve ARM for WS
-            vm.prank(user);
-            ws.approve(address(originARM), type(uint256).max);
-        }
-
-        // Swappers
-        for (uint256 i = NUM_LPS; i < NUM_LPS + NUM_SWAPS; i++) {
-            address user = users[i];
-            require(user != address(0), "IBT: INVALID_USER");
-            swaps.push(user);
-
-            // Give them a lot of WS and OS
-            deal(address(ws), user, INITIAL_AMOUNT_SWAPS);
-            deal(address(os), user, INITIAL_AMOUNT_SWAPS);
-
-            // Approve ARM for WS and OS
-            vm.startPrank(user);
-            os.approve(address(originARM), type(uint256).max);
-            ws.approve(address(originARM), type(uint256).max);
-            vm.stopPrank();
-        }
-
-        // Distribute a lot of WS to the vault, this will help for redeeming OS
-        deal(address(ws), address(vault), type(uint128).max);
-
-        // --- Setup ARM ---
-        // Set cross price
-        vm.prank(governor);
-        originARM.setCrossPrice(0.9999 * 1e36);
-        // Set prices
-        vm.prank(operator);
-        originARM.setPrices(MIN_BUY_PRICE, MAX_SELL_PRICE);
-
-        // --- Setup Markets ---
-        markets = new address[](2);
-        markets[0] = address(market);
-        markets[1] = address(siloMarket);
-        vm.prank(governor);
-        originARM.addMarkets(markets);
-
-        // Fund the markets
-        deal(address(ws), address(this), 2 * 1 ether);
-        ws.approve(address(market), type(uint256).max);
-        ws.approve(address(market2), type(uint256).max);
-        market.deposit(1 ether, address(this));
-        market2.deposit(1 ether, address(this));
 
         // --- Setup Fuzzer target ---
         // Setup target


### PR DESCRIPTION
This pull request refactors the setup logic for invariant tests in the `OriginARM` module by moving user initialization and contract setup from `FuzzerFoundry.sol` to a new private `_initiliaze` function in `Setup.sol`. This change improves modularity and reusability while maintaining the same functionality.

### Refactoring of Setup Logic:

* **Removed user and contract setup logic from `FuzzerFoundry.sol`:** The initialization of liquidity providers (LPs), swappers, and markets, as well as the configuration of the `originARM` contract, has been removed from `FuzzerFoundry.sol`. This includes logic for assigning users to categories, funding markets, and setting prices. (`test/invariants/OriginARM/FuzzerFoundry.sol`)

* **Moved setup logic to a new `_initiliaze` function in `Setup.sol`:** A private `_initiliaze` function has been added to centralize the initialization of LPs, swappers, and contract configurations. This function replicates the removed logic from `FuzzerFoundry.sol` and ensures it is reusable across other test contracts. (`test/invariants/OriginARM/Setup.sol`)

### Code Improvements:

* **Declared constants for LPs and swappers in `Setup.sol`:** The constants `NUM_LPS` and `NUM_SWAPS` have been defined in `Setup.sol` to make the configuration more explicit and accessible. (`test/invariants/OriginARM/Setup.sol`)

* **Integrated `_initiliaze` into the setup process:** The `_initiliaze` function is now called during the setup phase in `Setup.sol`, ensuring that all test contracts benefit from the centralized initialization logic. (`test/invariants/OriginARM/Setup.sol`)