### PR TITLE
WIP ARM fees charged on buying base assets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ make coverage         # LCOV coverage report
 
 Linting: `forge fmt --check` (Solidity), `pnpm lint` (JS), `pnpm prettier:check` (JS)
 
+When changing Solidity files, run `forge fmt` before finishing your work.
+
 ## Environment Setup
 
 Copy `.env.example` to `.env` and set `PROVIDER_URL` (Ethereum RPC) and `SONIC_URL` (Sonic RPC). Fork tests require these RPC endpoints.

--- a/script/deploy/mainnet/027_UpgradeLidoARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/027_UpgradeLidoARMSwapFeeScript.s.sol
@@ -30,7 +30,11 @@ contract $027_UpgradeLidoARMSwapFeeScript is AbstractDeployScript("027_UpgradeLi
 
         address lidoARMProxy = resolver.resolve("LIDO_ARM");
         govProposal.action(lidoARMProxy, "collectFees()", "");
-        govProposal.action(lidoARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("LIDO_ARM_IMPL")));
+        govProposal.action(
+            lidoARMProxy,
+            "upgradeToAndCall(address,bytes)",
+            abi.encode(resolver.resolve("LIDO_ARM_IMPL"), abi.encodeWithSelector(LidoARM.migrateFeesAccrued.selector))
+        );
     }
 
     function _fork() internal override {
@@ -42,7 +46,7 @@ contract $027_UpgradeLidoARMSwapFeeScript is AbstractDeployScript("027_UpgradeLi
         vm.startPrank(proxy.owner());
         // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
         LidoARM(payable(address(proxy))).collectFees();
-        proxy.upgradeTo(impl);
+        proxy.upgradeToAndCall(impl, abi.encodeWithSelector(LidoARM.migrateFeesAccrued.selector));
         vm.stopPrank();
     }
 }

--- a/script/deploy/mainnet/027_UpgradeLidoARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/027_UpgradeLidoARMSwapFeeScript.s.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contract
+import {Proxy} from "contracts/Proxy.sol";
+import {LidoARM} from "contracts/LidoARM.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";
+
+contract $027_UpgradeLidoARMSwapFeeScript is AbstractDeployScript("027_UpgradeLidoARMSwapFeeScript") {
+    using GovHelper for GovProposal;
+
+    bool public constant override skip = true;
+
+    function _execute() internal override {
+        uint256 claimDelay = 10 minutes;
+        uint256 minSharesToRedeem = 1e7;
+        int256 allocateThreshold = 1e18;
+        LidoARM lidoARMImpl = new LidoARM(
+            Mainnet.STETH, Mainnet.WETH, Mainnet.LIDO_WITHDRAWAL, claimDelay, minSharesToRedeem, allocateThreshold
+        );
+        _recordDeployment("LIDO_ARM_IMPL", address(lidoARMImpl));
+    }
+
+    function _buildGovernanceProposal() internal override {
+        govProposal.setDescription("Collect legacy Lido ARM fees and upgrade to swap-only fee accrual");
+
+        address lidoARMProxy = resolver.resolve("LIDO_ARM");
+        govProposal.action(lidoARMProxy, "collectFees()", "");
+        govProposal.action(lidoARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("LIDO_ARM_IMPL")));
+    }
+
+    function _fork() internal override {
+        Proxy proxy = Proxy(payable(resolver.resolve("LIDO_ARM")));
+        address impl = resolver.resolve("LIDO_ARM_IMPL");
+
+        if (proxy.implementation() == impl) return;
+
+        vm.startPrank(proxy.owner());
+        // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
+        LidoARM(payable(address(proxy))).collectFees();
+        proxy.upgradeTo(impl);
+        vm.stopPrank();
+    }
+}

--- a/script/deploy/mainnet/028_UpgradeEtherFiARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/028_UpgradeEtherFiARMSwapFeeScript.s.sol
@@ -36,9 +36,7 @@ contract $028_UpgradeEtherFiARMSwapFeeScript is AbstractDeployScript("028_Upgrad
 
         address etherFiARMProxy = resolver.resolve("ETHER_FI_ARM");
         govProposal.action(etherFiARMProxy, "collectFees()", "");
-        govProposal.action(
-            etherFiARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("ETHERFI_ARM_IMPL"))
-        );
+        govProposal.action(etherFiARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("ETHERFI_ARM_IMPL")));
     }
 
     function _fork() internal override {

--- a/script/deploy/mainnet/028_UpgradeEtherFiARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/028_UpgradeEtherFiARMSwapFeeScript.s.sol
@@ -36,7 +36,13 @@ contract $028_UpgradeEtherFiARMSwapFeeScript is AbstractDeployScript("028_Upgrad
 
         address etherFiARMProxy = resolver.resolve("ETHER_FI_ARM");
         govProposal.action(etherFiARMProxy, "collectFees()", "");
-        govProposal.action(etherFiARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("ETHERFI_ARM_IMPL")));
+        govProposal.action(
+            etherFiARMProxy,
+            "upgradeToAndCall(address,bytes)",
+            abi.encode(
+                resolver.resolve("ETHERFI_ARM_IMPL"), abi.encodeWithSelector(EtherFiARM.migrateFeesAccrued.selector)
+            )
+        );
     }
 
     function _fork() internal override {
@@ -48,7 +54,7 @@ contract $028_UpgradeEtherFiARMSwapFeeScript is AbstractDeployScript("028_Upgrad
         vm.startPrank(proxy.owner());
         // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
         EtherFiARM(payable(address(proxy))).collectFees();
-        proxy.upgradeTo(impl);
+        proxy.upgradeToAndCall(impl, abi.encodeWithSelector(EtherFiARM.migrateFeesAccrued.selector));
         vm.stopPrank();
     }
 }

--- a/script/deploy/mainnet/028_UpgradeEtherFiARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/028_UpgradeEtherFiARMSwapFeeScript.s.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contract
+import {Proxy} from "contracts/Proxy.sol";
+import {EtherFiARM} from "contracts/EtherFiARM.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";
+
+contract $028_UpgradeEtherFiARMSwapFeeScript is AbstractDeployScript("028_UpgradeEtherFiARMSwapFeeScript") {
+    using GovHelper for GovProposal;
+
+    bool public constant override skip = true;
+
+    function _execute() internal override {
+        uint256 claimDelay = 10 minutes;
+        uint256 minSharesToRedeem = 1e7;
+        int256 allocateThreshold = 1e18;
+        EtherFiARM etherFiARMImpl = new EtherFiARM(
+            Mainnet.EETH,
+            Mainnet.WETH,
+            Mainnet.ETHERFI_WITHDRAWAL,
+            claimDelay,
+            minSharesToRedeem,
+            allocateThreshold,
+            Mainnet.ETHERFI_WITHDRAWAL_NFT
+        );
+        _recordDeployment("ETHERFI_ARM_IMPL", address(etherFiARMImpl));
+    }
+
+    function _buildGovernanceProposal() internal override {
+        govProposal.setDescription("Collect legacy EtherFi ARM fees and upgrade to swap-only fee accrual");
+
+        address etherFiARMProxy = resolver.resolve("ETHER_FI_ARM");
+        govProposal.action(etherFiARMProxy, "collectFees()", "");
+        govProposal.action(
+            etherFiARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("ETHERFI_ARM_IMPL"))
+        );
+    }
+
+    function _fork() internal override {
+        Proxy proxy = Proxy(payable(resolver.resolve("ETHER_FI_ARM")));
+        address impl = resolver.resolve("ETHERFI_ARM_IMPL");
+
+        if (proxy.implementation() == impl) return;
+
+        vm.startPrank(proxy.owner());
+        // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
+        EtherFiARM(payable(address(proxy))).collectFees();
+        proxy.upgradeTo(impl);
+        vm.stopPrank();
+    }
+}

--- a/script/deploy/mainnet/029_UpgradeEthenaARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/029_UpgradeEthenaARMSwapFeeScript.s.sol
@@ -28,7 +28,13 @@ contract $029_UpgradeEthenaARMSwapFeeScript is AbstractDeployScript("029_Upgrade
 
         address ethenaARMProxy = resolver.resolve("ETHENA_ARM");
         govProposal.action(ethenaARMProxy, "collectFees()", "");
-        govProposal.action(ethenaARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("ETHENA_ARM_IMPL")));
+        govProposal.action(
+            ethenaARMProxy,
+            "upgradeToAndCall(address,bytes)",
+            abi.encode(
+                resolver.resolve("ETHENA_ARM_IMPL"), abi.encodeWithSelector(EthenaARM.migrateFeesAccrued.selector)
+            )
+        );
     }
 
     function _fork() internal override {
@@ -40,7 +46,7 @@ contract $029_UpgradeEthenaARMSwapFeeScript is AbstractDeployScript("029_Upgrade
         vm.startPrank(proxy.owner());
         // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
         EthenaARM(payable(address(proxy))).collectFees();
-        proxy.upgradeTo(impl);
+        proxy.upgradeToAndCall(impl, abi.encodeWithSelector(EthenaARM.migrateFeesAccrued.selector));
         vm.stopPrank();
     }
 }

--- a/script/deploy/mainnet/029_UpgradeEthenaARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/029_UpgradeEthenaARMSwapFeeScript.s.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contract
+import {Proxy} from "contracts/Proxy.sol";
+import {EthenaARM} from "contracts/EthenaARM.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";
+
+contract $029_UpgradeEthenaARMSwapFeeScript is AbstractDeployScript("029_UpgradeEthenaARMSwapFeeScript") {
+    using GovHelper for GovProposal;
+
+    bool public constant override skip = true;
+
+    function _execute() internal override {
+        uint256 claimDelay = 10 minutes;
+        uint256 minSharesToRedeem = 1e18;
+        int256 allocateThreshold = 100e18;
+        EthenaARM armImpl = new EthenaARM(Mainnet.USDE, Mainnet.SUSDE, claimDelay, minSharesToRedeem, allocateThreshold);
+        _recordDeployment("ETHENA_ARM_IMPL", address(armImpl));
+    }
+
+    function _buildGovernanceProposal() internal override {
+        govProposal.setDescription("Collect legacy Ethena ARM fees and upgrade to swap-only fee accrual");
+
+        address ethenaARMProxy = resolver.resolve("ETHENA_ARM");
+        govProposal.action(ethenaARMProxy, "collectFees()", "");
+        govProposal.action(ethenaARMProxy, "upgradeTo(address)", abi.encode(resolver.resolve("ETHENA_ARM_IMPL")));
+    }
+
+    function _fork() internal override {
+        Proxy proxy = Proxy(payable(resolver.resolve("ETHENA_ARM")));
+        address impl = resolver.resolve("ETHENA_ARM_IMPL");
+
+        if (proxy.implementation() == impl) return;
+
+        vm.startPrank(proxy.owner());
+        // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
+        EthenaARM(payable(address(proxy))).collectFees();
+        proxy.upgradeTo(impl);
+        vm.stopPrank();
+    }
+}

--- a/script/deploy/sonic/006_UpgradeOriginARMSwapFeeScript.s.sol
+++ b/script/deploy/sonic/006_UpgradeOriginARMSwapFeeScript.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contract
+import {Proxy} from "contracts/Proxy.sol";
+import {OriginARM} from "contracts/OriginARM.sol";
+import {Sonic} from "contracts/utils/Addresses.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+
+contract $006_UpgradeOriginARMSwapFeeScript is AbstractDeployScript("006_UpgradeOriginARMSwapFeeScript") {
+    bool public constant override skip = true;
+
+    function _execute() internal override {
+        uint256 claimDelay = 10 minutes;
+        uint256 minSharesToRedeem = 1e7;
+        int256 allocateThreshold = 1e18;
+        OriginARM originARMImpl =
+            new OriginARM(Sonic.OS, Sonic.WS, Sonic.OS_VAULT, claimDelay, minSharesToRedeem, allocateThreshold);
+        _recordDeployment("ORIGIN_ARM_IMPL", address(originARMImpl));
+    }
+
+    function _fork() internal override {
+        Proxy proxy = Proxy(payable(resolver.resolve("ORIGIN_ARM")));
+        address impl = resolver.resolve("ORIGIN_ARM_IMPL");
+
+        if (proxy.implementation() == impl) return;
+
+        vm.startPrank(proxy.owner());
+        // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
+        OriginARM(payable(address(proxy))).collectFees();
+        proxy.upgradeTo(impl);
+        vm.stopPrank();
+    }
+}

--- a/script/deploy/sonic/006_UpgradeOriginARMSwapFeeScript.s.sol
+++ b/script/deploy/sonic/006_UpgradeOriginARMSwapFeeScript.s.sol
@@ -30,7 +30,7 @@ contract $006_UpgradeOriginARMSwapFeeScript is AbstractDeployScript("006_Upgrade
         vm.startPrank(proxy.owner());
         // Legacy fees must be collected before the proxy switches to the new swap-only fee logic.
         OriginARM(payable(address(proxy))).collectFees();
-        proxy.upgradeTo(impl);
+        proxy.upgradeToAndCall(impl, abi.encodeWithSelector(OriginARM.migrateFeesAccrued.selector));
         vm.stopPrank();
     }
 }

