### PR TITLE
Fix Actions for OZ Defender.

### DIFF
--- a/src/js/actions/setOSSiloPriceAction.js
+++ b/src/js/actions/setOSSiloPriceAction.js
@@ -36,11 +36,33 @@ const handler = async (credentials) => {
     "function market() external view returns (address)",
   ], signer);
 
+  // Get the WS and OS token contracts
+  const wSAddress = await arm.token0();
+  const wS = new ethers.Contract(wSAddress, [
+    "function balanceOf(address) external view returns (uint256)"
+  ], signer);
+
+  const oSAddress = await arm.token1();
+  const oS = new ethers.Contract(oSAddress, [
+    "function balanceOf(address) external view returns (uint256)"
+  ], signer);
+
+  // Get the OS Vault contract
+  const vaultAddress = await arm.vault();
+  const vault = new ethers.Contract(vaultAddress, [
+    "function withdrawalQueueMetadata() external view returns (uint128,uint128,uint128,uint128)",
+    "function withdrawalRequests(uint256) external view returns (address,bool,uint40,uint128,uint128)"
+  ], signer);
+
   await setOSSiloPrice({
     signer,
     arm,
     siloMarketWrapper,
     execute: true,
+    wS,
+    oS,
+    vault,
+    blockTag: "latest",
   });
 };
 

--- a/src/js/tasks/tasks.js
+++ b/src/js/tasks/tasks.js
@@ -1173,12 +1173,38 @@ subtask(
       signer
     );
 
+    // Get the WS and OS token contracts
+    const wSAddress = await arm.token0();
+    const wS = await hre.ethers.getContractAt(
+      [`function balanceOf(address owner) external view returns (uint256)`],
+      wSAddress
+    );
+
+    const oSAddress = await arm.token1();
+    const oS = await hre.ethers.getContractAt(
+      [`function balanceOf(address owner) external view returns (uint256)`],
+      oSAddress
+    );
+
+    // Get the Vault contract
+    const vaultAddress = await arm.vault();
+    const vault = await hre.ethers.getContractAt(
+      [
+        `function withdrawalQueueMetadata() external view returns (uint128,uint128,uint128,uint128)`,
+        `function withdrawalRequests(uint256) external view returns (address,bool,uint40,uint128,uint128)`
+      ],
+      vaultAddress
+    );
+
     await setOSSiloPrice({
       tolerance: taskArgs.tolerance,
       signer,
       arm,
       siloMarketWrapper,
-      block: taskArgs.block,
+      wS,
+      oS,
+      vault,
+      blockTag: taskArgs.block,
     });
   });
 task("setOSSiloPrice").setAction(async (_, __, runSuper) => {


### PR DESCRIPTION
## Description
This pull request refactors how contract instances and block tags are passed to the OS Silo price calculation logic. Instead of creating contract instances inside the pricing logic, they are now instantiated earlier and passed as parameters, which improves modularity and testability. Additionally, the code now consistently uses `blockTag` instead of `block` and updates contract calls to use the provided signer and provider.

**Refactoring contract instance management:**

* Contract instances for WS, OS, and Vault tokens are now created outside of the price calculation logic (`setOSSiloPrice` and `estimateAverageWithdrawTime`) and passed in as parameters, rather than being instantiated internally. This change is reflected in both the handler and subtask setup (`src/js/actions/setOSSiloPriceAction.js`, `src/js/tasks/tasks.js`). [[1]](diffhunk://#diff-ee04f41356d03c9ed025629ef867940d836ac55a210f3c3c71566591156b77a6R39-R65) [[2]](diffhunk://#diff-2a337b3f971a9cb995f465d80ab3f300e2a63ca5fe74c090688f8f4dbb1e3150R1176-R1207)

**API and parameter changes:**

* The `setOSSiloPrice` and `estimateAverageWithdrawTime` functions now accept `wS`, `oS`, `vault`, and `blockTag` as parameters instead of instantiating them internally or using `block`. This makes the functions more flexible and easier to test. [[1]](diffhunk://#diff-d5b2cce20c27cff95dddc8c70e3684bd434484c98a947674105cda2e56a66cfeL19-R22) [[2]](diffhunk://#diff-d5b2cce20c27cff95dddc8c70e3684bd434484c98a947674105cda2e56a66cfeL40-R43) [[3]](diffhunk://#diff-d5b2cce20c27cff95dddc8c70e3684bd434484c98a947674105cda2e56a66cfeL172-R180)

**Provider and contract call updates:**

* Contract calls within `estimateAverageWithdrawTime` now use `signer.provider` instead of `hre.ethers.provider`, and contract instances are used directly from the parameters, streamlining access and ensuring consistency. [[1]](diffhunk://#diff-d5b2cce20c27cff95dddc8c70e3684bd434484c98a947674105cda2e56a66cfeL172-R180) [[2]](diffhunk://#diff-d5b2cce20c27cff95dddc8c70e3684bd434484c98a947674105cda2e56a66cfeL188-L206) [[3]](diffhunk://#diff-d5b2cce20c27cff95dddc8c70e3684bd434484c98a947674105cda2e56a66cfeL218-L223)

**Execution logic adjustment:**

* The logic for blocking historical price updates now checks for `blockTag !== "latest"` instead of `block !== undefined`, aligning with the new parameter convention.