### PR TITLE
Refactor price calculation logs in setOSSiloPrice task

### DIFF
--- a/src/js/actions/setOSSiloPriceAction.js
+++ b/src/js/actions/setOSSiloPriceAction.js
@@ -31,16 +31,12 @@ const handler = async (credentials) => {
     "function market() external view returns (address)",
   ], signer);
 
-  try {
     await setOSSiloPrice({
       signer,
       arm,
       siloMarketWrapper,
       execute: true,
     });
-  } catch (error) {
-    console.error(error);
-  }
 };
 
 module.exports = { handler };

--- a/src/js/tasks/osSiloPrice.js
+++ b/src/js/tasks/osSiloPrice.js
@@ -33,13 +33,13 @@ const setOSSiloPrice = async (options) => {
     const currentPricing = await getFlyTradePrice(testAmountIn, signer);
     log(`Current market pricing: ${Number(formatUnits(currentPricing, 18)).toFixed(4)}`);
 
-    // 4. Calculate minBuyingPrice based on APY
+    // 4. Calculate highest buy price, we should always target a price lower than this to maintain the APY
     const minBuyingPrice = calculateMinBuyingPrice(currentApyLending);
-    log(`Calculated min buying price: ${Number(formatUnits(minBuyingPrice, 36)).toFixed(4)}`);
+    log(`Calculated highest buying price to maintain APY: ${Number(formatUnits(minBuyingPrice, 36)).toFixed(4)}`);
 
-    // 5. Calculate maxBuyingPrice
+    // 5. Calculate maxBuyingPrice, market price with an added premium
     const maxBuyingPrice = calculateMaxBuyingPrice(currentPricing, minBuyingPrice);
-    log(`Calculated max buying price: ${Number(formatUnits(maxBuyingPrice, 36)).toFixed(4)}`);
+    log(`Calculated max buying price (market price + premium): ${Number(formatUnits(maxBuyingPrice, 36)).toFixed(4)}`);
 
     // 6. Set the prices on the ARM contract
     const targetBuyPrice = maxBuyingPrice;


### PR DESCRIPTION
## Description
This pull request refines the logic and messaging around setting the OS Silo price and removes unnecessary error handling from the action handler. The main changes focus on clarifying the calculation steps for buy prices and improving code robustness.

Improvements to price calculation logic and messaging:

* Updated comments and log messages in `src/js/tasks/osSiloPrice.js` to clarify the calculation of buy prices, making it explicit that the highest buy price is targeted to maintain APY, and that the max buy price includes a market premium.

Code simplification:

* Removed the try-catch block from the `handler` in `src/js/actions/setOSSiloPriceAction.js`, allowing errors to propagate naturally and simplifying the function.