### PR TITLE
Add lending market data to `snapLido`

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,14 @@ npx hardhat setActionVars --id 563d8d0c-17dc-46d3-8955-e4824864869f
 npx hardhat setActionVars --id c010fb76-ea63-409d-9981-69322d27993a
 npx hardhat setActionVars --id 127171fd-7b85-497e-8335-fd7907c08386
 npx hardhat setActionVars --id 84b5f134-8351-4402-8f6a-fb4376034bc4
-npx hardhat setActionVars --id ffcfc580-7b0a-42ed-a4f2-3f0a3add9779
+npx hardhat setActionVars --id ffcfc580-7b0a-42ed-a4f2-3f0a3add9779 (--name ONEINCH_API_KEY) # Don't forget to run `export ONEINCH_API_KEY=...` first! 
 npx hardhat setActionVars --id 32dbc67b-89f3-4856-8f3d-ad4dc5a09322
 npx hardhat setActionVars --id 7a0cb2c9-11c2-41dd-bcd0-d7c2dbda6af6
 npx hardhat setActionVars --id a9fc4c86-0506-4809-afbc-93b5e558cb68
 npx hardhat setActionVars --id 12977d51-d107-45eb-ac20-45942009ab01
 npx hardhat setActionVars --id 6ec46510-0b8e-48b4-a4c8-de759aad0ba4
 npx hardhat setActionVars --id 6d148f26-54a6-4377-92f2-3148d572eea3
+npx hardhat setActionVars --id acfbb7d6-5ea6-4ffc-a758-fa4b4f584dd1 
 
 # The Defender autotask client uses generic env var names so we'll set them first from the values in the .env file
 export API_KEY=
@@ -275,6 +276,7 @@ npx defender-autotask update-code a9fc4c86-0506-4809-afbc-93b5e558cb68 ./dist/co
 npx defender-autotask update-code 12977d51-d107-45eb-ac20-45942009ab01 ./dist/autoRequestWithdrawSonic
 npx defender-autotask update-code 6ec46510-0b8e-48b4-a4c8-de759aad0ba4 ./dist/autoClaimWithdrawSonic
 npx defender-autotask update-code 6d148f26-54a6-4377-92f2-3148d572eea3 ./dist/setOSSiloPriceAction
