### PR TITLE
Fetch deployed address using build file.

### DIFF
--- a/script/deploy/sonic/002_DeployOriginARM.sol
+++ b/script/deploy/sonic/002_DeployOriginARM.sol
@@ -21,6 +21,7 @@ contract DeployOriginARMScript is AbstractDeployScript {
     Proxy public originARMProxy;
 
     constructor(address _originARMProxy) {
+        require(_originARMProxy != address(0), "Invalid proxy address");
         originARMProxy = Proxy(payable(_originARMProxy));
     }
 
@@ -43,7 +44,7 @@ contract DeployOriginARMScript is AbstractDeployScript {
         _recordDeploy("ORIGIN_ARM_CAP_IMPL", address(capManagerImpl));
 
         // 3. Initialize Proxy with CapManager implementation and set the owner to the deployer for now
-        bytes memory data = abi.encodeWithSignature("initialize(address)", Sonic.RELAYER);
+        bytes memory data = abi.encodeWithSelector(CapManager.initialize.selector, Sonic.RELAYER);
         capManProxy.initialize(address(capManagerImpl), deployer, data);
         capManager = CapManager(address(capManProxy));
 
@@ -61,7 +62,6 @@ contract DeployOriginARMScript is AbstractDeployScript {
         // 7. Approve a little bit of wS to be transferred to the ARM proxy
         // This is needed for the initialize function which will mint some ARM LP tokens
         // and send to a dead address
-        console.log("Msg sender", msg.sender);
         IERC20(Sonic.WS).approve(address(originARMProxy), 1e12);
 
         // 8. Initialize Proxy with Origin ARM implementation and set the owner to the deployer for now


### PR DESCRIPTION
This pull request introduces enhancements to the deployment scripts, focusing on improving the robustness of contract deployment and initialization processes. Key changes include adding a utility function for fetching deployed contract addresses from JSON files, improving argument validation, and refining proxy initialization logic.

### Changes to `DeployManager.sol`:

* **Utility Function for JSON-Based Address Retrieval**:
  - Added `getDeployedAddressInBuild` to fetch contract addresses from deployment JSON files using `stdJson`. This ensures better integration with deployment artifacts.
  - Updated the `DeployOriginARMScript` invocation to use `getDeployedAddressInBuild` instead of `getDeployment`.

* **Library and Syntax Enhancements**:
  - Imported the `stdJson` library and added a `using stdJson for string` directive for JSON parsing functionality. [[1]](diffhunk://#diff-5a9ecc11d4800fb63e0de557f97dc8fb647e93e91c7524583e9df0964108b3d4R6) [[2]](diffhunk://#diff-5a9ecc11d4800fb63e0de557f97dc8fb647e93e91c7524583e9df0964108b3d4R20-R21)

### Changes to `DeployOriginARM.sol`:

* **Improved Argument Validation**:
  - Added a `require` statement in the constructor to validate that the provided proxy address is not zero.

* **Proxy Initialization Refinement**:
  - Replaced `abi.encodeWithSignature` with `abi.encodeWithSelector` for initializing the proxy, improving code clarity and reducing potential errors.

* **Code Cleanup**:
  - Removed unnecessary `console.log` statements to streamline the deployment logs.