### PR TITLE
Fixed deprecated apollo use

### DIFF
--- a/src/js/tasks/etherfiQueue.js
+++ b/src/js/tasks/etherfiQueue.js
@@ -1,7 +1,8 @@
-const { ApolloClient, InMemoryCache, gql } = require("@apollo/client/core");
+const { gql } = require("@apollo/client/core");
 const { parseUnits } = require("ethers");
 
 const { baseWithdrawAmount } = require("./liquidityAutomation");
+const { createApolloClient } = require("../utils/apollo");
 const { logTxDetails } = require("../utils/txLogger");
 
 const log = require("../utils/logger")("task:etherfiQueue");
@@ -42,10 +43,7 @@ const claimEtherFiWithdrawals = async (options) => {
 };
 
 const claimableEtherFiRequests = async () => {
-  const client = new ApolloClient({
-    uri,
-    cache: new InMemoryCache(),
-  });
+  const client = createApolloClient(uri);
 
   log(`About to get claimable EtherFi withdrawal requests`);
 

--- a/src/js/utils/apollo.js
+++ b/src/js/utils/apollo.js
@@ -1,0 +1,19 @@
+const {
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+} = require("@apollo/client/core");
+const fetch = require("node-fetch");
+
+const createApolloClient = (uri) =>
+  new ApolloClient({
+    link: new HttpLink({
+      uri,
+      fetch,
+    }),
+    cache: new InMemoryCache(),
+  });
+
+module.exports = {
+  createApolloClient,
+};

--- a/src/js/utils/armQueue.js
+++ b/src/js/utils/armQueue.js
@@ -1,15 +1,13 @@
-const { ApolloClient, InMemoryCache, gql } = require("@apollo/client/core");
+const { gql } = require("@apollo/client/core");
 const { formatUnits } = require("ethers");
 
+const { createApolloClient } = require("./apollo");
 const log = require("./logger")("utils:queue");
 
 const uri = "https://origin.squids.live/origin-squid/graphql";
 
 const outstandingWithdrawalAmount = async ({ withdrawer }) => {
-  const client = new ApolloClient({
-    uri,
-    cache: new InMemoryCache(),
-  });
+  const client = createApolloClient(uri);
 
   log(`About to get outstanding withdrawal requests for ${withdrawer}`);
 
@@ -58,10 +56,7 @@ const claimableRequests = async ({
   queuedAmountClaimable,
   claimCutoff,
 }) => {
-  const client = new ApolloClient({
-    uri,
-    cache: new InMemoryCache(),
-  });
+  const client = createApolloClient(uri);
 
   log(
     `About to get claimable withdrawal requests for withdrawer ${withdrawer} up to ${formatUnits(

--- a/src/js/utils/osStaking.js
+++ b/src/js/utils/osStaking.js
@@ -1,14 +1,12 @@
-const { ApolloClient, InMemoryCache, gql } = require("@apollo/client/core");
+const { gql } = require("@apollo/client/core");
 
+const { createApolloClient } = require("./apollo");
 const log = require("./logger")("utils:os:staking");
 
 const uri = "https://origin.squids.live/origin-squid/graphql";
 
 const outstandingValidatorWithdrawalRequests = async () => {
-  const client = new ApolloClient({
-    uri,
-    cache: new InMemoryCache(),
-  });
+  const client = createApolloClient(uri);
 
   log(`About to get outstanding undelegate requests from the Sonic validators`);
 


### PR DESCRIPTION
Fixes this warning
```
An error occurred! For more details, see the full error text at https://go.apollo.dev/c/err#%7B%22version%22%3A%223.14.1%22%2C%22message%22%3A103%2C%22args%22%3A%5B%22ApolloClient%22%2C%22uri%22%2C%22Please%20initialize%20an%20instance%20of%20%60HttpLink%60%20with%20%60uri%60%20instead.%22%5D%7D
```