### PR TITLE
Tighter pnpm config

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "github.com:originprotocol/arm-oeth"
   },
   "license": "MIT",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.33.2",
   "devDependencies": {
     "@apollo/client": "^3.11.4",
     "@ethersproject/providers": "^5.7.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
Help avoid supply chain attacks by not installing packages not older than 7 days