### PR TITLE
Reduced the Ethena ARM DELAY_REQUEST from 3 hours to 30 minutes

### DIFF
--- a/src/contracts/EthenaARM.sol
+++ b/src/contracts/EthenaARM.sol
@@ -13,7 +13,7 @@ import {IERC20, IStakedUSDe, UserCooldown} from "./Interfaces.sol";
  */
 contract EthenaARM is Initializable, AbstractARM {
     /// @notice The delay before a new unstake request can be made
-    uint256 public constant DELAY_REQUEST = 3 hours;
+    uint256 public constant DELAY_REQUEST = 30 minutes;
     /// @notice The maximum number of unstaker helper contracts
     uint8 public constant MAX_UNSTAKERS = 42;
     /// @notice The address of Ethena's synthetic dollar token (USDe)

--- a/src/js/tasks/ethenaQueue.js
+++ b/src/js/tasks/ethenaQueue.js
@@ -14,13 +14,13 @@ const requestEthenaWithdrawals = async (options) => {
     : await baseWithdrawAmount(options);
   if (!withdrawAmount || withdrawAmount === 0n) return;
 
-  // 2. Check 3 hours has passed since last withdrawal request
+  // 2. Check the contract request delay has passed since the last withdrawal request
   const lastRequestTime = await arm.lastRequestTimestamp();
+  const requestDelay = Number(await arm.DELAY_REQUEST());
   const currentTime = Math.floor(Date.now() / 1000);
   const timeSinceLastRequest = currentTime - Number(lastRequestTime);
-  const THREE_HOURS = 3 * 60 * 60;
-  if (timeSinceLastRequest < THREE_HOURS) {
-    const timeLeft = THREE_HOURS - timeSinceLastRequest;
+  if (timeSinceLastRequest < requestDelay) {
+    const timeLeft = requestDelay - timeSinceLastRequest;
     log(
       `Skipping: Last withdrawal request was only ${timeSinceLastRequest} seconds ago; need to wait another ${timeLeft} seconds`,
     );

--- a/test/invariants/EthenaARM/TargetFunctions.sol
+++ b/test/invariants/EthenaARM/TargetFunctions.sol
@@ -527,23 +527,24 @@ abstract contract TargetFunctions is Setup, StdUtils {
 
         // Ensure time delay has passed
         uint32 lastRequestTimestamp = arm.lastRequestTimestamp();
-        if (block.timestamp < lastRequestTimestamp + 3 hours) {
+        uint256 requestDelay = arm.DELAY_REQUEST();
+        if (block.timestamp < lastRequestTimestamp + requestDelay) {
             if (isConsoleAvailable) {
                 console.log(
                     StdStyle.yellow(
                         string(
                             abi.encodePacked(
                                 ">>> Time jump:\t Fast forwarded to: ",
-                                vm.toString(lastRequestTimestamp + 3 hours),
+                                vm.toString(lastRequestTimestamp + requestDelay),
                                 "  (+ ",
-                                vm.toString((lastRequestTimestamp + 3 hours) - block.timestamp),
+                                vm.toString((lastRequestTimestamp + requestDelay) - block.timestamp),
                                 "s)"
                             )
                         )
                     )
                 );
             }
-            vm.warp(lastRequestTimestamp + 3 hours);
+            vm.warp(lastRequestTimestamp + requestDelay);
         }
 
         vm.prank(operator);

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -33,7 +33,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         proxy = Proxy(payable(resolver.resolve("LIDO_ARM")));
         lidoARM = LidoARM(payable(resolver.resolve("LIDO_ARM")));
         capManager = CapManager(resolver.resolve("LIDO_ARM_CAP_MAN"));
-        morphoMarket = IERC4626(resolver.resolve("MORPHO_MARKET_MEVCAPITAL"));
+        morphoMarket = IERC4626(resolver.resolve("MORPHO_MARKET_LIDO"));
 
         // Only fuzz from this address. Big speedup on fork.
         targetSender(address(this));
@@ -241,8 +241,9 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         lidoARM.setActiveMarket(address(morphoMarket));
         vm.stopPrank();
 
-        // Deal WETH to the ARM
-        deal(address(weth), address(lidoARM), 100 ether);
+        // Deal enough WETH to cover the outstanding withdrawal queue plus extra to deposit
+        uint256 outstandingWithdrawals = lidoARM.withdrawsQueued() - lidoARM.withdrawsClaimed();
+        deal(address(weth), address(lidoARM), outstandingWithdrawals + 100 ether);
 
         uint256 armWethBefore = weth.balanceOf(address(lidoARM));
         uint256 marketBalanceBefore = morphoMarket.maxWithdraw(address(lidoARM));
@@ -275,8 +276,9 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         lidoARM.setActiveMarket(address(morphoMarket));
         vm.stopPrank();
 
-        // Deal WETH to the ARM and allocate to market with buffer at 0%
-        deal(address(weth), address(lidoARM), 100 ether);
+        // Deal enough WETH to cover the outstanding withdrawal queue plus extra to deposit
+        uint256 outstandingWithdrawals = lidoARM.withdrawsQueued() - lidoARM.withdrawsClaimed();
+        deal(address(weth), address(lidoARM), outstandingWithdrawals + 100 ether);
         vm.prank(Mainnet.ARM_RELAYER);
         lidoARM.setARMBuffer(0);
         vm.prank(Mainnet.ARM_RELAYER);


### PR DESCRIPTION
Ethena recently reduced sUSDe's cooldown from 7 days to just 1 day. This means the Ethena ARM can request a lot more withdrawals in a day using its 42 EthenaUnstaker contracts.