### PR TITLE
Fix: Change MIN_SHARES_TO_REDEEM from constant to immutable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-std:
 	forge test --summary --fail-fast --show-progress
 
 test:
-	@FOUNDRY_NO_MATCH_CONTRACT=Invariant make test-std
+	@FOUNDRY_NO_MATCH_CONTRACT=Fuzzer make test-std
 
 test-f-%:
 	@FOUNDRY_MATCH_TEST=$* make test-std

--- a/script/deploy/sonic/001_DeployOriginARM.sol
+++ b/script/deploy/sonic/001_DeployOriginARM.sol
@@ -55,7 +55,7 @@ contract DeployOriginARMScript is AbstractDeployScript {
 
         // 7. Deploy new Origin ARM implementation
         uint256 claimDelay = tenderlyTestnet ? 1 minutes : 10 minutes;
-        originARMImpl = new OriginARM(Sonic.OS, Sonic.WS, Sonic.OS_VAULT, claimDelay);
+        originARMImpl = new OriginARM(Sonic.OS, Sonic.WS, Sonic.OS_VAULT, claimDelay, 1e7);
         _recordDeploy("ORIGIN_ARM_IMPL", address(originARMImpl));
 
         // 8. Approve a little bit of wS to be transferred to the ARM proxy

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -144,7 +144,13 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     event ARMBufferUpdated(uint256 armBuffer);
     event Allocated(address indexed market, int256 assets);
 
-    constructor(address _token0, address _token1, address _liquidityAsset, uint256 _claimDelay, uint256 _minSharesToRedeem) {
+    constructor(
+        address _token0,
+        address _token1,
+        address _liquidityAsset,
+        uint256 _claimDelay,
+        uint256 _minSharesToRedeem
+    ) {
         require(IERC20(_token0).decimals() == 18);
         require(IERC20(_token1).decimals() == 18);
 

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -24,8 +24,6 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     uint256 public constant PRICE_SCALE = 1e36;
     /// @dev The amount of shares that are minted to a dead address on initialization
     uint256 internal constant MIN_TOTAL_SUPPLY = 1e12;
-    /// @dev The minimum amount of shares that can be redeemed from the active market.
-    uint256 public constant MIN_SHARES_TO_REDEEM = 1e7;
     /// @dev The address with no known private key that the initial shares are minted to
     address internal constant DEAD_ACCOUNT = 0x000000000000000000000000000000000000dEaD;
     /// @notice The scale of the performance fee
@@ -35,7 +33,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     ////////////////////////////////////////////////////
     ///             Immutable Variables
     ////////////////////////////////////////////////////
-
+    /// @dev The minimum amount of shares that can be redeemed from the active market.
+    uint256 public immutable minSharesToRedeem;
     /// @notice The address of the asset that is used to add and remove liquidity. eg WETH
     /// This is also the quote asset when the prices are set.
     /// eg the stETH/WETH price has a base asset of stETH and quote asset of WETH.
@@ -145,7 +144,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     event ARMBufferUpdated(uint256 armBuffer);
     event Allocated(address indexed market, int256 assets);
 
-    constructor(address _token0, address _token1, address _liquidityAsset, uint256 _claimDelay) {
+    constructor(address _token0, address _token1, address _liquidityAsset, uint256 _claimDelay, uint256 _minSharesToRedeem) {
         require(IERC20(_token0).decimals() == 18);
         require(IERC20(_token1).decimals() == 18);
 
@@ -160,6 +159,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         liquidityAsset = _liquidityAsset;
         // The base asset, eg stETH, is not the liquidity asset, eg WETH
         baseAsset = _liquidityAsset == _token0 ? _token1 : _token0;
+        minSharesToRedeem = _minSharesToRedeem;
     }
 
     /// @notice Initialize the contract.
@@ -812,7 +812,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             // maxRedeem can return a smaller amount of shares than balanceOf if the market is highly utilized.
             uint256 shares = IERC4626(previousActiveMarket).balanceOf(address(this));
             // This could fail if the market has high utilization
-            if (shares > MIN_SHARES_TO_REDEEM) {
+            if (shares > minSharesToRedeem) {
                 IERC4626(previousActiveMarket).redeem(shares, address(this), address(this));
             }
         }
@@ -862,7 +862,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
                 // redeem of the ARM's balance can fail if the lending market is highly utilized or temporarily paused.
                 // Redeem and not withdrawal is used to avoid leaving a small amount of assets in the market.
                 uint256 shares = IERC4626(activeMarket).maxRedeem(address(this));
-                if (shares <= MIN_SHARES_TO_REDEEM) return;
+                if (shares <= minSharesToRedeem) return;
                 // This should not fail according to the ERC-4626 spec as maxRedeem was used earlier
                 // but it depends on the 4626 implementation of the lending market.
                 // It may fail if the market is highly utilized and not compliant with 4626.

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -38,7 +38,7 @@ contract LidoARM is Initializable, AbstractARM {
     /// @param _lidoWithdrawalQueue The address of the Lido's withdrawal queue contract
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
     constructor(address _steth, address _weth, address _lidoWithdrawalQueue, uint256 _claimDelay)
-        AbstractARM(_weth, _steth, _weth, _claimDelay)
+        AbstractARM(_weth, _steth, _weth, _claimDelay, 0)
     {
         steth = IERC20(_steth);
         weth = IWETH(_weth);

--- a/src/contracts/OethARM.sol
+++ b/src/contracts/OethARM.sol
@@ -17,7 +17,7 @@ contract OethARM is Initializable, OwnerLP, PeggedARM, OethLiquidityManager {
     /// @param _weth The address of the WETH token that is being swapped out of this contract.
     /// @param _oethVault The address of the OETH Vault proxy.
     constructor(address _oeth, address _weth, address _oethVault)
-        AbstractARM(_oeth, _weth, _weth, 10 minutes)
+        AbstractARM(_oeth, _weth, _weth, 10 minutes, 0)
         PeggedARM(false)
         OethLiquidityManager(_oeth, _oethVault)
     {}

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -28,9 +28,13 @@ contract OriginARM is Initializable, AbstractARM {
     /// @param _liquidityAsset The address of the liquidity asset. eg WETH or wS
     /// @param _vault The address of the Origin Vault
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
-    constructor(address _otoken, address _liquidityAsset, address _vault, uint256 _claimDelay, uint256 _minSharesToRedeem)
-        AbstractARM(_liquidityAsset, _otoken, _liquidityAsset, _claimDelay, _minSharesToRedeem)
-    {
+    constructor(
+        address _otoken,
+        address _liquidityAsset,
+        address _vault,
+        uint256 _claimDelay,
+        uint256 _minSharesToRedeem
+    ) AbstractARM(_liquidityAsset, _otoken, _liquidityAsset, _claimDelay, _minSharesToRedeem) {
         vault = _vault;
 
         _disableInitializers();

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -28,8 +28,8 @@ contract OriginARM is Initializable, AbstractARM {
     /// @param _liquidityAsset The address of the liquidity asset. eg WETH or wS
     /// @param _vault The address of the Origin Vault
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
-    constructor(address _otoken, address _liquidityAsset, address _vault, uint256 _claimDelay)
-        AbstractARM(_liquidityAsset, _otoken, _liquidityAsset, _claimDelay)
+    constructor(address _otoken, address _liquidityAsset, address _vault, uint256 _claimDelay, uint256 _minSharesToRedeem)
+        AbstractARM(_liquidityAsset, _otoken, _liquidityAsset, _claimDelay, _minSharesToRedeem)
     {
         vault = _vault;
 

--- a/test/fork/OriginARM/shared/Shared.sol
+++ b/test/fork/OriginARM/shared/Shared.sol
@@ -86,7 +86,7 @@ abstract contract Fork_Shared_Test is Base_Test_, Modifiers {
         Proxy marketAdapterProxy = new Proxy();
 
         // --- Deploy OriginARM implementation
-        originARM = new OriginARM(address(os), address(ws), address(vault), CLAIM_DELAY);
+        originARM = new OriginARM(address(os), address(ws), address(vault), CLAIM_DELAY, 1e7);
 
         // --- Deploy SiloMarket implementation
         siloMarket = new SiloMarket(address(originARMProxy), Sonic.SILO_VARLAMORE_S_VAULT, Sonic.SILO_VARLAMORE_S_GAUGE);

--- a/test/invariants/OriginARM/FuzzerFoundry.sol
+++ b/test/invariants/OriginARM/FuzzerFoundry.sol
@@ -59,6 +59,6 @@ contract FuzzerFoundry_OriginARM is TargetFunction {
 
     function afterInvariant() public {
         handler_afterInvariants();
-        assertLpsAreUpOnly(originARM.MIN_SHARES_TO_REDEEM());
+        assertLpsAreUpOnly(originARM.minSharesToRedeem());
     }
 }

--- a/test/invariants/OriginARM/Setup.sol
+++ b/test/invariants/OriginARM/Setup.sol
@@ -140,7 +140,7 @@ abstract contract Setup is Base_Test_ {
         // ---
         // --- 2. Deploy all implementations. ---
         // Deploy OriginARM implementation
-        originARM = new OriginARM(address(os), address(ws), address(vault), CLAIM_DELAY);
+        originARM = new OriginARM(address(os), address(ws), address(vault), CLAIM_DELAY, 1e7);
 
         // Deploy SiloMarket implementation
         siloMarket = new SiloMarket(address(originARMProxy), address(market2), makeAddr("fake gauge"));

--- a/test/unit/shared/Shared.sol
+++ b/test/unit/shared/Shared.sol
@@ -69,7 +69,7 @@ abstract contract Unit_Shared_Test is Base_Test_, Modifiers {
         Proxy siloMarketProxy = new Proxy();
 
         // --- Deploy OriginARM implementation
-        originARM = new OriginARM(address(oeth), address(weth), address(vault), CLAIM_DELAY);
+        originARM = new OriginARM(address(oeth), address(weth), address(vault), CLAIM_DELAY, 1e7);
         capManager = new CapManager(address(address(originARMProxy)));
 
         // --- Deploy SiloMarket implementation


### PR DESCRIPTION
This pull request introduces changes to improve the flexibility and configurability of the `OriginARM` contract by replacing the constant `MIN_SHARES_TO_REDEEM` with an immutable variable `minSharesToRedeem`. It also updates related deployment scripts, test cases, and constructor calls to support this modification. Additionally, there is a minor change in the `Makefile` to adjust the `FOUNDRY_NO_MATCH_CONTRACT` environment variable.

### Enhancements to `OriginARM` and related contracts:
* Replaced the constant `MIN_SHARES_TO_REDEEM` with an immutable variable `minSharesToRedeem` in `AbstractARM` to allow for more dynamic configuration. This includes updates to the constructor and relevant logic where the constant was previously used (`src/contracts/AbstractARM.sol`). [[1]](diffhunk://#diff-41d22a3c9825e8099b1b619e93c45f5bd7b925c76b9d0e66069adf568e3bcaf6L27-L28) [[2]](diffhunk://#diff-41d22a3c9825e8099b1b619e93c45f5bd7b925c76b9d0e66069adf568e3bcaf6L38-R37) [[3]](diffhunk://#diff-41d22a3c9825e8099b1b619e93c45f5bd7b925c76b9d0e66069adf568e3bcaf6L148-R147) [[4]](diffhunk://#diff-41d22a3c9825e8099b1b619e93c45f5bd7b925c76b9d0e66069adf568e3bcaf6R162) [[5]](diffhunk://#diff-41d22a3c9825e8099b1b619e93c45f5bd7b925c76b9d0e66069adf568e3bcaf6L815-R815) [[6]](diffhunk://#diff-41d22a3c9825e8099b1b619e93c45f5bd7b925c76b9d0e66069adf568e3bcaf6L865-R865)
* Updated constructors of derived contracts (`OriginARM`, `LidoARM`, `OethARM`) to include the new `minSharesToRedeem` parameter (`src/contracts/OriginARM.sol`, `src/contracts/LidoARM.sol`, `src/contracts/OethARM.sol`). [[1]](diffhunk://#diff-1ce4a0e2cc5ded0833dea6886e98d62af81d0dd0ccbe87bd7b2143495772ee28L31-R32) [[2]](diffhunk://#diff-de88c57d6541f75ebfe062c7e15987f37bcff7af38b45b811bbb260d05ccf8f8L41-R41) [[3]](diffhunk://#diff-3ca39eee7f7d37797000a4a697e742fa09cb863d052cb3c48fc15a4c35001d3fL20-R20)

### Deployment script updates:
* Modified the deployment script for `OriginARM` to pass the new `minSharesToRedeem` parameter during contract deployment (`script/deploy/sonic/001_DeployOriginARM.sol`).

### Test case updates:
* Updated test cases to reflect the new `minSharesToRedeem` parameter in `OriginARM` deployment and assertions (`test/fork/OriginARM/shared/Shared.sol`, `test/invariants/OriginARM/FuzzerFoundry.sol`, `test/invariants/OriginARM/Setup.sol`, `test/unit/shared/Shared.sol`). [[1]](diffhunk://#diff-82144adc2ac6cb3a968039117f6292dbf43ee7c8ec3466246349d17eaa6d85b0L89-R89) [[2]](diffhunk://#diff-67540c10c7ebae236c0ec365746c752f03fe58f19904c08479cb44b4bc90ce37L62-R62) [[3]](diffhunk://#diff-d661f4e5ceb3f8923169faa9bc205057710aa70c7077e430986b7dbcc2b38df4L143-R143) [[4]](diffhunk://#diff-bc390b35a65648bee88e57f38041e92da1d8c731bebaea55a5873d9741ab2ef2L72-R72)

### Miscellaneous:
* Adjusted the `Makefile` to change the `FOUNDRY_NO_MATCH_CONTRACT` environment variable from `Invariant` to `Fuzzer` for the `test` target (`Makefile`).