### PR TITLE
Fix CI install

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -46,11 +46,11 @@ fail_on_revert = false
 [dependencies]
 solmate = "6.7.0"
 forge-std = "1.9.7"
-"@pendle-sy-1.0.0" = { version = "1.0.0", git = "git@github.com:pendle-finance/Pendle-SY-Public.git", rev = "3256e7728d1656a8e16e2e70aa885f69fc66088d" }
-"@openzeppelin-contracts-4.9.3" = { version = "4.9.3", git = "git@github.com:OpenZeppelin/openzeppelin-contracts.git", rev = "fd81a96f01cc42ef1c9a5399364968d0e07e9e90" }
-"@openzeppelin-contracts-5.0.2" = { version = "5.0.2", git = "git@github.com:OpenZeppelin/openzeppelin-contracts.git", rev = "dbb6104ce834628e473d2173bbc9d47f81a9eec3" }
-"@openzeppelin-contracts-upgradeable-4.9.3" = { version = "4.9.3", git = "git@github.com:OpenZeppelin/openzeppelin-contracts-upgradeable.git", rev = "3d4c0d5741b131c231e558d7a6213392ab3672a5" }
-"@openzeppelin-contracts-upgradeable-5.0.2" = { version = "5.0.2", git = "git@github.com:OpenZeppelin/openzeppelin-contracts-upgradeable.git", rev = "723f8cab09cdae1aca9ec9cc1cfa040c2d4b06c1" }
+"@pendle-sy-1.0.0" = { version = "1.0.0", git = "https://github.com/pendle-finance/Pendle-SY-Public.git", rev = "3256e7728d1656a8e16e2e70aa885f69fc66088d" }
+"@openzeppelin-contracts-4.9.3" = { version = "4.9.3", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "fd81a96f01cc42ef1c9a5399364968d0e07e9e90" }
+"@openzeppelin-contracts-5.0.2" = { version = "5.0.2", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "dbb6104ce834628e473d2173bbc9d47f81a9eec3" }
+"@openzeppelin-contracts-upgradeable-4.9.3" = { version = "4.9.3", git = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git", rev = "3d4c0d5741b131c231e558d7a6213392ab3672a5" }
+"@openzeppelin-contracts-upgradeable-5.0.2" = { version = "5.0.2", git = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git", rev = "723f8cab09cdae1aca9ec9cc1cfa040c2d4b06c1" }
 
 [soldeer]
 recursive_deps = false


### PR DESCRIPTION
## Description
This pull request updates the dependency configuration in `foundry.toml` to use HTTPS URLs for all external git repositories instead of SSH. This change improves compatibility for environments where SSH keys are not configured or available.

Dependency configuration updates:

* Changed the `git` URLs for all external dependencies (`@pendle-sy-1.0.0`, `@openzeppelin-contracts-4.9.3`, `@openzeppelin-contracts-5.0.2`, `@openzeppelin-contracts-upgradeable-4.9.3`, `@openzeppelin-contracts-upgradeable-5.0.2`) from SSH (`git@github.com:...`) to HTTPS (`https://github.com/...`) in `foundry.toml`.