### PR TITLE
Add gas limit buffer to allocation in autoClaimWithdraw handler

### DIFF
--- a/src/js/actions/autoClaimWithdrawSonic.js
+++ b/src/js/actions/autoClaimWithdrawSonic.js
@@ -39,8 +39,12 @@ const handler = async (event) => {
 
   // If any requests were claimed
   if (requestIds?.length > 0) {
+    // Add 10% buffer to gas limit
+    let gasLimit = await arm.connect(signer).allocate.estimateGas();
+    gasLimit = (gasLimit * 12n) / 10n;
+    
     // Allocate any excess liquidity to the lending market
-    const tx = await arm.allocate();
+    const tx = await arm.allocate({ gasLimit });
     await logTxDetails(tx, "allocate");
   }
 };


### PR DESCRIPTION
## Description
This pull request introduces a small but important improvement to the gas estimation logic in the `autoClaimWithdrawSonic.js` action. When allocating excess liquidity, the code now estimates the gas required for the transaction and adds a 20% buffer to the gas limit to help prevent out-of-gas errors.

Gas estimation improvement:

* The `allocate` transaction now uses an estimated gas limit with a 20% buffer, reducing the likelihood of failed transactions due to insufficient gas. (`src/js/actions/autoClaimWithdrawSonic.js`)