--- a/src/abis/EthenaARM.json
+++ b/src/abis/EthenaARM.json
@@ -1089,19 +1089,6 @@
   },
   {
     "inputs": [],
-    "name": "lastAvailableAssets",
-    "outputs": [
-      {
-        "internalType": "int128",
-        "name": "",
-        "type": "int128"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "lastRequestTimestamp",
     "outputs": [
       {

--- a/src/abis/EtherFiARM.json
+++ b/src/abis/EtherFiARM.json
@@ -1132,19 +1132,6 @@
   },
   {
     "inputs": [],
-    "name": "lastAvailableAssets",
-    "outputs": [
-      {
-        "internalType": "int128",
-        "name": "",
-        "type": "int128"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "liquidityAsset",
     "outputs": [
       {

--- a/src/abis/LidoARM.json
+++ b/src/abis/LidoARM.json
@@ -780,13 +780,6 @@
   },
   {
     "inputs": [],
-    "name": "lastAvailableAssets",
-    "outputs": [{ "internalType": "int128", "name": "", "type": "int128" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "lidoWithdrawalQueue",
     "outputs": [
       {

--- a/src/abis/OethARM.json
+++ b/src/abis/OethARM.json
@@ -1068,19 +1068,6 @@
   },
   {
     "inputs": [],
-    "name": "lastAvailableAssets",
-    "outputs": [
-      {
-        "internalType": "int128",
-        "name": "",
-        "type": "int128"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "liquidityAsset",
     "outputs": [
       {

--- a/src/abis/OriginARM.json
+++ b/src/abis/OriginARM.json
@@ -1068,19 +1068,6 @@
   },
   {
     "inputs": [],
-    "name": "lastAvailableAssets",
-    "outputs": [
-      {
-        "internalType": "int128",
-        "name": "",
-        "type": "int128"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "liquidityAsset",
     "outputs": [
       {

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -108,14 +108,18 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Mapping of withdrawal request indices to the user withdrawal request data.
     mapping(uint256 requestId => WithdrawalRequest) public withdrawalRequests;
 
+    struct FeeData {
+        uint16 fee;
+        uint128 feesAccrued;
+    }
+
     /// @notice Fee charged on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
     /// 10,000 = 100% fee.
     /// 2,000 = 20% fee.
     /// 500 = 5% fee.
-    uint16 public fee;
+    FeeData internal feeData;
     /// @notice Accrued swap fees denominated in the liquidity asset.
     /// Stored with a 1 wei sentinel so fee-bearing swaps avoid a 0 -> nonzero storage write after collection.
-    uint128 public feesAccrued;
     /// @notice The account or contract that can collect the accrued swap fee.
     address public feeCollector;
     /// @notice The address of the CapManager contract used to manage the ARM's liquidity provider and total assets caps.
@@ -218,7 +222,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         _setFeeCollector(_feeCollector);
 
         // Initialize the fee balance sentinel so later fee accruals avoid a 0 -> nonzero storage write.
-        feesAccrued = 1;
+        feeData.feesAccrued = 1;
 
         capManager = _capManager;
         emit CapManagerUpdated(_capManager);
@@ -456,7 +460,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
      * @param amountOut The amount of liquidity asset paid out by the ARM.
      */
     function _accrueSwapFee(IERC20 inToken, IERC20 outToken, uint256 amountIn, uint256 amountOut) internal {
-        if (address(inToken) != baseAsset || address(outToken) != liquidityAsset || fee == 0) return;
+        FeeData memory feeDataMem = feeData;
+        if (address(inToken) != baseAsset || address(outToken) != liquidityAsset || feeDataMem.fee == 0) return;
 
         uint256 convertedAmountIn = _convert(address(inToken), amountIn);
         if (convertedAmountIn <= amountOut) return;
@@ -464,7 +469,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // Discount amount = converted base value - liquid amount out.
         // For example, if the ARM buys stETH for 0.9998 WETH, then the discount is 0.0002 WETH.
         // Accrued fee = discount amount * fee percentage.
-        feesAccrued += uint128((convertedAmountIn - amountOut) * fee / FEE_SCALE);
+        feeData.feesAccrued =
+            feeDataMem.feesAccrued + uint128((convertedAmountIn - amountOut) * feeDataMem.fee / FEE_SCALE);
     }
 
     /// @notice Get the available liquidity for a each token in the ARM.
@@ -743,10 +749,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // While waiting to claim their request, the ARM suffer a loss of assets. eg lending market loss.
         // When they claim their request, the newAvailableAssets will be zero as
         // the ARM assets will be less than the outstanding withdrawal request that was calculated before the loss.
-        if (feesAccrued + MIN_TOTAL_SUPPLY >= newAvailableAssets) return MIN_TOTAL_SUPPLY;
+        if (feeData.feesAccrued + MIN_TOTAL_SUPPLY >= newAvailableAssets) return MIN_TOTAL_SUPPLY;
 
         // Remove accrued swap fees from the available assets.
-        return newAvailableAssets - feesAccrued;
+        return newAvailableAssets - feeData.feesAccrued;
     }
 
     /// @notice The liquidity asset used for deposits and redeems. eg WETH or wS
@@ -841,7 +847,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // Collect any accrued swap fees up to this point using the old fee.
         collectFees();
 
-        fee = SafeCast.toUint16(_fee);
+        feeData.fee = SafeCast.toUint16(_fee);
 
         emit FeeUpdated(_fee);
     }
@@ -861,7 +867,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// avoids paying a more expensive 0 -> nonzero storage write.
     /// @return fees The amount of accrued swap fees collected
     function collectFees() public returns (uint256 fees) {
-        fees = feesAccrued;
+        fees = feeData.feesAccrued;
         if (fees == 0) return 0;
 
         // Check there is enough liquidity assets (WETH) that are not reserved for the withdrawal queue
@@ -873,7 +879,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // a failed WETH transfer so we spend the extra gas to check and give a meaningful error message.
         require(fees <= IERC20(liquidityAsset).balanceOf(address(this)), "ARM: insufficient liquidity");
 
-        feesAccrued = 1;
+        feeData.feesAccrued = 1;
         IERC20(liquidityAsset).transfer(feeCollector, fees);
 
         emit FeeCollected(feeCollector, fees);
@@ -883,7 +889,15 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// This must be called exactly once during proxy upgrade via `upgradeToAndCall(...)`
     /// after any legacy fees have been collected under the previous implementation.
     function _migrateFeesAccrued() internal {
-        feesAccrued = 1;
+        feeData.feesAccrued = 1;
+    }
+
+    function fee() external view returns (uint16) {
+        return feeData.fee;
+    }
+
+    function feesAccrued() external view returns (uint128) {
+        return feeData.feesAccrued;
     }
 
     ////////////////////////////////////////////////////

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -114,7 +114,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// 500 = 5% fee.
     uint16 public fee;
     /// @notice Accrued swap fees denominated in the liquidity asset.
-    /// Stored in the legacy lastAvailableAssets slot and must be zeroed via the migration initializer on upgrade.
+    /// Stored with a 1 wei sentinel so fee-bearing swaps avoid a 0 -> nonzero storage write after collection.
     uint128 public feesAccrued;
     /// @notice The account or contract that can collect the accrued swap fee.
     address public feeCollector;
@@ -216,6 +216,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
         _setFee(_fee);
         _setFeeCollector(_feeCollector);
+
+        // Initialize the fee balance sentinel so later fee accruals avoid a 0 -> nonzero storage write.
+        feesAccrued = 1;
 
         capManager = _capManager;
         emit CapManagerUpdated(_capManager);
@@ -854,6 +857,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Transfer accrued swap fees to the fee collector
     /// This requires enough liquidity assets in the ARM that are not reserved
     /// for the withdrawal queue to cover the accrued fees.
+    /// @dev Resets `feesAccrued` to 1 wei instead of 0 so the next fee-bearing swap
+    /// avoids paying a more expensive 0 -> nonzero storage write.
     /// @return fees The amount of accrued swap fees collected
     function collectFees() public returns (uint256 fees) {
         fees = feesAccrued;
@@ -868,7 +873,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // a failed WETH transfer so we spend the extra gas to check and give a meaningful error message.
         require(fees <= IERC20(liquidityAsset).balanceOf(address(this)), "ARM: insufficient liquidity");
 
-        feesAccrued = 0;
+        feesAccrued = 1;
         IERC20(liquidityAsset).transfer(feeCollector, fees);
 
         emit FeeCollected(feeCollector, fees);
@@ -878,7 +883,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// This must be called exactly once during proxy upgrade via `upgradeToAndCall(...)`
     /// after any legacy fees have been collected under the previous implementation.
     function _migrateFeesAccrued() internal {
-        feesAccrued = 0;
+        feesAccrued = 1;
     }
 
     ////////////////////////////////////////////////////

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -113,13 +113,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// 2,000 = 20% fee.
     /// 500 = 5% fee.
     uint16 public fee;
-    /// @notice Deprecated legacy state retained for storage compatibility.
-    /// This value is no longer used for fee accrual logic.
-    int128 private deprecated_lastAvailableAssets;
+    /// @notice Accrued swap fees denominated in the liquidity asset.
+    /// Stored in the legacy lastAvailableAssets slot and must be zeroed via the migration initializer on upgrade.
+    uint128 public feesAccrued;
     /// @notice The account or contract that can collect the accrued swap fee.
     address public feeCollector;
-    /// @notice Accrued swap fees denominated in the liquidity asset.
-    uint256 public feesAccrued;
     /// @notice The address of the CapManager contract used to manage the ARM's liquidity provider and total assets caps.
     address public capManager;
 
@@ -130,7 +128,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Percentage of available liquid assets to keep in the ARM. 100% = 1e18.
     uint256 public armBuffer;
 
-    uint256[37] private _gap;
+    uint256[38] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Events
@@ -463,7 +461,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // Discount amount = converted base value - liquid amount out.
         // For example, if the ARM buys stETH for 0.9998 WETH, then the discount is 0.0002 WETH.
         // Accrued fee = discount amount * fee percentage.
-        feesAccrued += (convertedAmountIn - amountOut) * fee / FEE_SCALE;
+        feesAccrued += uint128((convertedAmountIn - amountOut) * fee / FEE_SCALE);
     }
 
     /// @notice Get the available liquidity for a each token in the ARM.
@@ -874,6 +872,13 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         IERC20(liquidityAsset).transfer(feeCollector, fees);
 
         emit FeeCollected(feeCollector, fees);
+    }
+
+    /// @dev Clears the reused legacy storage region that now backs `feesAccrued`.
+    /// This must be called exactly once during proxy upgrade via `upgradeToAndCall(...)`
+    /// after any legacy fees have been collected under the previous implementation.
+    function _migrateFeesAccrued() internal {
+        feesAccrued = 0;
     }
 
     ////////////////////////////////////////////////////

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -26,8 +26,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     uint256 internal constant MIN_TOTAL_SUPPLY = 1e12;
     /// @notice The address with no known private key that the initial shares are minted to
     address internal constant DEAD_ACCOUNT = 0x000000000000000000000000000000000000dEaD;
-    /// @notice The scale of the performance fee
-    /// 10,000 = 100% performance fee
+    /// @notice The scale of the swap fee.
+    /// 10,000 = 100% fee.
     uint256 public constant FEE_SCALE = 10000;
 
     ////////////////////////////////////////////////////
@@ -108,17 +108,18 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Mapping of withdrawal request indices to the user withdrawal request data.
     mapping(uint256 requestId => WithdrawalRequest) public withdrawalRequests;
 
-    /// @notice Performance fee that is collected by the feeCollector measured in basis points (1/100th of a percent).
-    /// 10,000 = 100% performance fee
-    /// 2,000 = 20% performance fee
-    /// 500 = 5% performance fee
+    /// @notice Fee charged on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
+    /// 10,000 = 100% fee.
+    /// 2,000 = 20% fee.
+    /// 500 = 5% fee.
     uint16 public fee;
-    /// @notice The available assets the last time the performance fees were collected and adjusted
-    /// for liquidity assets (WETH) deposited and redeemed.
-    /// This can be negative if there were asset gains and then all the liquidity providers redeemed.
-    int128 public lastAvailableAssets;
-    /// @notice The account or contract that can collect the performance fee.
+    /// @notice Deprecated legacy state retained for storage compatibility.
+    /// This value is no longer used for fee accrual logic.
+    int128 private deprecated_lastAvailableAssets;
+    /// @notice The account or contract that can collect the accrued swap fee.
     address public feeCollector;
+    /// @notice Accrued swap fees denominated in the liquidity asset.
+    uint256 public feesAccrued;
     /// @notice The address of the CapManager contract used to manage the ARM's liquidity provider and total assets caps.
     address public capManager;
 
@@ -129,7 +130,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Percentage of available liquid assets to keep in the ARM. 100% = 1e18.
     uint256 public armBuffer;
 
-    uint256[38] private _gap;
+    uint256[37] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Events
@@ -185,10 +186,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param _operator The address of the account that can request and claim Lido withdrawals.
     /// @param _name The name of the liquidity provider (LP) token.
     /// @param _symbol The symbol of the liquidity provider (LP) token.
-    /// @param _fee The performance fee that is collected by the feeCollector measured in basis points (1/100th of a percent).
-    /// 10,000 = 100% performance fee
-    /// 500 = 5% performance fee
-    /// @param _feeCollector The account that can collect the performance fee
+    /// @param _fee The fee charged on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
+    /// 10,000 = 100% fee
+    /// 500 = 5% fee
+    /// @param _feeCollector The account that can collect the accrued swap fee
     /// @param _capManager The address of the CapManager contract
     function _initARM(
         address _operator,
@@ -215,10 +216,6 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         traderate1 = PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION;
         emit TraderateChanged(traderate0, traderate1);
 
-        // Initialize the last available assets to the current available assets
-        // This ensures no performance fee is accrued when the performance fee is calculated when the fee is set
-        (uint256 availableAssets,) = _availableAssets();
-        lastAvailableAssets = SafeCast.toInt128(SafeCast.toInt256(availableAssets));
         _setFee(_fee);
         _setFeeCollector(_feeCollector);
 
@@ -400,6 +397,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
         // Transfer the output tokens to the recipient
         _transferAsset(address(outToken), to, amountOut);
+
+        _accrueSwapFee(inToken, outToken, amountIn, amountOut);
     }
 
     function _swapTokensForExactTokens(IERC20 inToken, IERC20 outToken, uint256 amountOut, address to)
@@ -430,6 +429,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
         // Transfer the output tokens to the recipient
         _transferAsset(address(outToken), to, amountOut);
+
+        _accrueSwapFee(inToken, outToken, amountIn, amountOut);
     }
 
     /// @dev Convert between base asset and liquidity asset if needed.
@@ -441,6 +442,28 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// For example, wstETH to WETH, weETH to WETH, sUSDe to USDe or wOETH to WETH.
     function _convert(address token, uint256 amount) internal view virtual returns (uint256) {
         return amount;
+    }
+
+    /**
+     * @dev Accrues a fee only when the ARM buys the base asset with the liquidity asset at a discount.
+     * The fee is measured in liquidity-asset terms as a percentage of the discount captured on the swap:
+     * `(_convert(baseAsset, amountIn) - amountOut) * fee / FEE_SCALE`.
+     * No fee is accrued when the ARM sells the base asset or when the executed swap is at or above par.
+     * @param inToken The token sent into the ARM by the swapper.
+     * @param outToken The token sent out from the ARM to the swapper.
+     * @param amountIn The amount of base asset received by the ARM.
+     * @param amountOut The amount of liquidity asset paid out by the ARM.
+     */
+    function _accrueSwapFee(IERC20 inToken, IERC20 outToken, uint256 amountIn, uint256 amountOut) internal {
+        if (address(inToken) != baseAsset || address(outToken) != liquidityAsset || fee == 0) return;
+
+        uint256 convertedAmountIn = _convert(address(inToken), amountIn);
+        if (convertedAmountIn <= amountOut) return;
+
+        // Discount amount = converted base value - liquid amount out.
+        // For example, if the ARM buys stETH for 0.9998 WETH, then the discount is 0.0002 WETH.
+        // Accrued fee = discount amount * fee percentage.
+        feesAccrued += (convertedAmountIn - amountOut) * fee / FEE_SCALE;
     }
 
     /// @notice Get the available liquidity for a each token in the ARM.
@@ -553,12 +576,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // Do not allow deposits if the ARM can not meet all its withdrawal obligations.
         require(totalAssets() > MIN_TOTAL_SUPPLY || withdrawsQueued == withdrawsClaimed, "ARM: insolvent");
 
-        // Calculate the amount of shares to mint after the performance fees have been accrued
+        // Calculate the amount of shares to mint after accrued swap fees have been excluded
         // which reduces the available assets, and before new assets are deposited.
         shares = convertToShares(assets);
-
-        // Add the deposited assets to the last available assets
-        lastAvailableAssets += SafeCast.toInt128(SafeCast.toInt256(assets));
 
         // Transfer the liquidity asset from the sender to this contract
         IERC20(liquidityAsset).transferFrom(msg.sender, address(this), assets);
@@ -613,9 +633,6 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
         // burn redeemer's shares
         _burn(msg.sender, shares);
-
-        // Remove the redeemed assets from the last available assets
-        lastAvailableAssets -= SafeCast.toInt128(SafeCast.toInt256(assets));
 
         emit RedeemRequested(msg.sender, requestId, assets, queued, claimTimestamp);
     }
@@ -695,7 +712,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     // That is, the amount of liquidity assets (WETH) that is available to be swapped or collected as fees.
     // If no outstanding withdrawals, no check will be done of the amount against the balance of the liquidity assets in the ARM.
     // This is a gas optimization for swaps.
-    // The ARM can swap out liquidity assets (WETH) that has been accrued from the performance fee for the fee collector.
+    // The ARM can swap out liquidity assets that are also used to collect accrued swap fees for the fee collector.
     // There is no liquidity guarantee for the fee collector. If there is not enough liquidity assets (WETH) in
     // the ARM to collect the accrued fees, then the fee collector will have to wait until there is enough liquidity assets.
     function _requireLiquidityAvailable(uint256 amount) internal view {
@@ -713,10 +730,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     }
 
     /// @notice The total amount of assets in the ARM, active lending market and external withdrawal queue,
-    /// less the liquidity assets reserved for the ARM's withdrawal queue and accrued fees.
+    /// less the liquidity assets reserved for the ARM's withdrawal queue and accrued swap fees.
     /// @return The total amount of assets in the ARM
     function totalAssets() public view virtual returns (uint256) {
-        (uint256 fees, uint256 newAvailableAssets) = _feesAccrued();
+        (uint256 newAvailableAssets,) = _availableAssets();
 
         // total assets should only go up from the initial deposit amount that is burnt
         // but in case of something unforeseen, return at least MIN_TOTAL_SUPPLY.
@@ -725,10 +742,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // While waiting to claim their request, the ARM suffer a loss of assets. eg lending market loss.
         // When they claim their request, the newAvailableAssets will be zero as
         // the ARM assets will be less than the outstanding withdrawal request that was calculated before the loss.
-        if (fees + MIN_TOTAL_SUPPLY >= newAvailableAssets) return MIN_TOTAL_SUPPLY;
+        if (feesAccrued + MIN_TOTAL_SUPPLY >= newAvailableAssets) return MIN_TOTAL_SUPPLY;
 
-        // Remove the performance fee from the available assets
-        return newAvailableAssets - fees;
+        // Remove accrued swap fees from the available assets.
+        return newAvailableAssets - feesAccrued;
     }
 
     /// @notice The liquidity asset used for deposits and redeems. eg WETH or wS
@@ -740,7 +757,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @dev Calculate the available assets which is the assets in the ARM, external withdrawal queue,
     /// and active lending market, less liquidity assets reserved for the ARM's withdrawal queue.
-    /// This does not exclude any accrued performance fees.
+    /// This does not exclude any accrued swap fees.
     function _availableAssets() internal view returns (uint256 availableAssets, uint256 outstandingWithdrawals) {
         // Convert the base assets in the ARM to the amount of liquidity assets
         uint256 baseConvertedToLiquid = _convert(baseAsset, IERC20(baseAsset).balanceOf(address(this)));
@@ -802,16 +819,16 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     ///         Performance Fee Functions
     ////////////////////////////////////////////////////
 
-    /// @notice Owner sets the performance fee on increased assets
-    /// @param _fee The performance fee measured in basis points (1/100th of a percent)
-    /// 10,000 = 100% performance fee
-    /// 500 = 5% performance fee
-    /// The max allowed performance fee is 50% (5000)
+    /// @notice Owner sets the fee on discounted base-asset buy swaps.
+    /// @param _fee The fee measured in basis points (1/100th of a percent)
+    /// 10,000 = 100% fee
+    /// 500 = 5% fee
+    /// The max allowed fee is 50% (5000)
     function setFee(uint256 _fee) external onlyOwner {
         _setFee(_fee);
     }
 
-    /// @notice Owner sets the account/contract that receives the performance fee
+    /// @notice Owner sets the account/contract that receives the accrued swap fee
     /// @param _feeCollector The address of the fee collector
     function setFeeCollector(address _feeCollector) external onlyOwner {
         _setFeeCollector(_feeCollector);
@@ -820,7 +837,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     function _setFee(uint256 _fee) internal {
         require(_fee <= FEE_SCALE / 2, "ARM: fee too high");
 
-        // Collect any performance fees up to this point using the old fee
+        // Collect any accrued swap fees up to this point using the old fee.
         collectFees();
 
         fee = SafeCast.toUint16(_fee);
@@ -836,20 +853,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         emit FeeCollectorUpdated(_feeCollector);
     }
 
-    /// @notice Transfer accrued performance fees to the fee collector
-    /// This requires enough liquidity assets (WETH) in the ARM that are not reserved
+    /// @notice Transfer accrued swap fees to the fee collector
+    /// This requires enough liquidity assets in the ARM that are not reserved
     /// for the withdrawal queue to cover the accrued fees.
-    /// @return fees The amount of performance fees collected
+    /// @return fees The amount of accrued swap fees collected
     function collectFees() public returns (uint256 fees) {
-        uint256 newAvailableAssets;
-        // Accrue any performance fees up to this point
-        (fees, newAvailableAssets) = _feesAccrued();
-
-        // Save the new available assets back to storage less the collected fees.
-        // This needs to be done before the fees == 0 check to cover the scenario where the performance fee is zero
-        // and there has been an increase in assets since the last time fees were collected.
-        lastAvailableAssets = SafeCast.toInt128(SafeCast.toInt256(newAvailableAssets) - SafeCast.toInt256(fees));
-
+        fees = feesAccrued;
         if (fees == 0) return 0;
 
         // Check there is enough liquidity assets (WETH) that are not reserved for the withdrawal queue
@@ -861,27 +870,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // a failed WETH transfer so we spend the extra gas to check and give a meaningful error message.
         require(fees <= IERC20(liquidityAsset).balanceOf(address(this)), "ARM: insufficient liquidity");
 
+        feesAccrued = 0;
         IERC20(liquidityAsset).transfer(feeCollector, fees);
 
         emit FeeCollected(feeCollector, fees);
-    }
-
-    /// @notice Calculates the performance fees accrued since the last time fees were collected
-    /// @param fees The amount of performance fees accrued
-    function feesAccrued() external view returns (uint256 fees) {
-        (fees,) = _feesAccrued();
-    }
-
-    function _feesAccrued() internal view returns (uint256 fees, uint256 newAvailableAssets) {
-        (newAvailableAssets,) = _availableAssets();
-
-        // Calculate the increase in assets since the last time fees were calculated
-        int256 assetIncrease = SafeCast.toInt256(newAvailableAssets) - lastAvailableAssets;
-
-        // Do not accrued a performance fee if the available assets has decreased
-        if (assetIncrease <= 0) return (0, newAvailableAssets);
-
-        fees = SafeCast.toUint256(assetIncrease) * fee / FEE_SCALE;
     }
 
     ////////////////////////////////////////////////////

--- a/src/contracts/EthenaARM.sol
+++ b/src/contracts/EthenaARM.sol
@@ -73,6 +73,12 @@ contract EthenaARM is Initializable, AbstractARM {
         _initARM(_operator, _name, _symbol, _fee, _feeCollector, _capManager);
     }
 
+    /// @notice Clears the legacy storage region reused for packed swap fee accrual.
+    /// This should be called via `upgradeToAndCall(...)` after legacy fees are collected.
+    function migrateFeesAccrued() external reinitializer(2) onlyOwner {
+        _migrateFeesAccrued();
+    }
+
     /// @notice Request a cooldown of USDe from Ethena's Staked USDe (sUSDe) contract.
     /// @dev Uses a round robin to select the next unstaker helper contract.
     /// @param baseAmount The amount of staked USDe (sUSDe) to withdraw.

--- a/src/contracts/EthenaARM.sol
+++ b/src/contracts/EthenaARM.sol
@@ -57,10 +57,10 @@ contract EthenaARM is Initializable, AbstractARM {
     /// @param _name The name of the liquidity provider (LP) token.
     /// @param _symbol The symbol of the liquidity provider (LP) token.
     /// @param _operator The address of the account that can request and claim withdrawals.
-    /// @param _fee The performance fee that is collected by the feeCollector measured in basis points (1/100th of a percent).
-    /// 10,000 = 100% performance fee
-    /// 1,500 = 15% performance fee
-    /// @param _feeCollector The account that can collect the performance fee
+    /// @param _fee The fee accrued on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
+    /// 10,000 = 100% fee
+    /// 1,500 = 15% fee
+    /// @param _feeCollector The account that can collect the accrued swap fee
     /// @param _capManager The address of the CapManager contract
     function initialize(
         string calldata _name,

--- a/src/contracts/EtherFiARM.sol
+++ b/src/contracts/EtherFiARM.sol
@@ -12,7 +12,7 @@ import {IERC20, IWETH, IEETHWithdrawal, IEETHWithdrawalNFT, IEETHRedemptionManag
  * @dev This implementation supports multiple Liquidity Providers (LPs) with single buy and sell prices.
  * It also integrates to a CapManager contract that caps the amount of assets a liquidity provider
  * can deposit and caps the ARM's total assets.
- * A performance fee is also collected on increases in the ARM's total assets.
+ * A fee is accrued on discounted base-asset buy swaps.
  * @author Origin Protocol Inc
  */
 contract EtherFiARM is Initializable, AbstractARM, IERC721Receiver {
@@ -63,10 +63,10 @@ contract EtherFiARM is Initializable, AbstractARM, IERC721Receiver {
     /// @param _name The name of the liquidity provider (LP) token.
     /// @param _symbol The symbol of the liquidity provider (LP) token.
     /// @param _operator The address of the account that can request and claim EtherFi withdrawals.
-    /// @param _fee The performance fee that is collected by the feeCollector measured in basis points (1/100th of a percent).
-    /// 10,000 = 100% performance fee
-    /// 1,500 = 15% performance fee
-    /// @param _feeCollector The account that can collect the performance fee
+    /// @param _fee The fee accrued on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
+    /// 10,000 = 100% fee
+    /// 1,500 = 15% fee
+    /// @param _feeCollector The account that can collect the accrued swap fee
     /// @param _capManager The address of the CapManager contract
     function initialize(
         string calldata _name,

--- a/src/contracts/EtherFiARM.sol
+++ b/src/contracts/EtherFiARM.sol
@@ -82,6 +82,12 @@ contract EtherFiARM is Initializable, AbstractARM, IERC721Receiver {
         eeth.approve(address(etherfiWithdrawalQueue), type(uint256).max);
     }
 
+    /// @notice Clears the legacy storage region reused for packed swap fee accrual.
+    /// This should be called via `upgradeToAndCall(...)` after legacy fees are collected.
+    function migrateFeesAccrued() external reinitializer(2) onlyOwner {
+        _migrateFeesAccrued();
+    }
+
     /**
      * @notice Request an eETH for ETH withdrawal.
      * Reference: https://etherfi.gitbook.io/etherfi/contracts-and-integrations/how-to

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -12,7 +12,7 @@ import {IERC20, IStETHWithdrawal, IWETH} from "./Interfaces.sol";
  * @dev This implementation supports multiple Liquidity Providers (LPs) with single buy and sell prices.
  * It also integrates to a CapManager contract that caps the amount of assets a liquidity provider
  * can deposit and caps the ARM's total assets.
- * A performance fee is also collected on increases in the ARM's total assets.
+ * A fee is accrued on discounted base-asset buy swaps.
  * @author Origin Protocol Inc
  */
 contract LidoARM is Initializable, AbstractARM {
@@ -60,10 +60,10 @@ contract LidoARM is Initializable, AbstractARM {
     /// @param _name The name of the liquidity provider (LP) token.
     /// @param _symbol The symbol of the liquidity provider (LP) token.
     /// @param _operator The address of the account that can request and claim Lido withdrawals.
-    /// @param _fee The performance fee that is collected by the feeCollector measured in basis points (1/100th of a percent).
-    /// 10,000 = 100% performance fee
-    /// 1,500 = 15% performance fee
-    /// @param _feeCollector The account that can collect the performance fee
+    /// @param _fee The fee accrued on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
+    /// 10,000 = 100% fee
+    /// 1,500 = 15% fee
+    /// @param _feeCollector The account that can collect the accrued swap fee
     /// @param _capManager The address of the CapManager contract
     function initialize(
         string calldata _name,

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -79,6 +79,12 @@ contract LidoARM is Initializable, AbstractARM {
         steth.approve(address(lidoWithdrawalQueue), type(uint256).max);
     }
 
+    /// @notice Clears the legacy storage region reused for packed swap fee accrual.
+    /// This should be called via `upgradeToAndCall(...)` after legacy fees are collected.
+    function migrateFeesAccrued() external reinitializer(3) onlyOwner {
+        _migrateFeesAccrued();
+    }
+
     /**
      * @notice Register the Lido withdrawal requests to the ARM contract.
      * This can only be called once by the contract Owner.

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -11,7 +11,7 @@ import {IOriginVault} from "./Interfaces.sol";
  * @dev This implementation supports multiple Liquidity Providers (LPs) with single buy and sell prices.
  * It also integrates to a CapManager contract that caps the amount of assets a liquidity provider
  * can deposit and caps the ARM's total assets.
- * A performance fee is also collected on increases in the ARM's total assets.
+ * A fee is accrued on discounted base-asset buy swaps.
  * @author Origin Protocol Inc
  */
 contract OriginARM is Initializable, AbstractARM {
@@ -49,10 +49,10 @@ contract OriginARM is Initializable, AbstractARM {
     /// @param _name The name of the liquidity provider (LP) token.
     /// @param _symbol The symbol of the liquidity provider (LP) token.
     /// @param _operator The address of the account that can request and claim Lido withdrawals.
-    /// @param _fee The performance fee that is collected by the feeCollector measured in basis points (1/100th of a percent).
-    /// 10,000 = 100% performance fee
-    /// 1,500 = 15% performance fee
-    /// @param _feeCollector The account that can collect the performance fee
+    /// @param _fee The fee accrued on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
+    /// 10,000 = 100% fee
+    /// 1,500 = 15% fee
+    /// @param _feeCollector The account that can collect the accrued swap fee
     /// @param _capManager The address of the CapManager contract
     function initialize(
         string calldata _name,

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -65,6 +65,12 @@ contract OriginARM is Initializable, AbstractARM {
         _initARM(_operator, _name, _symbol, _fee, _feeCollector, _capManager);
     }
 
+    /// @notice Clears the legacy storage region reused for packed swap fee accrual.
+    /// This should be called via `upgradeToAndCall(...)` after legacy fees are collected.
+    function migrateFeesAccrued() external reinitializer(2) onlyOwner {
+        _migrateFeesAccrued();
+    }
+
     /**
      * @notice Request a withdrawal of oTokens from the Origin Vault.
      * @param amount The amount of oTokens to withdraw from the Origin Vault.

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -29,7 +29,7 @@ import {IOriginVault} from "contracts/Interfaces.sol";
 /// @dev This contract should only be used as storage for common variables.
 /// @dev Helpers and other functions should be defined in a separate contract.
 abstract contract Base_Test_ is Test {
-    uint256 internal constant _DEPRECATED_LAST_AVAILABLE_ASSETS_SLOT = 56;
+    uint256 internal constant _FEE_STORAGE_SLOT = 56;
 
     //////////////////////////////////////////////////////
     /// --- CONTRACTS
@@ -151,10 +151,7 @@ abstract contract Base_Test_ is Test {
         if (_address != address(0)) vm.label(_address, _name);
     }
 
-    function deprecatedLastAvailableAssets(address arm) internal view returns (int128 value) {
-        bytes32 slotValue = vm.load(arm, bytes32(_DEPRECATED_LAST_AVAILABLE_ASSETS_SLOT));
-        assembly {
-            value := signextend(15, shr(16, slotValue))
-        }
+    function feeStorageSlot(address arm) internal view returns (bytes32 value) {
+        value = vm.load(arm, bytes32(_FEE_STORAGE_SLOT));
     }
 }

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -29,6 +29,8 @@ import {IOriginVault} from "contracts/Interfaces.sol";
 /// @dev This contract should only be used as storage for common variables.
 /// @dev Helpers and other functions should be defined in a separate contract.
 abstract contract Base_Test_ is Test {
+    uint256 internal constant _DEPRECATED_LAST_AVAILABLE_ASSETS_SLOT = 56;
+
     //////////////////////////////////////////////////////
     /// --- CONTRACTS
     //////////////////////////////////////////////////////
@@ -147,5 +149,12 @@ abstract contract Base_Test_ is Test {
 
     function _labelNotNull(address _address, string memory _name) internal {
         if (_address != address(0)) vm.label(_address, _name);
+    }
+
+    function deprecatedLastAvailableAssets(address arm) internal view returns (int128 value) {
+        bytes32 slotValue = vm.load(arm, bytes32(_DEPRECATED_LAST_AVAILABLE_ASSETS_SLOT));
+        assembly {
+            value := signextend(15, shr(16, slotValue))
+        }
     }
 }

--- a/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
@@ -89,8 +89,8 @@ contract Fork_Concrete_EthenaARM_swapExactTokensForTokens_Test_ is Fork_Shared_T
         // Precompute expected amount out
         uint256 traderate = ethenaARM.traderate1();
         uint256 expectedAmountOut = (susde.convertToAssets(AMOUNT_IN) * traderate) / 1e36;
-        uint256 expectedFee = (susde.convertToAssets(AMOUNT_IN) - expectedAmountOut) * ethenaARM.fee()
-            / ethenaARM.FEE_SCALE();
+        uint256 expectedFee =
+            (susde.convertToAssets(AMOUNT_IN) - expectedAmountOut) * ethenaARM.fee() / ethenaARM.FEE_SCALE();
 
         // Expected events
         vm.expectEmit({emitter: address(susde)});

--- a/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
@@ -84,10 +84,13 @@ contract Fork_Concrete_EthenaARM_swapExactTokensForTokens_Test_ is Fork_Shared_T
         // Record balances before swap
         uint256 usdeBalanceBefore = usde.balanceOf(address(this));
         uint256 susdeBalanceBefore = susde.balanceOf(address(this));
+        uint256 feesAccruedBefore = ethenaARM.feesAccrued();
 
         // Precompute expected amount out
         uint256 traderate = ethenaARM.traderate1();
         uint256 expectedAmountOut = (susde.convertToAssets(AMOUNT_IN) * traderate) / 1e36;
+        uint256 expectedFee = (susde.convertToAssets(AMOUNT_IN) - expectedAmountOut) * ethenaARM.fee()
+            / ethenaARM.FEE_SCALE();
 
         // Expected events
         vm.expectEmit({emitter: address(susde)});
@@ -108,6 +111,9 @@ contract Fork_Concrete_EthenaARM_swapExactTokensForTokens_Test_ is Fork_Shared_T
         assertEq(obtained[1], expectedAmountOut, "Obtained USDe amount should match expected output");
         assertEq(usdeBalanceAfter, usdeBalanceBefore + expectedAmountOut, "USDe balance should have increased");
         assertEq(susdeBalanceBefore, susdeBalanceAfter + AMOUNT_IN, "SUSDe balance should have decreased");
+        assertEq(
+            ethenaARM.feesAccrued() - feesAccruedBefore, expectedFee, "Fees accrued should match converted discount"
+        );
     }
 
     function test_swapExactTokensForTokens_SUSDE_To_USDE_WithOutstandingWithdrawals_Sig1() public {

--- a/test/fork/LidoARM/ClaimRedeem.t.sol
+++ b/test/fork/LidoARM/ClaimRedeem.t.sol
@@ -124,7 +124,6 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -146,7 +145,6 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -191,7 +189,6 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), 0);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -215,7 +212,6 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT / 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -243,7 +239,6 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);

--- a/test/fork/LidoARM/ClaimRedeem.t.sol
+++ b/test/fork/LidoARM/ClaimRedeem.t.sol
@@ -124,7 +124,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -146,7 +146,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -191,7 +191,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), 0);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -215,7 +215,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT / 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -243,7 +243,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);

--- a/test/fork/LidoARM/CollectFees.t.sol
+++ b/test/fork/LidoARM/CollectFees.t.sol
@@ -49,19 +49,20 @@ contract Fork_Concrete_LidoARM_CollectFees_Test_ is Fork_Shared_Test_ {
     function test_CollectFees_Once() public {
         address feeCollector = lidoARM.feeCollector();
         (, uint256 fee) = _swapBaseForLiquidity(200 ether, 100 ether);
+        uint256 expectedCollectedFee = fee + 1;
 
         // Expected Events
         vm.expectEmit({emitter: address(weth)});
-        emit IERC20.Transfer(address(lidoARM), feeCollector, fee);
+        emit IERC20.Transfer(address(lidoARM), feeCollector, expectedCollectedFee);
         vm.expectEmit({emitter: address(lidoARM)});
-        emit AbstractARM.FeeCollected(feeCollector, fee);
+        emit AbstractARM.FeeCollected(feeCollector, expectedCollectedFee);
 
         // Main call
         uint256 claimedFee = lidoARM.collectFees();
 
         // Assertions after
-        assertEq(claimedFee, fee);
-        assertEq(lidoARM.feesAccrued(), 0);
+        assertEq(claimedFee, expectedCollectedFee);
+        assertEq(lidoARM.feesAccrued(), 1);
     }
 
     function test_CollectFees_Twice() public {
@@ -73,6 +74,6 @@ contract Fork_Concrete_LidoARM_CollectFees_Test_ is Fork_Shared_Test_ {
         uint256 claimedFee = lidoARM.collectFees();
 
         // Assertions after
-        assertEq(claimedFee, expectedFee);
+        assertEq(claimedFee, expectedFee + 1);
     }
 }

--- a/test/fork/LidoARM/CollectFees.t.sol
+++ b/test/fork/LidoARM/CollectFees.t.sol
@@ -9,6 +9,8 @@ import {IERC20} from "contracts/Interfaces.sol";
 import {AbstractARM} from "contracts/AbstractARM.sol";
 
 contract Fork_Concrete_LidoARM_CollectFees_Test_ is Fork_Shared_Test_ {
+    uint256 internal constant DISCOUNTED_PRICE = 9995e32; // 0.9995
+
     //////////////////////////////////////////////////////
     /// --- SETUP
     //////////////////////////////////////////////////////
@@ -16,14 +18,27 @@ contract Fork_Concrete_LidoARM_CollectFees_Test_ is Fork_Shared_Test_ {
         super.setUp();
     }
 
+    function _swapBaseForLiquidity(uint256 wethBalance, uint256 amountIn)
+        internal
+        returns (uint256 amountOut, uint256 expectedFee)
+    {
+        lidoARM.setPrices(DISCOUNTED_PRICE, 1001e33);
+        deal(address(weth), address(lidoARM), wethBalance);
+        deal(address(steth), address(this), amountIn);
+        steth.approve(address(lidoARM), type(uint256).max);
+
+        uint256[] memory amounts = lidoARM.swapExactTokensForTokens(steth, weth, amountIn, 0, address(this));
+        amountOut = amounts[1];
+        expectedFee = (amountIn - amountOut) * lidoARM.fee() / lidoARM.FEE_SCALE();
+    }
+
     //////////////////////////////////////////////////////
     /// --- REVERTING TESTS
     //////////////////////////////////////////////////////
-    /// @notice This test is expected to revert as almost all the liquidity is in stETH
-    function test_RevertWhen_CollectFees_Because_InsufficientLiquidity()
-        public
-        simulateAssetGainInLidoARM(DEFAULT_AMOUNT, address(steth), true)
-    {
+    /// @notice This test is expected to revert as the discounted swap leaves too little WETH to collect the accrued fee.
+    function test_RevertWhen_CollectFees_Because_InsufficientLiquidity() public {
+        _swapBaseForLiquidity(99_955e15, 100 ether);
+
         vm.expectRevert("ARM: insufficient liquidity");
         lidoARM.collectFees();
     }
@@ -31,9 +46,9 @@ contract Fork_Concrete_LidoARM_CollectFees_Test_ is Fork_Shared_Test_ {
     //////////////////////////////////////////////////////
     /// --- PASSING TESTS
     //////////////////////////////////////////////////////
-    function test_CollectFees_Once() public simulateAssetGainInLidoARM(DEFAULT_AMOUNT, address(weth), true) {
+    function test_CollectFees_Once() public {
         address feeCollector = lidoARM.feeCollector();
-        uint256 fee = DEFAULT_AMOUNT * 20 / 100;
+        (, uint256 fee) = _swapBaseForLiquidity(200 ether, 100 ether);
 
         // Expected Events
         vm.expectEmit({emitter: address(weth)});
@@ -49,16 +64,15 @@ contract Fork_Concrete_LidoARM_CollectFees_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.feesAccrued(), 0);
     }
 
-    function test_CollectFees_Twice()
-        public
-        simulateAssetGainInLidoARM(DEFAULT_AMOUNT, address(weth), true)
-        collectFeesOnLidoARM
-        simulateAssetGainInLidoARM(DEFAULT_AMOUNT, address(weth), true)
-    {
+    function test_CollectFees_Twice() public {
+        _swapBaseForLiquidity(200 ether, 100 ether);
+        lidoARM.collectFees();
+        (, uint256 expectedFee) = _swapBaseForLiquidity(200 ether, 100 ether);
+
         // Main call
         uint256 claimedFee = lidoARM.collectFees();
 
         // Assertions after
-        assertEq(claimedFee, DEFAULT_AMOUNT * 20 / 100); // This test should pass!
+        assertEq(claimedFee, expectedFee);
     }
 }

--- a/test/fork/LidoARM/Constructor.t.sol
+++ b/test/fork/LidoARM/Constructor.t.sol
@@ -23,7 +23,7 @@ contract Fork_Concrete_LidoARM_Constructor_Test is Fork_Shared_Test_ {
         assertEq(lidoARM.operator(), operator);
         assertEq(lidoARM.feeCollector(), feeCollector);
         assertEq(lidoARM.fee(), 2000);
-        assertEq(lidoARM.lastAvailableAssets(), int256(1e12));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.feesAccrued(), 0);
         // the 20% performance fee is removed on initialization
         assertEq(lidoARM.totalAssets(), 1e12);

--- a/test/fork/LidoARM/Constructor.t.sol
+++ b/test/fork/LidoARM/Constructor.t.sol
@@ -23,7 +23,6 @@ contract Fork_Concrete_LidoARM_Constructor_Test is Fork_Shared_Test_ {
         assertEq(lidoARM.operator(), operator);
         assertEq(lidoARM.feeCollector(), feeCollector);
         assertEq(lidoARM.fee(), 2000);
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.feesAccrued(), 0);
         // the 20% performance fee is removed on initialization
         assertEq(lidoARM.totalAssets(), 1e12);

--- a/test/fork/LidoARM/Deposit.t.sol
+++ b/test/fork/LidoARM/Deposit.t.sol
@@ -130,7 +130,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        if (ac) assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        if (ac) assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0); // Ensure no shares before
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply before"); // Minted to dead on deploy
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, "total assets before");
@@ -155,7 +155,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + amount));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), shares);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount, "total supply after");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount, "total assets after");
@@ -179,7 +179,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + amount));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), amount);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount); // Minted to dead on deploy
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount);
@@ -204,7 +204,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + amount * 2));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), shares * 2);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount * 2);
@@ -229,7 +229,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + amount));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(alice), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount); // Minted to dead on deploy
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount);
@@ -255,7 +255,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + amount * 2));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(alice), shares);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount * 2);
@@ -276,16 +276,15 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         uint256 assetGain = DEFAULT_AMOUNT;
         deal(address(weth), address(lidoARM), balanceBefore + assetGain);
 
-        // 20% of the asset gain goes to the performance fees
-        uint256 expectedFeesAccrued = assetGain * 20 / 100;
-        uint256 expectedTotalAssetsBeforeDeposit = balanceBefore + assetGain * 80 / 100;
+        uint256 expectedFeesAccrued = 0;
+        uint256 expectedTotalAssetsBeforeDeposit = balanceBefore + assetGain;
 
         // Assertions Before
         assertEq(steth.balanceOf(address(lidoARM)), 0);
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + assetGain);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether before");
         assertEq(lidoARM.feesAccrued(), expectedFeesAccrued, "fee accrued before"); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY), "last available assets before");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "user shares before"); // Ensure no shares before
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "Total supply before"); // Minted to dead on deploy
         // 80% of the asset gain goes to the total assets
@@ -316,7 +315,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + assetGain + depositedAssets, "WETH balance after");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether after");
         assertEq(lidoARM.feesAccrued(), expectedFeesAccrued, "fees accrued after"); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + depositedAssets), "last total assets after");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), expectedShares, "user shares after");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + expectedShares, "total supply after");
         assertEq(lidoARM.totalAssets(), expectedTotalAssetsBeforeDeposit + depositedAssets, "Total assets after");
@@ -338,7 +337,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         lidoARM.setPrices(1e36 - 1, 1e36);
 
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT, "total assets before swap");
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT), "last available before swap");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // User Swap stETH for 3/4 of WETH in the ARM
         deal(address(steth), address(this), DEFAULT_AMOUNT);
@@ -349,7 +348,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
             STETH_ERROR_ROUNDING,
             "total assets after swap"
         );
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT), "last available after swap");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // First user requests a full withdrawal
         uint256 firstUserShares = lidoARM.balanceOf(address(this));
@@ -367,12 +366,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), wethBalanceBefore, "WETH ARM balance before deposit");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether before");
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued before deposit");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            int256(MIN_TOTAL_SUPPLY),
-            STETH_ERROR_ROUNDING,
-            "last available assets before"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(alice), 0, "alice shares before deposit");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply before deposit");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + 1, "total assets before deposit");
@@ -406,12 +400,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), wethBalanceBefore + amount, "WETH ARM balance after deposit");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether after deposit");
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued after deposit"); // No perfs so no fees
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            int256(MIN_TOTAL_SUPPLY + amount),
-            STETH_ERROR_ROUNDING,
-            "last available assets after deposit"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(alice), shares, "alice shares after deposit");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + expectedShares, "total supply after deposit");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount + 1, "total assets after deposit");
@@ -437,14 +426,14 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
     {
         // Assertions Before
         uint256 expectedTotalSupplyBeforeDeposit = MIN_TOTAL_SUPPLY;
-        uint256 expectTotalAssetsBeforeDeposit = MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 80 / 100;
+        uint256 expectTotalAssetsBeforeDeposit = MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT;
         assertEq(steth.balanceOf(address(lidoARM)), 0);
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), DEFAULT_AMOUNT, "stETH in Lido withdrawal queue before deposit");
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply before deposit");
         assertEq(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, "total assets before deposit");
-        assertEq(lidoARM.feesAccrued(), DEFAULT_AMOUNT * 20 / 100, "fees accrued before deposit");
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY), "last available assets before deposit");
+        assertEq(lidoARM.feesAccrued(), 0, "fees accrued before deposit");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0); // Ensure no shares before
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), DEFAULT_AMOUNT);
         assertEqQueueMetadata(0, 0, 0);
@@ -469,12 +458,8 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
 
         assertEq(shares, expectShares, "shares after deposit");
         assertEq(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT, "total assets after deposit");
-        assertEq(lidoARM.feesAccrued(), DEFAULT_AMOUNT * 20 / 100, "fees accrued after deposit");
-        assertEq(
-            lidoARM.lastAvailableAssets(),
-            int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT),
-            "last available assets after deposit"
-        );
+        assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // 4. Lido finalization process is simulated
         lidoARM.totalAssets();
@@ -499,10 +484,8 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue after redeem");
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply after redeem");
         assertApproxEqRel(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, 1e6, "total assets after redeem");
-        assertEq(lidoARM.feesAccrued(), DEFAULT_AMOUNT * 20 / 100, "fees accrued after redeem");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY), 4e6, "last available assets after redeem"
-        );
+        assertEq(lidoARM.feesAccrued(), 0, "fees accrued after redeem");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "User shares after redeem");
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0, "all user cap used");
         assertEqQueueMetadata(receivedAssets, 0, 1);
@@ -514,12 +497,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply after collect fees");
         assertApproxEqRel(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, 1e6, "total assets after collect fees");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after collect fees");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            int256(expectTotalAssetsBeforeDeposit),
-            4e6,
-            "last available assets after collect fees"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
     }
 
     /// @notice Test the following scenario:
@@ -561,7 +539,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0); // Ensure no shares after
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY); // Minted to dead on deploy
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // All the caps are used
@@ -585,22 +563,16 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
 
         // Main calls:
         // 1. User mint shares
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY), "last available assets before deposit");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         uint256 shares = lidoARM.deposit(DEFAULT_AMOUNT);
 
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
-        assertEq(
-            lidoARM.lastAvailableAssets(),
-            int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT),
-            "last available assets after deposit"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // 2. Simulate asset gain (on steth)
         deal(address(steth), address(lidoARM), DEFAULT_AMOUNT);
-        assertApproxEqAbs(
-            lidoARM.feesAccrued(), DEFAULT_AMOUNT * 20 / 100, STETH_ERROR_ROUNDING, "fees accrued before redeem"
-        );
+        assertEq(lidoARM.feesAccrued(), 0, "fees accrued before redeem");
 
         // 3. Operator request a claim on withdraw
         lidoARM.requestLidoWithdrawals(amounts1);
@@ -619,20 +591,14 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         // 5. User burn shares
         (, uint256 receivedAssets) = lidoARM.requestRedeem(shares);
 
-        uint256 userBenef = (DEFAULT_AMOUNT * 80 / 100) * DEFAULT_AMOUNT / (MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
+        uint256 userBenef = DEFAULT_AMOUNT * DEFAULT_AMOUNT / (MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         // Assertions After
         assertEq(receivedAssets, DEFAULT_AMOUNT + userBenef, "received assets");
         assertEq(steth.balanceOf(address(lidoARM)), 0);
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
-        assertApproxEqAbs(lidoARM.feesAccrued(), DEFAULT_AMOUNT * 20 / 100, 2, "fees accrued after redeem");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            // initial assets + user deposit - (user deposit + asset gain less fees)
-            int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT) - int256(DEFAULT_AMOUNT + userBenef),
-            STETH_ERROR_ROUNDING,
-            "last available assets after redeem"
-        );
+        assertEq(lidoARM.feesAccrued(), 0, "fees accrued after redeem");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "user shares after"); // Ensure no shares after
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply after"); // Minted to dead on deploy
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0, "user cap"); // All the caps are used
@@ -651,11 +617,11 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
     {
         // Assertions Before
         uint256 expectedTotalSupplyBeforeDeposit = MIN_TOTAL_SUPPLY;
-        uint256 expectTotalAssetsBeforeDeposit = MIN_TOTAL_SUPPLY + (MIN_TOTAL_SUPPLY * 80 / 100);
+        uint256 expectTotalAssetsBeforeDeposit = 2 * MIN_TOTAL_SUPPLY;
         uint256 assetsPerShareBefore = expectTotalAssetsBeforeDeposit * 1e18 / expectedTotalSupplyBeforeDeposit;
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply before deposit");
         assertEq(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, "total assets before deposit");
-        assertEq(lidoARM.feesAccrued(), MIN_TOTAL_SUPPLY * 20 / 100, "fees accrued before deposit");
+        assertEq(lidoARM.feesAccrued(), 0, "fees accrued before deposit");
 
         // shares = assets * total supply / total assets
         uint256 expectShares = DEFAULT_AMOUNT * expectedTotalSupplyBeforeDeposit / expectTotalAssetsBeforeDeposit;
@@ -673,12 +639,8 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(shares, expectShares, "shares after deposit");
         assertEq(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT, "total assets after deposit");
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit + shares, "total supply after deposit");
-        assertEq(lidoARM.feesAccrued(), MIN_TOTAL_SUPPLY * 20 / 100, "fees accrued after deposit");
-        assertEq(
-            lidoARM.lastAvailableAssets(),
-            int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT),
-            "last available assets after deposit"
-        );
+        assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.totalAssets() * 1e18 / lidoARM.totalSupply(), assetsPerShareBefore, "assets per share after deposit"
         );
@@ -696,12 +658,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
             "total assets after collect fees"
         );
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after collect fees");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            int256(expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT),
-            3,
-            "last available assets after collect fees"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.convertToAssets(shares), DEFAULT_AMOUNT - 1, "depositor has not lost value after collected fees"
         );
@@ -776,11 +733,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         );
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit + bobShares, "total supply after deposit");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
-        assertEq(
-            lidoARM.lastAvailableAssets(),
-            int256(expectTotalAssetsBeforeSwap + bobDeposit),
-            "last available assets after deposit"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.totalAssets() * 1e18 / lidoARM.totalSupply(),
             assetsPerShareBeforeSwap,
@@ -797,12 +750,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
             lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit + bobDeposit, 1e6, "total assets after collect fees"
         );
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after collect fees");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            int256(expectTotalAssetsBeforeDeposit + bobDeposit),
-            3,
-            "last available assets after collect fees"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.convertToAssets(bobShares), bobDeposit - 1, "depositor has not lost value after collected fees"
         );

--- a/test/fork/LidoARM/Deposit.t.sol
+++ b/test/fork/LidoARM/Deposit.t.sol
@@ -130,7 +130,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        if (ac) assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0); // Ensure no shares before
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply before"); // Minted to dead on deploy
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, "total assets before");
@@ -155,7 +154,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), shares);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount, "total supply after");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount, "total assets after");
@@ -179,7 +177,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), amount);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount); // Minted to dead on deploy
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount);
@@ -204,7 +201,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), shares * 2);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount * 2);
@@ -229,7 +225,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(alice), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount); // Minted to dead on deploy
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount);
@@ -255,7 +250,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(alice), shares);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + amount * 2);
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount * 2);
@@ -284,7 +278,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + assetGain);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether before");
         assertEq(lidoARM.feesAccrued(), expectedFeesAccrued, "fee accrued before"); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "user shares before"); // Ensure no shares before
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "Total supply before"); // Minted to dead on deploy
         // 80% of the asset gain goes to the total assets
@@ -315,7 +308,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + assetGain + depositedAssets, "WETH balance after");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether after");
         assertEq(lidoARM.feesAccrued(), expectedFeesAccrued, "fees accrued after"); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), expectedShares, "user shares after");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + expectedShares, "total supply after");
         assertEq(lidoARM.totalAssets(), expectedTotalAssetsBeforeDeposit + depositedAssets, "Total assets after");
@@ -337,7 +329,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         lidoARM.setPrices(1e36 - 1, 1e36);
 
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT, "total assets before swap");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // User Swap stETH for 3/4 of WETH in the ARM
         deal(address(steth), address(this), DEFAULT_AMOUNT);
@@ -348,7 +339,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
             STETH_ERROR_ROUNDING,
             "total assets after swap"
         );
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // First user requests a full withdrawal
         uint256 firstUserShares = lidoARM.balanceOf(address(this));
@@ -366,7 +356,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), wethBalanceBefore, "WETH ARM balance before deposit");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether before");
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued before deposit");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(alice), 0, "alice shares before deposit");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply before deposit");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + 1, "total assets before deposit");
@@ -400,7 +389,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), wethBalanceBefore + amount, "WETH ARM balance after deposit");
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "Outstanding ether after deposit");
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued after deposit"); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(alice), shares, "alice shares after deposit");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + expectedShares, "total supply after deposit");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount + 1, "total assets after deposit");
@@ -433,7 +421,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply before deposit");
         assertEq(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, "total assets before deposit");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued before deposit");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0); // Ensure no shares before
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), DEFAULT_AMOUNT);
         assertEqQueueMetadata(0, 0, 0);
@@ -459,7 +446,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(shares, expectShares, "shares after deposit");
         assertEq(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT, "total assets after deposit");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // 4. Lido finalization process is simulated
         lidoARM.totalAssets();
@@ -485,7 +471,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply after redeem");
         assertApproxEqRel(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, 1e6, "total assets after redeem");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after redeem");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "User shares after redeem");
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0, "all user cap used");
         assertEqQueueMetadata(receivedAssets, 0, 1);
@@ -497,7 +482,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply after collect fees");
         assertApproxEqRel(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, 1e6, "total assets after collect fees");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after collect fees");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
     }
 
     /// @notice Test the following scenario:
@@ -539,7 +523,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0); // Ensure no shares after
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY); // Minted to dead on deploy
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // All the caps are used
@@ -563,12 +546,10 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
 
         // Main calls:
         // 1. User mint shares
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         uint256 shares = lidoARM.deposit(DEFAULT_AMOUNT);
 
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
 
         // 2. Simulate asset gain (on steth)
         deal(address(steth), address(lidoARM), DEFAULT_AMOUNT);
@@ -598,7 +579,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 2);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after redeem");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "user shares after"); // Ensure no shares after
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply after"); // Minted to dead on deploy
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0, "user cap"); // All the caps are used
@@ -640,7 +620,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT, "total assets after deposit");
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit + shares, "total supply after deposit");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.totalAssets() * 1e18 / lidoARM.totalSupply(), assetsPerShareBefore, "assets per share after deposit"
         );
@@ -658,7 +637,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
             "total assets after collect fees"
         );
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after collect fees");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.convertToAssets(shares), DEFAULT_AMOUNT - 1, "depositor has not lost value after collected fees"
         );
@@ -733,7 +711,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         );
         assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit + bobShares, "total supply after deposit");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after deposit");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.totalAssets() * 1e18 / lidoARM.totalSupply(),
             assetsPerShareBeforeSwap,
@@ -750,7 +727,6 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
             lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit + bobDeposit, 1e6, "total assets after collect fees"
         );
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after collect fees");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertGe(
             lidoARM.convertToAssets(bobShares), bobDeposit - 1, "depositor has not lost value after collected fees"
         );

--- a/test/fork/LidoARM/RequestRedeem.t.sol
+++ b/test/fork/LidoARM/RequestRedeem.t.sol
@@ -37,7 +37,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -63,7 +63,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -82,7 +82,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 3 / 4));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT * 3 / 4);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 3 / 4);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // Down only
@@ -116,7 +116,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(lidoARM.lastAvailableAssets(), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 1 / 4));
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT * 1 / 4);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 1 / 4);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // Down only
@@ -145,9 +145,9 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         // Main call
         (, uint256 actualAssetsFromRedeem) = lidoARM.requestRedeem(DEFAULT_AMOUNT);
 
-        // Calculate expected values
-        uint256 expectedFeeAccrued = assetsGain * 20 / 100; // 20% fee
-        uint256 expectedTotalAsset = assetsAfterGain - expectedFeeAccrued;
+        // Calculate expected values. Passive asset gains no longer accrue fees.
+        uint256 expectedFeeAccrued = 0;
+        uint256 expectedTotalAsset = assetsAfterGain;
         uint256 expectedAssetsFromRedeem = DEFAULT_AMOUNT * expectedTotalAsset / (MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
 
         // Assertions After
@@ -156,12 +156,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), assetsAfterGain);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue");
         assertEq(lidoARM.feesAccrued(), expectedFeeAccrued, "fees accrued");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT) - int256(expectedAssetsFromRedeem),
-            1,
-            "last available assets after"
-        ); // 1 wei of error
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -208,12 +203,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - assetsLoss);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued");
-        assertApproxEqAbs(
-            lidoARM.lastAvailableAssets(),
-            int256(assetsBeforeLoss - expectedAssetsFromRedeem),
-            1,
-            "last available assets"
-        ); // 1 wei of error
+        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "user LP balance");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, "total assets");

--- a/test/fork/LidoARM/RequestRedeem.t.sol
+++ b/test/fork/LidoARM/RequestRedeem.t.sol
@@ -37,7 +37,6 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -63,7 +62,6 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -82,7 +80,6 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT * 3 / 4);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 3 / 4);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // Down only
@@ -116,7 +113,6 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT * 1 / 4);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 1 / 4);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // Down only
@@ -156,7 +152,6 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), assetsAfterGain);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue");
         assertEq(lidoARM.feesAccrued(), expectedFeeAccrued, "fees accrued");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
@@ -203,7 +198,6 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - assetsLoss);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued");
-        assertEq(deprecatedLastAvailableAssets(address(lidoARM)), int256(0), "deprecated field should stay zero");
         assertEq(lidoARM.balanceOf(address(this)), 0, "user LP balance");
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply");
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, "total assets");

--- a/test/fork/LidoARM/SwapGasImpact.t.sol
+++ b/test/fork/LidoARM/SwapGasImpact.t.sol
@@ -1,118 +1,167 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-// Contracts
-import {Proxy} from "contracts/Proxy.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import {IERC20} from "contracts/Interfaces.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
-
-// Test imports
-import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
-
-// Utils
+import {Proxy} from "contracts/Proxy.sol";
 import {Mainnet} from "contracts/utils/Addresses.sol";
 
-contract Fork_Concrete_LidoARM_SwapGasImpact_Test is Fork_Shared_Test_ {
+import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+import {LegacyLidoARMForGasTest} from "test/mocks/LegacyLidoARMForGasTest.sol";
+
+interface IBenchmarkARM {
+    function swapExactTokensForTokens(
+        IERC20 inToken,
+        IERC20 outToken,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address to
+    ) external returns (uint256[] memory amounts);
+    function feesAccrued() external view returns (uint256);
+}
+
+abstract contract Fork_Shared_LidoARM_SwapGasImpact_Test is Fork_Shared_Test_ {
     uint256 internal constant INITIAL_ARM_BALANCE = 1_000 ether;
-    uint256 internal constant INITIAL_USER_BALANCE = 200 ether;
     uint256 internal constant BUY_PRICE = 0.9995e36;
     uint256 internal constant SELL_PRICE = 1.001e36;
     uint256 internal constant EXACT_IN = 100 ether;
     uint256 internal constant EXACT_OUT = 99.95 ether;
 
-    Proxy internal noSwapFeeProxy;
-    LidoARM internal noSwapFeeLidoARM;
-    address internal noSwapFeeUser;
+    Proxy internal legacyProxy;
+    LegacyLidoARMForGasTest internal legacyLidoARM;
+
+    address internal legacyUser;
     address internal upgradedUser;
 
-    function setUp() public override {
+    function setUp() public virtual override {
         super.setUp();
 
-        noSwapFeeUser = makeAddr("noSwapFeeUser");
+        legacyUser = makeAddr("legacyUser");
         upgradedUser = makeAddr("upgradedUser");
 
-        noSwapFeeProxy = new Proxy();
-        LidoARM noSwapFeeImpl = new LidoARM(address(steth), address(weth), Mainnet.LIDO_WITHDRAWAL, 10 minutes, 0, 0);
+        legacyProxy = new Proxy();
+        LegacyLidoARMForGasTest legacyImpl = new LegacyLidoARMForGasTest(address(steth), address(weth));
 
         deal(address(weth), address(this), weth.balanceOf(address(this)) + 1e12);
-        weth.approve(address(noSwapFeeProxy), type(uint256).max);
+        weth.approve(address(legacyProxy), type(uint256).max);
 
         bytes memory data = abi.encodeWithSignature(
             "initialize(string,string,address,uint256,address,address)",
-            "Lido ARM No Swap Fee",
-            "ARM-ST-NO-FEE",
+            "Legacy Lido ARM",
+            "ARM-ST-LEGACY",
             operator,
-            0,
+            2000,
             feeCollector,
             address(lpcProxy)
         );
-        noSwapFeeProxy.initialize(address(noSwapFeeImpl), address(this), data);
-        noSwapFeeLidoARM = LidoARM(payable(address(noSwapFeeProxy)));
+        legacyProxy.initialize(address(legacyImpl), address(this), data);
+        legacyLidoARM = LegacyLidoARMForGasTest(payable(address(legacyProxy)));
 
+        legacyLidoARM.setPrices(BUY_PRICE, SELL_PRICE);
         lidoARM.setPrices(BUY_PRICE, SELL_PRICE);
-        noSwapFeeLidoARM.setPrices(BUY_PRICE, SELL_PRICE);
 
-        deal(address(weth), address(lidoARM), INITIAL_ARM_BALANCE);
-        deal(address(steth), address(lidoARM), INITIAL_ARM_BALANCE);
-        deal(address(weth), address(noSwapFeeLidoARM), INITIAL_ARM_BALANCE);
-        deal(address(steth), address(noSwapFeeLidoARM), INITIAL_ARM_BALANCE);
+        deal(address(steth), legacyUser, EXACT_IN * 4);
+        deal(address(steth), upgradedUser, EXACT_IN * 4);
 
-        deal(address(steth), upgradedUser, INITIAL_USER_BALANCE);
-        deal(address(steth), noSwapFeeUser, INITIAL_USER_BALANCE);
+        vm.prank(legacyUser);
+        steth.approve(address(legacyLidoARM), type(uint256).max);
 
         vm.prank(upgradedUser);
         steth.approve(address(lidoARM), type(uint256).max);
 
-        vm.prank(noSwapFeeUser);
-        steth.approve(address(noSwapFeeLidoARM), type(uint256).max);
+        _prepareScenario();
     }
 
-    function test_GasImpact_Baseline_SwapExactTokensForTokens_StethToWeth() public {
-        uint256 baselineGas = _gasForSwapExactTokensForTokens(noSwapFeeLidoARM, noSwapFeeUser, EXACT_IN);
-        emit log_named_uint("baseline swapExact stETH->WETH gas", baselineGas);
-        assertEq(noSwapFeeLidoARM.feesAccrued(), 0, "baseline fee accrual");
-    }
+    function _prepareScenario() internal virtual;
 
-    function test_GasImpact_Upgraded_SwapExactTokensForTokens_StethToWeth() public {
-        uint256 upgradedGas = _gasForSwapExactTokensForTokens(lidoARM, upgradedUser, EXACT_IN);
-        emit log_named_uint("upgraded swapExact stETH->WETH gas", upgradedGas);
-        assertGt(lidoARM.feesAccrued(), 0, "upgraded fee accrual");
-    }
+    function _gasForSwapExactTokensForTokens(IBenchmarkARM arm, address user) internal returns (uint256 gasUsed) {
+        deal(address(steth), user, steth.balanceOf(user) + EXACT_IN);
 
-    function test_GasImpact_Baseline_SwapTokensForExactTokens_StethToWeth() public {
-        uint256 baselineGas = _gasForSwapTokensForExactTokens(noSwapFeeLidoARM, noSwapFeeUser, EXACT_OUT);
-        emit log_named_uint("baseline swapForExact stETH->WETH gas", baselineGas);
-        assertEq(noSwapFeeLidoARM.feesAccrued(), 0, "baseline fee accrual");
-    }
-
-    function test_GasImpact_Upgraded_SwapTokensForExactTokens_StethToWeth() public {
-        uint256 upgradedGas = _gasForSwapTokensForExactTokens(lidoARM, upgradedUser, EXACT_OUT);
-        emit log_named_uint("upgraded swapForExact stETH->WETH gas", upgradedGas);
-        assertGt(lidoARM.feesAccrued(), 0, "upgraded fee accrual");
-    }
-
-    function _gasForSwapExactTokensForTokens(LidoARM arm, address user, uint256 amountIn)
-        internal
-        returns (uint256 gasUsed)
-    {
         vm.prank(user);
         uint256 gasBefore = gasleft();
         uint256[] memory amounts =
-            arm.swapExactTokensForTokens(steth, weth, amountIn, amountIn * BUY_PRICE / 1e36, user);
+            arm.swapExactTokensForTokens(steth, weth, EXACT_IN, EXACT_IN * BUY_PRICE / 1e36, user);
         gasUsed = gasBefore - gasleft();
 
-        assertEq(amounts[0], amountIn, "amount in");
-        assertEq(amounts[1], amountIn * BUY_PRICE / 1e36, "amount out");
+        assertEq(amounts[0], EXACT_IN, "amount in");
+        assertEq(amounts[1], EXACT_IN * BUY_PRICE / 1e36, "amount out");
     }
 
-    function _gasForSwapTokensForExactTokens(LidoARM arm, address user, uint256 amountOut)
-        internal
-        returns (uint256 gasUsed)
-    {
-        vm.prank(user);
-        uint256 gasBefore = gasleft();
-        uint256[] memory amounts = arm.swapTokensForExactTokens(steth, weth, amountOut, type(uint256).max, user);
-        gasUsed = gasBefore - gasleft();
+    function _setArmBalances(address arm, uint256 wethBalance, uint256 stethBalance) internal {
+        deal(address(weth), arm, 0);
+        deal(address(steth), arm, 0);
+        deal(address(weth), arm, wethBalance);
+        deal(address(steth), arm, stethBalance);
+    }
 
-        assertEq(amounts[1], amountOut, "amount out");
+    function _legacyAvailableAssets() internal pure returns (int128) {
+        return SafeCast.toInt128(SafeCast.toInt256(INITIAL_ARM_BALANCE * 2));
+    }
+
+    function _setPackedFeesAccrued(address arm, uint128 value) internal {
+        bytes32 slot = vm.load(arm, bytes32(_FEE_STORAGE_SLOT));
+        uint256 preservedFee = uint256(slot) & 0xFFFF;
+        uint256 encodedValue = uint256(value) << 16;
+        vm.store(arm, bytes32(_FEE_STORAGE_SLOT), bytes32(preservedFee | encodedValue));
+    }
+}
+
+contract Fork_Concrete_LegacyLidoARM_AfterCollect_SwapGasImpact_Test is Fork_Shared_LidoARM_SwapGasImpact_Test {
+    function _prepareScenario() internal override {
+        _setArmBalances(address(legacyLidoARM), INITIAL_ARM_BALANCE, INITIAL_ARM_BALANCE);
+        legacyLidoARM.setLastAvailableAssetsForGasTest(_legacyAvailableAssets());
+    }
+
+    function test_GasImpact() public {
+        assertEq(IBenchmarkARM(address(legacyLidoARM)).feesAccrued(), 0, "legacy fees should be collected");
+
+        uint256 gasUsed = _gasForSwapExactTokensForTokens(IBenchmarkARM(address(legacyLidoARM)), legacyUser);
+        emit log_named_uint("legacy performance fee after collect swapExact stETH->WETH gas", gasUsed);
+    }
+}
+
+contract Fork_Concrete_LegacyLidoARM_AfterAnotherSwap_SwapGasImpact_Test is Fork_Shared_LidoARM_SwapGasImpact_Test {
+    function _prepareScenario() internal override {
+        _setArmBalances(address(legacyLidoARM), INITIAL_ARM_BALANCE - EXACT_OUT, INITIAL_ARM_BALANCE + EXACT_IN);
+        legacyLidoARM.setLastAvailableAssetsForGasTest(_legacyAvailableAssets());
+    }
+
+    function test_GasImpact() public {
+        assertGt(IBenchmarkARM(address(legacyLidoARM)).feesAccrued(), 0, "legacy swap should create performance fees");
+
+        uint256 gasUsed = _gasForSwapExactTokensForTokens(IBenchmarkARM(address(legacyLidoARM)), legacyUser);
+        emit log_named_uint("legacy performance fee after another swap swapExact stETH->WETH gas", gasUsed);
+    }
+}
+
+contract Fork_Concrete_NewLidoARM_AfterCollect_SwapGasImpact_Test is Fork_Shared_LidoARM_SwapGasImpact_Test {
+    function _prepareScenario() internal override {
+        _setArmBalances(address(lidoARM), INITIAL_ARM_BALANCE, INITIAL_ARM_BALANCE);
+        _setPackedFeesAccrued(address(lidoARM), 1);
+    }
+
+    function test_GasImpact() public {
+        assertEq(IBenchmarkARM(address(lidoARM)).feesAccrued(), 1, "new swap fee should reset to sentinel");
+
+        uint256 gasUsed = _gasForSwapExactTokensForTokens(IBenchmarkARM(address(lidoARM)), upgradedUser);
+        emit log_named_uint("new swap fee after collect swapExact stETH->WETH gas", gasUsed);
+    }
+}
+
+contract Fork_Concrete_NewLidoARM_AfterAnotherSwap_SwapGasImpact_Test is Fork_Shared_LidoARM_SwapGasImpact_Test {
+    function _prepareScenario() internal override {
+        _setArmBalances(address(lidoARM), INITIAL_ARM_BALANCE - EXACT_OUT, INITIAL_ARM_BALANCE + EXACT_IN);
+        _setPackedFeesAccrued(
+            address(lidoARM), uint128((EXACT_IN - EXACT_OUT) * lidoARM.fee() / lidoARM.FEE_SCALE() + 1)
+        );
+    }
+
+    function test_GasImpact() public {
+        assertGt(IBenchmarkARM(address(lidoARM)).feesAccrued(), 1, "new swap should leave accrued swap fees");
+
+        uint256 gasUsed = _gasForSwapExactTokensForTokens(IBenchmarkARM(address(lidoARM)), upgradedUser);
+        emit log_named_uint("new swap fee after another swap swapExact stETH->WETH gas", gasUsed);
     }
 }

--- a/test/fork/LidoARM/SwapGasImpact.t.sol
+++ b/test/fork/LidoARM/SwapGasImpact.t.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {Proxy} from "contracts/Proxy.sol";
+import {LidoARM} from "contracts/LidoARM.sol";
+
+// Test imports
+import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+
+// Utils
+import {Mainnet} from "contracts/utils/Addresses.sol";
+
+contract Fork_Concrete_LidoARM_SwapGasImpact_Test is Fork_Shared_Test_ {
+    uint256 internal constant INITIAL_ARM_BALANCE = 1_000 ether;
+    uint256 internal constant INITIAL_USER_BALANCE = 200 ether;
+    uint256 internal constant BUY_PRICE = 0.9995e36;
+    uint256 internal constant SELL_PRICE = 1.001e36;
+    uint256 internal constant EXACT_IN = 100 ether;
+    uint256 internal constant EXACT_OUT = 99.95 ether;
+
+    Proxy internal noSwapFeeProxy;
+    LidoARM internal noSwapFeeLidoARM;
+    address internal noSwapFeeUser;
+    address internal upgradedUser;
+
+    function setUp() public override {
+        super.setUp();
+
+        noSwapFeeUser = makeAddr("noSwapFeeUser");
+        upgradedUser = makeAddr("upgradedUser");
+
+        noSwapFeeProxy = new Proxy();
+        LidoARM noSwapFeeImpl = new LidoARM(address(steth), address(weth), Mainnet.LIDO_WITHDRAWAL, 10 minutes, 0, 0);
+
+        deal(address(weth), address(this), weth.balanceOf(address(this)) + 1e12);
+        weth.approve(address(noSwapFeeProxy), type(uint256).max);
+
+        bytes memory data = abi.encodeWithSignature(
+            "initialize(string,string,address,uint256,address,address)",
+            "Lido ARM No Swap Fee",
+            "ARM-ST-NO-FEE",
+            operator,
+            0,
+            feeCollector,
+            address(lpcProxy)
+        );
+        noSwapFeeProxy.initialize(address(noSwapFeeImpl), address(this), data);
+        noSwapFeeLidoARM = LidoARM(payable(address(noSwapFeeProxy)));
+
+        lidoARM.setPrices(BUY_PRICE, SELL_PRICE);
+        noSwapFeeLidoARM.setPrices(BUY_PRICE, SELL_PRICE);
+
+        deal(address(weth), address(lidoARM), INITIAL_ARM_BALANCE);
+        deal(address(steth), address(lidoARM), INITIAL_ARM_BALANCE);
+        deal(address(weth), address(noSwapFeeLidoARM), INITIAL_ARM_BALANCE);
+        deal(address(steth), address(noSwapFeeLidoARM), INITIAL_ARM_BALANCE);
+
+        deal(address(steth), upgradedUser, INITIAL_USER_BALANCE);
+        deal(address(steth), noSwapFeeUser, INITIAL_USER_BALANCE);
+
+        vm.prank(upgradedUser);
+        steth.approve(address(lidoARM), type(uint256).max);
+
+        vm.prank(noSwapFeeUser);
+        steth.approve(address(noSwapFeeLidoARM), type(uint256).max);
+    }
+
+    function test_GasImpact_Baseline_SwapExactTokensForTokens_StethToWeth() public {
+        uint256 baselineGas = _gasForSwapExactTokensForTokens(noSwapFeeLidoARM, noSwapFeeUser, EXACT_IN);
+        emit log_named_uint("baseline swapExact stETH->WETH gas", baselineGas);
+        assertEq(noSwapFeeLidoARM.feesAccrued(), 0, "baseline fee accrual");
+    }
+
+    function test_GasImpact_Upgraded_SwapExactTokensForTokens_StethToWeth() public {
+        uint256 upgradedGas = _gasForSwapExactTokensForTokens(lidoARM, upgradedUser, EXACT_IN);
+        emit log_named_uint("upgraded swapExact stETH->WETH gas", upgradedGas);
+        assertGt(lidoARM.feesAccrued(), 0, "upgraded fee accrual");
+    }
+
+    function test_GasImpact_Baseline_SwapTokensForExactTokens_StethToWeth() public {
+        uint256 baselineGas = _gasForSwapTokensForExactTokens(noSwapFeeLidoARM, noSwapFeeUser, EXACT_OUT);
+        emit log_named_uint("baseline swapForExact stETH->WETH gas", baselineGas);
+        assertEq(noSwapFeeLidoARM.feesAccrued(), 0, "baseline fee accrual");
+    }
+
+    function test_GasImpact_Upgraded_SwapTokensForExactTokens_StethToWeth() public {
+        uint256 upgradedGas = _gasForSwapTokensForExactTokens(lidoARM, upgradedUser, EXACT_OUT);
+        emit log_named_uint("upgraded swapForExact stETH->WETH gas", upgradedGas);
+        assertGt(lidoARM.feesAccrued(), 0, "upgraded fee accrual");
+    }
+
+    function _gasForSwapExactTokensForTokens(LidoARM arm, address user, uint256 amountIn)
+        internal
+        returns (uint256 gasUsed)
+    {
+        vm.prank(user);
+        uint256 gasBefore = gasleft();
+        uint256[] memory amounts =
+            arm.swapExactTokensForTokens(steth, weth, amountIn, amountIn * BUY_PRICE / 1e36, user);
+        gasUsed = gasBefore - gasleft();
+
+        assertEq(amounts[0], amountIn, "amount in");
+        assertEq(amounts[1], amountIn * BUY_PRICE / 1e36, "amount out");
+    }
+
+    function _gasForSwapTokensForExactTokens(LidoARM arm, address user, uint256 amountOut)
+        internal
+        returns (uint256 gasUsed)
+    {
+        vm.prank(user);
+        uint256 gasBefore = gasleft();
+        uint256[] memory amounts = arm.swapTokensForExactTokens(steth, weth, amountOut, type(uint256).max, user);
+        gasUsed = gasBefore - gasleft();
+
+        assertEq(amounts[1], amountOut, "amount out");
+    }
+}

--- a/test/fork/LidoARM/TotalAssets.t.sol
+++ b/test/fork/LidoARM/TotalAssets.t.sol
@@ -44,7 +44,7 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
     }
 
     function test_TotalAssets_AfterDeposit_NoAssetGainOrLoss() public depositInLidoARM(address(this), DEFAULT_AMOUNT) {
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
+        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - 1);
     }
 
     function test_TotalAssets_AfterDeposit_WithAssetGain_InWETH()
@@ -55,7 +55,7 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         uint256 assetGain = DEFAULT_AMOUNT / 2;
         deal(address(weth), address(lidoARM), weth.balanceOf(address(lidoARM)) + assetGain);
 
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain);
+        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain - 1);
     }
 
     function test_TotalAssets_AfterDeposit_WithAssetGain_InSTETH()
@@ -68,7 +68,9 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         // We are sure that steth balance is empty, so we can deal directly final amount.
         deal(address(steth), address(lidoARM), assetGain);
 
-        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain, STETH_ERROR_ROUNDING);
+        assertApproxEqAbs(
+            lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain - 1, STETH_ERROR_ROUNDING
+        );
     }
 
     function test_TotalAssets_AfterDeposit_WithAssetLoss_InWETH()
@@ -79,7 +81,7 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         uint256 assetLoss = DEFAULT_AMOUNT / 2;
         deal(address(weth), address(lidoARM), weth.balanceOf(address(lidoARM)) - assetLoss);
 
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - assetLoss);
+        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - assetLoss - 1);
     }
 
     function test_TotalAssets_AfterDeposit_WithAssetLoss_InSTETH()
@@ -93,7 +95,9 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         uint256 assetLoss = swapAmount / 2;
         deal(address(steth), address(lidoARM), swapAmount / 2);
 
-        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - assetLoss, STETH_ERROR_ROUNDING);
+        assertApproxEqAbs(
+            lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - assetLoss - 1, STETH_ERROR_ROUNDING
+        );
     }
 
     function test_TotalAssets_After_WithdrawingFromLido() public {
@@ -121,8 +125,8 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         (uint256 amountOut, uint256 expectedFee) = _swapBaseForLiquidity(100 ether);
 
         // Assert fee accrued on discounted swap only.
-        assertEq(lidoARM.feesAccrued(), expectedFee);
-        assertApproxEqAbs(lidoARM.totalAssets(), totalAssetsBefore + 100 ether - amountOut - expectedFee, 1);
+        assertEq(lidoARM.feesAccrued(), expectedFee + 1);
+        assertApproxEqAbs(lidoARM.totalAssets(), totalAssetsBefore + 100 ether - amountOut - expectedFee - 1, 1);
     }
 
     function test_TotalAssets_When_ARMIsInsolvent()

--- a/test/fork/LidoARM/TotalAssets.t.sol
+++ b/test/fork/LidoARM/TotalAssets.t.sol
@@ -8,6 +8,8 @@ import {stdError} from "forge-std/StdError.sol";
 import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
 
 contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
+    uint256 internal constant DISCOUNTED_PRICE = 9995e32; // 0.9995
+
     //////////////////////////////////////////////////////
     /// --- SETUP
     //////////////////////////////////////////////////////
@@ -22,6 +24,16 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
 
         deal(address(weth), address(this), 1_000 ether);
         weth.approve(address(lidoARM), type(uint256).max);
+    }
+
+    function _swapBaseForLiquidity(uint256 amountIn) internal returns (uint256 amountOut, uint256 expectedFee) {
+        lidoARM.setPrices(DISCOUNTED_PRICE, 1001e33);
+        deal(address(steth), address(this), amountIn);
+        steth.approve(address(lidoARM), type(uint256).max);
+
+        uint256[] memory amounts = lidoARM.swapExactTokensForTokens(steth, weth, amountIn, 0, address(this));
+        amountOut = amounts[1];
+        expectedFee = (amountIn - amountOut) * lidoARM.fee() / lidoARM.FEE_SCALE();
     }
 
     //////////////////////////////////////////////////////
@@ -43,10 +55,7 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         uint256 assetGain = DEFAULT_AMOUNT / 2;
         deal(address(weth), address(lidoARM), weth.balanceOf(address(lidoARM)) + assetGain);
 
-        // Calculate Fees
-        uint256 fee = assetGain * 20 / 100; // 20% fee
-
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain - fee);
+        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain);
     }
 
     function test_TotalAssets_AfterDeposit_WithAssetGain_InSTETH()
@@ -59,12 +68,7 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         // We are sure that steth balance is empty, so we can deal directly final amount.
         deal(address(steth), address(lidoARM), assetGain);
 
-        // Calculate Fees
-        uint256 fee = assetGain * 20 / 100; // 20% fee
-
-        assertApproxEqAbs(
-            lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain - fee, STETH_ERROR_ROUNDING
-        );
+        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain, STETH_ERROR_ROUNDING);
     }
 
     function test_TotalAssets_AfterDeposit_WithAssetLoss_InWETH()
@@ -110,17 +114,15 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
     }
 
     function test_TotalAssets_With_FeeAccrued_NotNull() public {
-        uint256 assetGain = DEFAULT_AMOUNT;
-        // Simulate asset gain
-        deal(address(weth), address(lidoARM), weth.balanceOf(address(lidoARM)) + assetGain);
-
-        // User deposit, this will trigger a fee calculation
         lidoARM.deposit(DEFAULT_AMOUNT);
+        deal(address(weth), address(lidoARM), 200 ether);
+        uint256 totalAssetsBefore = lidoARM.totalAssets();
 
-        // Assert fee accrued is not null
-        assertEq(lidoARM.feesAccrued(), assetGain * 20 / 100);
+        (uint256 amountOut, uint256 expectedFee) = _swapBaseForLiquidity(100 ether);
 
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + assetGain - assetGain * 20 / 100);
+        // Assert fee accrued on discounted swap only.
+        assertEq(lidoARM.feesAccrued(), expectedFee);
+        assertApproxEqAbs(lidoARM.totalAssets(), totalAssetsBefore + 100 ether - amountOut - expectedFee, 1);
     }
 
     function test_TotalAssets_When_ARMIsInsolvent()

--- a/test/invariants/LidoARM/TargetFunction.sol
+++ b/test/invariants/LidoARM/TargetFunction.sol
@@ -293,10 +293,6 @@ abstract contract TargetFunction is Properties {
         return lidoARM.feesAccrued();
     }
 
-    function handler_lastAvailableAsset() public view returns (int128) {
-        return deprecatedLastAvailableAssets(address(lidoARM));
-    }
-
     ////////////////////////////////////////////////////
     /// --- DONATION
     ////////////////////////////////////////////////////

--- a/test/invariants/LidoARM/TargetFunction.sol
+++ b/test/invariants/LidoARM/TargetFunction.sol
@@ -294,7 +294,7 @@ abstract contract TargetFunction is Properties {
     }
 
     function handler_lastAvailableAsset() public view returns (int128) {
-        return lidoARM.lastAvailableAssets();
+        return deprecatedLastAvailableAssets(address(lidoARM));
     }
 
     ////////////////////////////////////////////////////

--- a/test/mocks/LegacyLidoARMForGasTest.sol
+++ b/test/mocks/LegacyLidoARMForGasTest.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import {IERC20} from "contracts/Interfaces.sol";
+
+/// @dev Test-only harness that preserves the old pre-upgrade Lido ARM fee model:
+/// performance fees accrue on increases in available assets and are collected in WETH.
+contract LegacyLidoARMForGasTest is Initializable {
+    uint256 public constant MAX_CROSS_PRICE_DEVIATION = 20e32;
+    uint256 public constant PRICE_SCALE = 1e36;
+    uint256 public constant FEE_SCALE = 10000;
+    uint256 internal constant MIN_TOTAL_SUPPLY = 1e12;
+
+    IERC20 public immutable weth;
+    IERC20 public immutable steth;
+
+    uint256 public traderate0;
+    uint256 public traderate1;
+    uint256 public crossPrice;
+
+    uint16 public fee;
+    int128 public lastAvailableAssets;
+    address public feeCollector;
+
+    event TraderateChanged(uint256 traderate0, uint256 traderate1);
+    event FeeCollected(address indexed feeCollector, uint256 fee);
+
+    constructor(address _steth, address _weth) {
+        steth = IERC20(_steth);
+        weth = IERC20(_weth);
+        _disableInitializers();
+    }
+
+    function initialize(string calldata, string calldata, address, uint256 _fee, address _feeCollector, address)
+        external
+        initializer
+    {
+        weth.transferFrom(msg.sender, address(this), MIN_TOTAL_SUPPLY);
+
+        traderate0 = PRICE_SCALE;
+        traderate1 = PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION;
+        crossPrice = PRICE_SCALE;
+
+        fee = SafeCast.toUint16(_fee);
+        feeCollector = _feeCollector;
+        lastAvailableAssets = SafeCast.toInt128(SafeCast.toInt256(_availableAssets()));
+    }
+
+    function setPrices(uint256 buyT1, uint256 sellT1) external {
+        traderate0 = PRICE_SCALE * PRICE_SCALE / sellT1;
+        traderate1 = buyT1;
+        emit TraderateChanged(traderate0, traderate1);
+    }
+
+    function swapExactTokensForTokens(
+        IERC20 inToken,
+        IERC20 outToken,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address to
+    ) external returns (uint256[] memory amounts) {
+        uint256 amountOut = _swapExactTokensForTokens(inToken, outToken, amountIn, to);
+        require(amountOut >= amountOutMin, "ARM: Insufficient output amount");
+
+        amounts = new uint256[](2);
+        amounts[0] = amountIn;
+        amounts[1] = amountOut;
+    }
+
+    function swapTokensForExactTokens(
+        IERC20 inToken,
+        IERC20 outToken,
+        uint256 amountOut,
+        uint256 amountInMax,
+        address to
+    ) external returns (uint256[] memory amounts) {
+        uint256 amountIn = _swapTokensForExactTokens(inToken, outToken, amountOut, to);
+        require(amountIn <= amountInMax, "ARM: Excess input amount");
+
+        amounts = new uint256[](2);
+        amounts[0] = amountIn;
+        amounts[1] = amountOut;
+    }
+
+    function collectFees() public returns (uint256 fees) {
+        uint256 newAvailableAssets;
+        (fees, newAvailableAssets) = _feesAccrued();
+
+        lastAvailableAssets = SafeCast.toInt128(SafeCast.toInt256(newAvailableAssets) - SafeCast.toInt256(fees));
+        if (fees == 0) return 0;
+
+        require(fees <= weth.balanceOf(address(this)), "ARM: insufficient liquidity");
+        weth.transfer(feeCollector, fees);
+
+        emit FeeCollected(feeCollector, fees);
+    }
+
+    function feesAccrued() external view returns (uint256 fees) {
+        (fees,) = _feesAccrued();
+    }
+
+    function setLastAvailableAssetsForGasTest(int128 value) external {
+        lastAvailableAssets = value;
+    }
+
+    function _feesAccrued() internal view returns (uint256 fees, uint256 newAvailableAssets) {
+        newAvailableAssets = _availableAssets();
+
+        int256 assetIncrease = SafeCast.toInt256(newAvailableAssets) - lastAvailableAssets;
+        if (assetIncrease <= 0) return (0, newAvailableAssets);
+
+        fees = SafeCast.toUint256(assetIncrease) * fee / FEE_SCALE;
+    }
+
+    function _availableAssets() internal view returns (uint256) {
+        return weth.balanceOf(address(this)) + steth.balanceOf(address(this)) * crossPrice / PRICE_SCALE;
+    }
+
+    function _swapExactTokensForTokens(IERC20 inToken, IERC20 outToken, uint256 amountIn, address to)
+        internal
+        returns (uint256 amountOut)
+    {
+        uint256 price = _price(inToken, outToken);
+        amountOut = amountIn * price / PRICE_SCALE;
+
+        inToken.transferFrom(msg.sender, address(this), amountIn);
+        outToken.transfer(to, amountOut);
+    }
+
+    function _swapTokensForExactTokens(IERC20 inToken, IERC20 outToken, uint256 amountOut, address to)
+        internal
+        returns (uint256 amountIn)
+    {
+        uint256 price = _price(inToken, outToken);
+        amountIn = ((amountOut * PRICE_SCALE) / price) + 3;
+
+        inToken.transferFrom(msg.sender, address(this), amountIn);
+        outToken.transfer(to, amountOut);
+    }
+
+    function _price(IERC20 inToken, IERC20 outToken) internal view returns (uint256 price) {
+        if (inToken == weth) {
+            require(outToken == steth, "ARM: Invalid out token");
+            return traderate0;
+        }
+        if (inToken == steth) {
+            require(outToken == weth, "ARM: Invalid out token");
+            return traderate1;
+        }
+        revert("ARM: Invalid in token");
+    }
+}

--- a/test/unit/OriginARM/CollectFees.sol
+++ b/test/unit/OriginARM/CollectFees.sol
@@ -9,8 +9,7 @@ contract Unit_Concrete_OriginARM_CollectFees_Test_ is Unit_Shared_Test {
         vm.startPrank(bob);
         deal(address(oeth), bob, 1_000 * DEFAULT_AMOUNT);
         oeth.approve(address(originARM), type(uint256).max);
-        uint256[] memory amounts =
-            originARM.swapTokensForExactTokens(oeth, weth, amountOut, type(uint256).max, bob);
+        uint256[] memory amounts = originARM.swapTokensForExactTokens(oeth, weth, amountOut, type(uint256).max, bob);
         vm.stopPrank();
 
         amountIn = amounts[0];

--- a/test/unit/OriginARM/CollectFees.sol
+++ b/test/unit/OriginARM/CollectFees.sol
@@ -5,55 +5,58 @@ import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
 import {AbstractARM} from "src/contracts/AbstractARM.sol";
 
 contract Unit_Concrete_OriginARM_CollectFees_Test_ is Unit_Shared_Test {
-    function test_RevertWhen_CollectFees_Because_InsufficientLiquidity()
-        public
-        deposit(alice, DEFAULT_AMOUNT)
-        requestRedeemAll(alice)
-        donate(oeth, address(originARM), DEFAULT_AMOUNT)
-        asRandomCaller
-    {
+    function _swapBaseForLiquidity(uint256 amountOut) internal returns (uint256 amountIn, uint256 expectedFee) {
+        vm.startPrank(bob);
+        deal(address(oeth), bob, 1_000 * DEFAULT_AMOUNT);
+        oeth.approve(address(originARM), type(uint256).max);
+        uint256[] memory amounts =
+            originARM.swapTokensForExactTokens(oeth, weth, amountOut, type(uint256).max, bob);
+        vm.stopPrank();
+
+        amountIn = amounts[0];
+        expectedFee = (amountIn - amountOut) * originARM.fee() / originARM.FEE_SCALE();
+    }
+
+    function test_RevertWhen_CollectFees_Because_InsufficientLiquidity() public deposit(alice, DEFAULT_AMOUNT) {
+        _swapBaseForLiquidity(DEFAULT_AMOUNT / 2);
+        uint256 shares = originARM.balanceOf(alice);
+        vm.prank(alice);
+        originARM.requestRedeem(shares);
+
+        vm.prank(vm.randomAddress());
         vm.expectRevert("ARM: Insufficient liquidity");
         originARM.collectFees();
     }
 
-    function test_RevertWhen_CollectFees_Because_InsufficientLiquidityBis()
-        public
-        donate(oeth, address(originARM), DEFAULT_AMOUNT)
-        asRandomCaller
-    {
+    function test_RevertWhen_CollectFees_Because_InsufficientLiquidityBis() public {
+        _swapBaseForLiquidity(1e12);
+
+        vm.prank(vm.randomAddress());
         vm.expectRevert("ARM: insufficient liquidity");
         originARM.collectFees();
     }
 
-    function test_CollectFees_When_NoFeeToCollect()
-        public
-        deposit(alice, DEFAULT_AMOUNT)
-        requestRedeemAll(alice)
-        asRandomCaller
-    {
+    function test_CollectFees_When_NoFeeToCollect() public deposit(alice, DEFAULT_AMOUNT) requestRedeemAll(alice) {
         uint256 collectorBalance = weth.balanceOf(feeCollector);
 
         // Collect fees
+        vm.prank(vm.randomAddress());
         originARM.collectFees();
 
         // Ensure there nothing has been allocated
         assertEq(weth.balanceOf(feeCollector), collectorBalance, "Collector balance should not change");
     }
 
-    function test_CollectFees_When_FeeToCollect()
-        public
-        donate(weth, address(originARM), DEFAULT_AMOUNT)
-        asRandomCaller
-    {
+    function test_CollectFees_When_FeeToCollect() public {
         uint256 collectorBalance = weth.balanceOf(feeCollector);
-        uint256 feePct = originARM.fee();
-        uint256 scale = originARM.FEE_SCALE();
-        uint256 expectedFees = DEFAULT_AMOUNT * feePct / scale;
+        deal(address(weth), address(originARM), DEFAULT_AMOUNT);
+        (, uint256 expectedFees) = _swapBaseForLiquidity(DEFAULT_AMOUNT / 2);
 
         vm.expectEmit(address(originARM));
         emit AbstractARM.FeeCollected(feeCollector, expectedFees);
 
         // Collect fees
+        vm.prank(vm.randomAddress());
         originARM.collectFees();
 
         // Ensure there nothing has been allocated

--- a/test/unit/OriginARM/Deposit.sol
+++ b/test/unit/OriginARM/Deposit.sol
@@ -46,7 +46,6 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         originARM.deposit(DEFAULT_AMOUNT);
 
         // Assertions
-        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     /// @notice Test under the following assumptions:
@@ -159,7 +158,6 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         vm.prank(alice);
         originARM.deposit(DEFAULT_AMOUNT);
         // Assertions
-        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     /// @notice Test under the following assumptions:
@@ -191,7 +189,6 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         vm.prank(alice);
         originARM.deposit(DEFAULT_AMOUNT);
         // Assertions
-        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     function test_Deposit_When_CapManagerIsSet() public setCapManager setTotalAssetsCapUnlimited {
@@ -207,7 +204,6 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         originARM.deposit(DEFAULT_AMOUNT);
 
         // Assertions
-        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     /// @notice Deposit reverts when the ARM is insolvent (totalAssets floored to MIN_TOTAL_SUPPLY)
@@ -289,7 +285,6 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         originARM.deposit(DEFAULT_AMOUNT, bob);
 
         // Assertions
-        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
         assertEq(originARM.balanceOf(bob), expectedShares, "Bob should have the shares");
     }
 }

--- a/test/unit/OriginARM/Deposit.sol
+++ b/test/unit/OriginARM/Deposit.sol
@@ -46,11 +46,7 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         originARM.deposit(DEFAULT_AMOUNT);
 
         // Assertions
-        assertEq(
-            originARM.lastAvailableAssets().toUint256(),
-            DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
-            "Last available assets should be updated"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     /// @notice Test under the following assumptions:
@@ -153,8 +149,6 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         // Then request a withdrawal, this will decrease the available assets
         vm.prank(governor);
         originARM.requestOriginWithdrawal(1e12 / 2);
-        uint256 lastAvailableAssets = originARM.lastAvailableAssets().toUint256();
-
         // Expected values
         uint256 expectedShares = originARM.convertToShares(DEFAULT_AMOUNT);
         assertApproxEqAbs(expectedShares, DEFAULT_AMOUNT, 1e16, "Shares should be eq amount");
@@ -165,11 +159,7 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         vm.prank(alice);
         originARM.deposit(DEFAULT_AMOUNT);
         // Assertions
-        assertEq(
-            originARM.lastAvailableAssets().toUint256(),
-            DEFAULT_AMOUNT + lastAvailableAssets,
-            "Last available assets should be updated"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     /// @notice Test under the following assumptions:
@@ -201,11 +191,7 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         vm.prank(alice);
         originARM.deposit(DEFAULT_AMOUNT);
         // Assertions
-        assertEq(
-            originARM.lastAvailableAssets().toUint256(),
-            DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
-            "Last available assets should be updated"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     function test_Deposit_When_CapManagerIsSet() public setCapManager setTotalAssetsCapUnlimited {
@@ -221,11 +207,7 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         originARM.deposit(DEFAULT_AMOUNT);
 
         // Assertions
-        assertEq(
-            originARM.lastAvailableAssets().toUint256(),
-            DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
-            "Last available assets should be updated"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
     }
 
     /// @notice Deposit reverts when the ARM is insolvent (totalAssets floored to MIN_TOTAL_SUPPLY)
@@ -307,11 +289,7 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         originARM.deposit(DEFAULT_AMOUNT, bob);
 
         // Assertions
-        assertEq(
-            originARM.lastAvailableAssets().toUint256(),
-            DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
-            "Last available assets should be updated"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
         assertEq(originARM.balanceOf(bob), expectedShares, "Bob should have the shares");
     }
 }

--- a/test/unit/OriginARM/Migration.sol
+++ b/test/unit/OriginARM/Migration.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
+
+contract Unit_Concrete_OriginARM_Migration_Test is Unit_Shared_Test {
+    function test_MigrateFeesAccrued_ClearsLegacyBitsAndPreservesFee() public {
+        uint256 originalFee = originARM.fee();
+        uint128 legacyValue = 123_456_789;
+
+        vm.store(address(originARM), bytes32(_FEE_STORAGE_SLOT), bytes32((uint256(legacyValue) << 16) | originalFee));
+
+        assertEq(originARM.feesAccrued(), legacyValue, "legacy bits should be visible before migration");
+        assertEq(originARM.fee(), originalFee, "fee should remain readable before migration");
+
+        vm.prank(governor);
+        originARM.migrateFeesAccrued();
+
+        assertEq(originARM.feesAccrued(), 0, "feesAccrued should be reset");
+        assertEq(originARM.fee(), originalFee, "fee should be preserved");
+    }
+
+    function test_RevertWhen_MigrateFeesAccrued_CalledTwice() public {
+        vm.prank(governor);
+        originARM.migrateFeesAccrued();
+
+        vm.prank(governor);
+        vm.expectRevert();
+        originARM.migrateFeesAccrued();
+    }
+}

--- a/test/unit/OriginARM/Migration.sol
+++ b/test/unit/OriginARM/Migration.sol
@@ -16,7 +16,7 @@ contract Unit_Concrete_OriginARM_Migration_Test is Unit_Shared_Test {
         vm.prank(governor);
         originARM.migrateFeesAccrued();
 
-        assertEq(originARM.feesAccrued(), 0, "feesAccrued should be reset");
+        assertEq(originARM.feesAccrued(), 1, "feesAccrued sentinel should be reset");
         assertEq(originARM.fee(), originalFee, "fee should be preserved");
     }
 

--- a/test/unit/OriginARM/RequestRedeem.sol
+++ b/test/unit/OriginARM/RequestRedeem.sol
@@ -41,7 +41,6 @@ contract Unit_Concrete_OriginARM_RequestRedeem_Test_ is Unit_Shared_Test {
         (address withdrawer, bool claimed, uint256 requestTimestamp, uint256 amount, uint256 queued_, uint256 shares) =
             originARM.withdrawalRequests(0);
         // Assertions
-        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
         assertEq(originARM.withdrawsQueued(), queued + DEFAULT_AMOUNT, "Withdraws queued should be updated");
         assertEq(originARM.nextWithdrawalIndex(), requestIndex + 1, "Next withdrawal index should be updated");
         assertEq(withdrawer, alice, "Withdrawer should be Alice");

--- a/test/unit/OriginARM/RequestRedeem.sol
+++ b/test/unit/OriginARM/RequestRedeem.sol
@@ -27,7 +27,6 @@ contract Unit_Concrete_OriginARM_RequestRedeem_Test_ is Unit_Shared_Test {
         uint256 expectedOETH = originARM.convertToAssets(expectedShares);
         uint256 requestIndex = originARM.nextWithdrawalIndex();
         uint128 queued = originARM.withdrawsQueued();
-        int128 lastAvailableAssets = originARM.lastAvailableAssets();
         uint256 previewRedeem = originARM.previewRedeem(DEFAULT_AMOUNT);
         assertEq(previewRedeem, expectedShares, "Preview redeem should match expected shares");
 
@@ -42,11 +41,7 @@ contract Unit_Concrete_OriginARM_RequestRedeem_Test_ is Unit_Shared_Test {
         (address withdrawer, bool claimed, uint256 requestTimestamp, uint256 amount, uint256 queued_, uint256 shares) =
             originARM.withdrawalRequests(0);
         // Assertions
-        assertEq(
-            originARM.lastAvailableAssets().toUint256(),
-            lastAvailableAssets.toUint256() - DEFAULT_AMOUNT,
-            "Last available assets should be updated"
-        );
+        assertEq(deprecatedLastAvailableAssets(address(originARM)).toUint256(), 0, "Deprecated field should stay zero");
         assertEq(originARM.withdrawsQueued(), queued + DEFAULT_AMOUNT, "Withdraws queued should be updated");
         assertEq(originARM.nextWithdrawalIndex(), requestIndex + 1, "Next withdrawal index should be updated");
         assertEq(withdrawer, alice, "Withdrawer should be Alice");


### PR DESCRIPTION
## Changes

- Replace the old performance-fee-on-asset-growth model with swap-only fee accrual, so fees accrue only on discounted base-asset buy swaps.
- Update swap fee math to charge `(convertedBaseAmountIn - liquidityAmountOut) * fee / FEE_SCALE` on qualifying swaps, including appreciating-base-asset paths like `sUSDe -> USDe`.
- Change `totalAssets()` to subtract only stored accrued swap fees instead of fees derived from passive asset growth.
- Replace legacy `lastAvailableAssets` fee accounting with explicit stored `feesAccrued`, and stop maintaining the deprecated legacy field after upgrade.
- Reuse the old fee storage slot via a packed `FeeData` struct that holds `fee` and `feesAccrued` in a single slot.
- Keep `feesAccrued` at a `1 wei` sentinel after collection to avoid a more expensive `0 -> nonzero` storage write on the next fee-bearing swap.
- Add migration initializers to LidoARM, EtherFiARM, EthenaARM, and OriginARM to clear the reused legacy fee storage during upgrade.
- Preserve the external `fee()` and `feesAccrued()` interfaces while moving internal fee state to the packed struct layout.

## Gas impact

- Before upgrade, the full Lido `stETH -> WETH` fee-bearing swap transaction used `96,864` gas.  
- After upgrade, the full swap transaction used `105,354` gas.  
- Net change: `+8,490` gas, which is about an `8.8%` increase.