+npx defender-autotask update-code acfbb7d6-5ea6-4ffc-a758-fa4b4f584dd1 ./dist/allocateLido
 ```
 
 `rollup` and `defender-autotask` can be installed globally to avoid the `npx` prefix.

--- a/src/js/actions/allocateLido.js
+++ b/src/js/actions/allocateLido.js
@@ -1,9 +1,9 @@
 const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
-const { setPrices } = require("../tasks/lidoMorphoPrices");
+const { allocate } = require("../tasks/admin");
 const { mainnet } = require("../utils/addresses");
-const lidoARMAbi = require("../../abis/LidoARM.json");
+const armAbi = require("../../abis/OriginARM.json");
 
 // Entrypoint for the Defender Action
 const handler = async (event) => {
@@ -20,24 +20,13 @@ const handler = async (event) => {
   );
 
   // References to contracts
-  const arm = new ethers.Contract(mainnet.lidoARM, lidoARMAbi, signer);
+  const arm = new ethers.Contract(mainnet.lidoARM, armAbi, signer);
 
   try {
-    await setPrices({
+    await allocate({
       signer,
       arm,
-      // sellPrice: 0.9998,
-      // buyPrice: 0.9997,
-      maxSellPrice: 0.9999,
-      minSellPrice: 0.9998,
-      maxBuyPrice: 0.9980,
-      minBuyPrice: 0.9950,
-      inch: true,
-      amount: 100,
-      tolerance: 0.1,
-      fee: 0.8,
-      offset: 0.2,
-      blockTag: "latest",
+      threshold: 20,
     });
   } catch (error) {
     console.error(error);

--- a/src/js/actions/rollup.config.cjs
+++ b/src/js/actions/rollup.config.cjs
@@ -129,4 +129,12 @@ module.exports = [
     },
     ...commonConfig,
   },
+    {
+    input: "allocateLido.js",
+    output: {
+      file: "dist/allocateLido/index.js",
+      format: "cjs",
+    },
+    ...commonConfig,
+  },
 ];

--- a/src/js/actions/setPrices.js
+++ b/src/js/actions/setPrices.js
@@ -30,13 +30,14 @@ const handler = async (event) => {
       // buyPrice: 0.9997,
       maxSellPrice: 0.9999,
       minSellPrice: 0.9998,
-      maxBuyPrice: 0.9980,
-      minBuyPrice: 0.9950,
+      maxBuyPrice: 0.998,
+      minBuyPrice: 0.995,
       inch: true,
       amount: 100,
       tolerance: 0.2,
       fee: 0.8,
       offset: 0.4,
+      priceOffset: true,
       blockTag: "latest",
     });
   } catch (error) {

--- a/src/js/actions/setPrices.js
+++ b/src/js/actions/setPrices.js
@@ -34,9 +34,9 @@ const handler = async (event) => {
       minBuyPrice: 0.9950,
       inch: true,
       amount: 100,
-      tolerance: 0.1,
+      tolerance: 0.2,
       fee: 0.8,
-      offset: 0.2,
+      offset: 0.4,
       blockTag: "latest",
     });
   } catch (error) {

--- a/src/js/tasks/defender.js
+++ b/src/js/tasks/defender.js
@@ -1,11 +1,9 @@
+require("dotenv").config();
 const { AutotaskClient } = require("@openzeppelin/defender-autotask-client");
-const path = require("path");
-
-require("dotenv").config({ path: path.resolve(__dirname, "../../../.env") });
 
 const log = require("../utils/logger")("task:defender");
 
-const setActionVars = async (options) => {
+const setActionVars = async ({ id, name }) => {
   log(`Used DEFENDER_TEAM_KEY ${process.env.DEFENDER_TEAM_KEY}`);
   const creds = {
     apiKey: process.env.DEFENDER_TEAM_KEY,
@@ -13,11 +11,17 @@ const setActionVars = async (options) => {
   };
   const client = new AutotaskClient(creds);
 
+  const envVars = {};
+  if (name) {
+    envVars[name] = process.env[name];
+  }
+
   // Update Variables
-  const variables = await client.updateEnvironmentVariables(options.id, {
+  const variables = await client.updateEnvironmentVariables(id, {
+    ...envVars,
     DEBUG: "origin*",
   });
-  console.log("updated Autotask environment variables", variables);
+  console.log("Updated Defender Actions environment variables to:", variables);
 };
 
 module.exports = {

--- a/src/js/tasks/lidoMorphoPrices.js
+++ b/src/js/tasks/lidoMorphoPrices.js
@@ -60,11 +60,11 @@ const setPrices = async (options) => {
 
     // 2.2 Calculate target prices
     const offsetBN = parseUnits(offset.toString(), 14);
-    if (priceOffset && referencePrices.buyPrice) {
+    if (priceOffset && referencePrices.sellPrice) {
       // If price offset is provided, adjust the target prices accordingly
       log(`\nCalculating target prices based on offset:`);
-      // Target buy price is the reference buy price plus the offset
-      targetBuyPrice = ((referencePrices.buyPrice) + offsetBN) * BigInt(1e18);
+      // Target buy price is the reference sell price plus the offset
+      targetBuyPrice = ((referencePrices.sellPrice) + offsetBN) * BigInt(1e18);
       // Target sell price is the target buy price plus 2x fee offset
       targetSellPrice = targetBuyPrice + parseUnits(fee.toString(), 32) * BigInt(2);
       log(`offset             : ${formatUnits(offsetBN, 14)} basis points`);

--- a/src/js/tasks/tasks.js
+++ b/src/js/tasks/tasks.js
@@ -735,7 +735,7 @@ subtask("setPrices", "Update Lido ARM's swap prices")
     );
     const arm = await ethers.getContractAt("AbstractARM", armAddress);
 
-    const activeMarket = "0x9a8bC3B04b7f3D87cfC09ba407dCED575f2d61D8"; //await arm.activeMarket();
+    const activeMarket = await arm.activeMarket();
     if (activeMarket === ethers.ZeroAddress) {
       console.log("No active lending market found, using default APY of 0%");
       return 0n;
@@ -1058,6 +1058,12 @@ subtask(
   "Set environment variables on a Defender Actions. eg DEBUG=origin*"
 )
   .addParam("id", "Identifier of the Defender Actions", undefined, types.string)
+  .addOptionalParam(
+    "name",
+    "Name of the environment variable to set. eg HOODI_BEACON_PROVIDER_URL",
+    undefined,
+    types.string
+  )
   .setAction(setActionVars);
 task("setActionVars").setAction(async (_, __, runSuper) => {
   return runSuper();

--- a/src/js/utils/fluid.js
+++ b/src/js/utils/fluid.js
@@ -6,7 +6,7 @@ const wstEthAbi = require("../../abis/wstETH.json");
 const addresses = require("./addresses");
 const { getSigner } = require("./signers");
 
-const log = require("../utils/logger")("utils:uniswap");
+const log = require("../utils/logger")("utils:fluid");
 
 const getFluidSpotPrices = async ({ amount, blockTag, gas }) => {
   const signer = await getSigner();


### PR DESCRIPTION
## Description

This pull request updates the `logAssets` function in `src/js/tasks/lido.js` to include balances and percentages for assets held in the active lending market. The changes add support for fetching and displaying the lending market balance and its proportion of total assets, using a hardcoded market address for now.

**Lending Market Integration:**

* Added logic to retrieve the ARM's balance in the active lending market (`Abstract4626MarketWrapper`), calculate its value in assets, and include it in the total asset calculation. The market address is currently hardcoded but will be dynamic in the future.
* Updated output to display the lending market balance and its percentage share alongside other asset categories.

(I generated description using copilot, not bad)