### PR TITLE
Reference: Model A loss-sharing for ARM withdrawal queue

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -138,7 +138,17 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Accrued swap fees denominated in the liquidity asset.
     uint128 public feesAccrued;
 
-    uint256[35] private _gap;
+    /// @notice Cumulative `request.assets` ever queued in this ARM's withdrawal queue.
+    /// @dev Asset-denominated mirror of `withdrawsQueued`, used for the swap-side liquidity reservation.
+    /// `withdrawsQueuedAssets - withdrawsClaimedAssets` is an upper bound on the WETH the queue can still
+    /// withdraw (each payout is min(request.assets, convertToAssets(shares)) ≤ request.assets), which lets
+    /// the swap path avoid an expensive convertToAssets / Morpho call.
+    uint128 public withdrawsQueuedAssets;
+    /// @notice Cumulative `request.assets` ever claimed (each claim increments by request.assets, NOT by
+    /// the actual reduced payout, so the difference with `withdrawsQueuedAssets` stays a true upper bound).
+    uint128 public withdrawsClaimedAssets;
+
+    uint256[34] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Events
@@ -372,9 +382,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param amount The amount of liquidity assets being sent out of the ARM.
     function _ensureLiquidityAvailableForSwap(uint256 amount) internal {
         uint256 liquidityBalance = IERC20(liquidityAsset).balanceOf(address(this));
-        // Reserve liquidity for queued redemptions, valued at current (loss-adjusted) share price.
-        uint256 outstandingShares = withdrawsQueued - withdrawsClaimed;
-        uint256 reservedAssets = outstandingShares == 0 ? 0 : convertToAssets(outstandingShares);
+        // Upper bound on what the queue can still withdraw. Cheap (no convertToAssets / Morpho call):
+        // each payout is min(request.assets, convertToAssets(shares)) ≤ request.assets, so the cumulative
+        // request.assets gap is always ≥ the actual remaining liability.
+        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
         uint256 requiredLiquidity = amount + reservedAssets;
 
         // If there is enough liquidity in the ARM to cover the swap after reserving liquidity for withdrawals
@@ -530,9 +541,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @return reserve0 The available liquidity for token0
     /// @return reserve1 The available liquidity for token1
     function getReserves() external view returns (uint256 reserve0, uint256 reserve1) {
-        // Liquidity reserved for queued redemptions, valued at current (loss-adjusted) share price.
-        uint256 outstandingShares = withdrawsQueued - withdrawsClaimed;
-        uint256 reservedAssets = outstandingShares == 0 ? 0 : convertToAssets(outstandingShares);
+        // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
+        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
 
         uint256 liquidityAssetsBalance = IERC20(liquidityAsset).balanceOf(address(this));
         address activeMarketMem = activeMarket;
@@ -698,6 +708,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         uint128 queued = SafeCast.toUint128(withdrawsQueued + shares);
         withdrawsQueued = queued;
 
+        // Cumulative ASSETS queued. Used for the cheap swap-side liquidity reservation
+        // (request.assets is an upper bound on the actual payout, by construction of the min cap).
+        withdrawsQueuedAssets = SafeCast.toUint128(withdrawsQueuedAssets + assets);
+
         uint40 claimTimestamp = uint40(block.timestamp + claimDelay);
 
         withdrawalRequests[requestId] = WithdrawalRequest({
@@ -747,8 +761,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
 
         withdrawalRequests[requestId].claimed = true;
-        // Cumulative claimed counter is in shares (matches the unit of withdrawsQueued and request.queued).
+        // Shares-denominated cumulative (matches withdrawsQueued and request.queued, used by the FIFO gate).
         withdrawsClaimed += request.shares;
+        // Assets-denominated cumulative incremented by request.assets (the upper bound), NOT by the
+        // actual capped payout. This keeps `withdrawsQueuedAssets - withdrawsClaimedAssets` a valid
+        // upper bound on the queue's remaining liability for the cheap swap-side reservation.
+        withdrawsClaimedAssets += request.assets;
 
         // Burn the escrowed shares now that they have been valued and are being paid out.
         // Doing this after computing `assets` keeps the conversion consistent.
@@ -800,13 +818,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     // There is no liquidity guarantee for the fee collector. If there is not enough liquidity assets (WETH) in
     // the ARM to collect the accrued fees, then the fee collector will have to wait until there is enough liquidity assets.
     function _requireLiquidityAvailable(uint256 amount) internal view {
-        // Outstanding shares queued for redemption, valued at current (loss-adjusted) share price.
-        uint256 outstandingShares = withdrawsQueued - withdrawsClaimed;
+        // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
+        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
 
-        // Save gas on the conversion and balanceOf call if there are no outstanding redemption shares
-        if (outstandingShares == 0) return;
-
-        uint256 reservedAssets = convertToAssets(outstandingShares);
+        // Save gas on the balanceOf call if there is nothing reserved for the queue
+        if (reservedAssets == 0) return;
 
         require(
             amount + reservedAssets <= IERC20(liquidityAsset).balanceOf(address(this)),
@@ -1056,11 +1072,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     }
 
     function _allocate() internal returns (int256 targetLiquidityDelta, int256 actualLiquidityDelta) {
-        (uint256 availableAssets, uint256 outstandingShares) = _availableAssets();
+        (uint256 availableAssets,) = _availableAssets();
         if (availableAssets == 0) return (0, 0);
 
-        // Reserved liquidity for queued redemptions, valued at current (loss-adjusted) share price.
-        uint256 reservedAssets = outstandingShares == 0 ? 0 : convertToAssets(outstandingShares);
+        // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
+        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
 
         // Net assets available after reserving for the queue. The buffer is sized against the net amount.
         uint256 netAvailable = availableAssets > reservedAssets ? availableAssets - reservedAssets : 0;

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -84,15 +84,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// This is also the price the base assets, eg stETH, in the ARM contract are priced at in `totalAssets`.
     uint256 public crossPrice;
 
-    /// @notice Cumulative `request.assets` ever queued in this ARM's withdrawal queue.
-    /// @dev Asset-denominated, same semantics as the original deployed contract. The pair
-    /// `withdrawsQueued - withdrawsClaimed` is an upper bound on the WETH the queue can still
-    /// withdraw (each payout is `min(request.assets, convertToAssets(shares)) ≤ request.assets`),
-    /// which lets the swap-side reservation avoid an expensive `convertToAssets` / Morpho call.
+    /// @notice Cumulative total of all withdrawal requests including the ones that have already been claimed.
     uint128 public withdrawsQueued;
-    /// @notice Cumulative `request.assets` ever claimed.
-    /// @dev Incremented by `request.assets` (the upper bound), NOT by the actual reduced payout,
-    /// so that the gap with `withdrawsQueued` stays a true upper bound on the queue's liability.
+    /// @notice Total of all the withdrawal requests that have been claimed.
     uint128 public withdrawsClaimed;
     /// @notice Index of the next withdrawal request starting at 0.
     uint256 public nextWithdrawalIndex;
@@ -102,13 +96,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         bool claimed;
         // When the withdrawal can be claimed
         uint40 claimTimestamp;
-        // Snapshot of the asset value of the redeemed shares at request time. Informational only.
-        // The actual payout at claim time uses the share price at that moment and may differ
-        // (lower if a loss occurred, higher if assets per share appreciated).
+        // Amount of liquidity assets to withdraw. eg WETH
         uint128 assets;
-        // Cumulative SHARES queued including this request, used for the FIFO gate.
+        // Cumulative shares queued including this request, used for the FIFO gate.
         uint128 queued;
-        // The amount of shares escrowed in the contract for this request. Burned at claim.
+        // The amount of shares that were escrowed at the time of this request.
         uint128 shares;
     }
 
@@ -142,13 +134,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Accrued swap fees denominated in the liquidity asset.
     uint128 public feesAccrued;
 
-    /// @notice Cumulative shares ever queued in this ARM's withdrawal queue.
-    /// @dev Shares-denominated, used by the FIFO gate at claim time
-    /// (`convertToAssets(request.queued - withdrawsClaimedShares) <= claimable()`).
-    /// New storage slot (added with the loss-sharing model).
+    /// @notice Cumulative shares queued for redemption, used by the FIFO gate in `claimRedeem`.
     uint128 public withdrawsQueuedShares;
-    /// @notice Cumulative shares ever claimed and burned.
-    /// @dev Shares-denominated mirror of `withdrawsClaimed`. New storage slot.
+    /// @notice Cumulative shares claimed (and burned). Mirror of `withdrawsClaimed` in shares.
     uint128 public withdrawsClaimedShares;
 
     uint256[34] private _gap;
@@ -385,11 +373,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param amount The amount of liquidity assets being sent out of the ARM.
     function _ensureLiquidityAvailableForSwap(uint256 amount) internal {
         uint256 liquidityBalance = IERC20(liquidityAsset).balanceOf(address(this));
-        // Upper bound on what the queue can still withdraw. Cheap (no convertToAssets / Morpho call):
-        // each payout is min(request.assets, convertToAssets(shares)) ≤ request.assets, so the cumulative
-        // request.assets gap is always ≥ the actual remaining liability.
-        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
-        uint256 requiredLiquidity = amount + reservedAssets;
+        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
+        uint256 requiredLiquidity = amount + outstandingWithdrawals;
 
         // If there is enough liquidity in the ARM to cover the swap after reserving liquidity for withdrawals
         if (requiredLiquidity <= liquidityBalance) return;
@@ -544,8 +529,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @return reserve0 The available liquidity for token0
     /// @return reserve1 The available liquidity for token1
     function getReserves() external view returns (uint256 reserve0, uint256 reserve1) {
-        // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
-        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
+        // The amount of liquidity assets (WETH) that is still to be claimed in the withdrawal queue
+        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
 
         uint256 liquidityAssetsBalance = IERC20(liquidityAsset).balanceOf(address(this));
         address activeMarketMem = activeMarket;
@@ -553,8 +538,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             liquidityAssetsBalance += IERC4626(activeMarketMem).maxWithdraw(address(this));
         }
 
-        // Ensure there is no negative reserves when reserved liquidity exceeds available liquidity
-        reserve0 = reservedAssets > liquidityAssetsBalance ? 0 : liquidityAssetsBalance - reservedAssets;
+        // Ensure there is no negative reserves when there are more outstanding withdrawals than liquidity assets in the ARM
+        reserve0 = outstandingWithdrawals > liquidityAssetsBalance ? 0 : liquidityAssetsBalance - outstandingWithdrawals;
         reserve1 = IERC20(baseAsset).balanceOf(address(this));
 
         // The previous assignment assumed token0 is be the liquidity asset.
@@ -661,11 +646,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @dev Internal logic for depositing liquidity assets in exchange for liquidity provider (LP) shares.
     function _deposit(uint256 assets, address receiver) internal returns (uint256 shares) {
-        // Safety guard: under the loss-sharing model, share price already reflects all outstanding claims
-        // (queued shares stay in totalSupply). The only pathological case is when totalAssets has hit the
-        // MIN_TOTAL_SUPPLY floor (near-total wipeout) AND there are still escrowed redemption shares;
-        // depositing then would be diluted to near zero. Block the deposit in that extreme case.
-        require(totalAssets() > MIN_TOTAL_SUPPLY || withdrawsQueuedShares == withdrawsClaimedShares, "ARM: insolvent");
+        // Do not allow deposits if the ARM can not meet all its withdrawal obligations.
+        require(totalAssets() > MIN_TOTAL_SUPPLY || withdrawsQueued == withdrawsClaimed, "ARM: insolvent");
 
         // Calculate the amount of shares to mint after accrued swap fees have been excluded,
         // and before new assets are deposited.
@@ -692,31 +674,29 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         assets = convertToAssets(shares);
     }
 
-    /// @notice Request to redeem liquidity provider shares for liquidity assets.
-    /// Shares are escrowed in the contract (not burned) and remain part of totalSupply()
-    /// so that any losses or gains between the request and the claim are absorbed pro-rata.
-    /// @param shares The amount of shares the redeemer wants to redeem
+    /// @notice Request to redeem liquidity provider shares for liquidity assets
+    /// @param shares The amount of shares the redeemer wants to burn for liquidity assets
     /// @return requestId The index of the withdrawal request
-    /// @return assets The asset value of the redeemed shares at request time. Informational only.
-    /// The actual payout at claim time will reflect the share price at that moment and may be
-    /// lower (after a loss) or higher (after appreciation).
+    /// @return assets The max amount of liquidity assets that will be claimable by the redeemer.
+    /// The amount can be less at claim time if ARM's assets per share has decreased. This can happen
+    /// from a significant slashing event on the base asset, eg stETH.
     function requestRedeem(uint256 shares) external returns (uint256 requestId, uint256 assets) {
-        // Snapshot of the asset value at request time. Informational; payout uses claim-time price.
+        // Calculate the amount of assets to transfer to the redeemer
         assets = convertToAssets(shares);
 
         requestId = nextWithdrawalIndex;
+        // Store the next withdrawal request
         nextWithdrawalIndex = requestId + 1;
 
-        // Cumulative SHARES queued including this request. Used for the FIFO gate at claim time.
+        // Cumulative shares queued including this request, used for the FIFO gate at claim
         uint128 queued = SafeCast.toUint128(withdrawsQueuedShares + shares);
         withdrawsQueuedShares = queued;
-
-        // Cumulative ASSETS queued. Used for the cheap swap-side liquidity reservation
-        // (request.assets is an upper bound on the actual payout, by construction of the min cap).
+        // Cumulative assets queued (upper bound on liability), used for the swap-side reservation
         withdrawsQueued = SafeCast.toUint128(withdrawsQueued + assets);
 
         uint40 claimTimestamp = uint40(block.timestamp + claimDelay);
 
+        // Store requests
         withdrawalRequests[requestId] = WithdrawalRequest({
             withdrawer: msg.sender,
             claimed: false,
@@ -726,8 +706,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             shares: SafeCast.toUint128(shares)
         });
 
-        // Escrow the redeemer's shares. They stay in totalSupply() so the share price keeps
-        // reflecting the full set of claims on the ARM, including this queued one.
+        // escrow redeemer's shares so they stay in totalSupply() and share losses/gains pro-rata
         _transfer(msg.sender, address(this), shares);
 
         emit RedeemRequested(msg.sender, requestId, assets, queued, claimTimestamp);
@@ -735,68 +714,63 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @notice Claim liquidity assets from a previous withdrawal request after the claim delay has passed.
     /// This will try and withdraw from the active lending market if there are not enough liquidity assets in the ARM.
-    /// The payout is the lower of `request.assets` (the snapshot at request time) and the current asset value
-    /// of the escrowed shares. This caps any upside accrued during the wait (which is redistributed to the
-    /// remaining LPs) while still passing on any loss pro-rata to the redeemer.
-    /// The FIFO gate prevents skipping ahead: this claim only succeeds if there is enough current liquidity
-    /// to also satisfy every earlier unclaimed request, valued at the same current share price.
+    /// If there is not enough liquidity in the ARM and lending market the transaction will revert.
+    /// If the lending market has enough liquidity but has high utilization preventing the withdrawal, the transaction will revert.
+    /// If the assets per shares has decreased since the redeem request, the asset value of the redeemed shares at claim is used.
     /// @param requestId The index of the withdrawal request
     /// @return assets The amount of liquidity assets that were transferred to the redeemer
     function claimRedeem(uint256 requestId) external returns (uint256 assets) {
+        // Load the struct from storage into memory
         WithdrawalRequest memory request = withdrawalRequests[requestId];
 
         require(request.claimTimestamp <= block.timestamp, "Claim delay not met");
+        // Is there enough liquidity in the ARM and lending market to claim this request?
+        // Pending shares are valued at the current (loss-adjusted) share price; matches the actual
+        // payout below in the loss case and is conservative in the gain case.
+        uint256 pendingShares = request.queued - withdrawsClaimedShares;
+        require(convertToAssets(pendingShares) <= claimable(), "Queue pending liquidity");
         require(request.withdrawer == msg.sender, "Not requester");
         require(request.claimed == false, "Already claimed");
 
-        // FIFO gate: enough current liquidity to satisfy every unclaimed earlier request and this one,
-        // valued at the current (loss-adjusted) share price. This is conservative for the gain case
-        // (overestimates payouts that are then capped at request.assets) but never causes a deadlock.
-        uint256 pendingShares = request.queued - withdrawsClaimedShares;
-        require(convertToAssets(pendingShares) <= claimable(), "Queue pending liquidity");
-
-        // Payout is min(request.assets, current value of the escrowed shares).
-        // - If the share price dropped: assets = current value (loss is absorbed pro-rata).
-        // - If the share price rose: assets = request.assets (upside is forfeited to remaining LPs).
-        // This removes the free-timing-option the redeemer would otherwise have between claimDelay
-        // expiry and an arbitrarily later claim moment.
+        // In the scenario where the ARM has made a loss from after the redeem request, the asset value of
+        // the redeemed shares at the time of the claim is used.
+        // This can happen if there was a significant slashing event on the base asset, eg stETH, after the redeem request was made.
         uint256 assetsAtClaim = convertToAssets(request.shares);
+        // Use the minimum of the asset value of the redeemed shares at request or claim.
         assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
 
+        // Store the request as claimed
         withdrawalRequests[requestId].claimed = true;
-        // Shares-denominated cumulative (matches withdrawsQueuedShares and request.queued, used by the FIFO gate).
+        // Cumulative claimed amount in assets (upper bound, used by the swap-side reservation)
+        withdrawsClaimed += SafeCast.toUint128(request.assets);
+        // Cumulative claimed amount in shares (used by the FIFO gate above)
         withdrawsClaimedShares += request.shares;
-        // Assets-denominated cumulative incremented by request.assets (the upper bound), NOT by the
-        // actual capped payout. This keeps `withdrawsQueued - withdrawsClaimed` a valid
-        // upper bound on the queue's remaining liability for the cheap swap-side reservation.
-        withdrawsClaimed += request.assets;
 
-        // Burn the escrowed shares now that they have been valued and are being paid out.
-        // Doing this after computing `assets` keeps the conversion consistent.
+        // Burn the escrowed shares (after `assets` was computed so the conversion stays consistent)
         _burn(address(this), request.shares);
 
         // If there is not enough liquidity assets in the ARM, get from the active market if one is configured.
+        // Read the active market address from storage once to save gas.
         address activeMarketMem = activeMarket;
         if (activeMarketMem != address(0)) {
             uint256 liquidityInARM = IERC20(liquidityAsset).balanceOf(address(this));
 
             if (assets > liquidityInARM) {
                 uint256 liquidityFromMarket = assets - liquidityInARM;
-                // This should work as we checked earlier that claimable() (= ARM balance + market) covers the claim
+                // This should work as we have checked earlier the claimable() amount which includes the active market
                 IERC4626(activeMarketMem).withdraw(liquidityFromMarket, address(this), address(this));
             }
         }
 
+        // transfer the liquidity asset to the withdrawer
         IERC20(liquidityAsset).transfer(msg.sender, assets);
 
         emit RedeemClaimed(msg.sender, requestId, assets);
     }
 
-    /// @notice The current liquidity available to satisfy redemption claims.
-    /// @return claimableAmount The ARM's liquidity asset balance plus what can be withdrawn from the active lending market.
-    /// @dev Compared in claimRedeem against `convertToAssets(pendingShares)` rather than a cumulative
-    /// asset counter, since under the loss-sharing model the queue is denominated in shares and revalued
-    /// at claim time.
+    /// @notice The liquidity currently available to satisfy a withdrawal request.
+    /// @return claimableAmount The liquidity in the ARM and that is withdrawable from the lending market.
+    /// Compared in `claimRedeem` against `convertToAssets(pendingShares)`.
     function claimable() public view returns (uint256 claimableAmount) {
         claimableAmount = IERC20(liquidityAsset).balanceOf(address(this));
 
@@ -813,37 +787,37 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     ///         Asset amount functions
     ////////////////////////////////////////////////////
 
-    /// @dev Checks if there is enough liquidity asset (WETH) in the ARM that is not reserved for the withdrawal queue.
+    /// @dev Checks if there is enough liquidity asset (WETH) in the ARM is not reserved for the withdrawal queue.
     // That is, the amount of liquidity assets (WETH) that is available to be swapped or collected as fees.
-    // If no outstanding shares are queued, no check will be done of the amount against the balance of the liquidity assets in the ARM.
+    // If no outstanding withdrawals, no check will be done of the amount against the balance of the liquidity assets in the ARM.
     // This is a gas optimization for swaps.
     // The ARM can swap out liquidity assets that are also used to collect accrued swap fees for the fee collector.
     // There is no liquidity guarantee for the fee collector. If there is not enough liquidity assets (WETH) in
     // the ARM to collect the accrued fees, then the fee collector will have to wait until there is enough liquidity assets.
     function _requireLiquidityAvailable(uint256 amount) internal view {
-        // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
-        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
+        // The amount of liquidity assets (WETH) that is still to be claimed in the withdrawal queue
+        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
 
-        // Save gas on the balanceOf call if there is nothing reserved for the queue
-        if (reservedAssets == 0) return;
+        // Save gas on an external balanceOf call if there are no outstanding withdrawals
+        if (outstandingWithdrawals == 0) return;
 
+        // If there is not enough liquidity assets in the ARM to cover the outstanding withdrawals and the amount
         require(
-            amount + reservedAssets <= IERC20(liquidityAsset).balanceOf(address(this)),
+            amount + outstandingWithdrawals <= IERC20(liquidityAsset).balanceOf(address(this)),
             "ARM: Insufficient liquidity"
         );
     }
 
-    /// @notice The gross economic value of assets in the ARM, active lending market and external withdrawal queue,
-    /// less only the accrued swap fees. Queued redemption shares are still part of totalSupply() so the share
-    /// price already reflects all outstanding claims; no separate subtraction is needed here.
+    /// @notice The economic value of assets in the ARM, active lending market and external withdrawal queue,
+    /// less the accrued swap fees. Queued redemption shares stay in totalSupply() so the share price
+    /// already reflects all outstanding claims; no subtraction for the queue is needed here.
     /// The active lending market is valued using ERC-4626 share conversion rather than current redeemable liquidity.
     /// @return The total amount of assets in the ARM
     function totalAssets() public view virtual returns (uint256) {
         (uint256 newAvailableAssets,) = _availableAssets();
 
-        // Floor at MIN_TOTAL_SUPPLY to prevent division by zero in convertToShares / convertToAssets.
-        // In the loss-sharing model, the floor only triggers in the extreme case where almost all assets
-        // have been wiped out. The pro-rata distribution still applies up to that point.
+        // total assets should only go up from the initial deposit amount that is burnt
+        // but in case of something unforeseen, return at least MIN_TOTAL_SUPPLY.
         uint256 feesAccruedMem = feesAccrued;
         if (feesAccruedMem + MIN_TOTAL_SUPPLY >= newAvailableAssets) return MIN_TOTAL_SUPPLY;
 
@@ -858,25 +832,22 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         return liquidityAsset;
     }
 
-    /// @dev Calculate the gross economic value of assets in the ARM, external withdrawal queue,
-    /// and active lending market. This does NOT subtract anything for the queued redemption shares:
-    /// those shares remain in totalSupply() under the loss-sharing model, so the share price already
-    /// represents the per-share value across all outstanding shares (free + escrowed for redemption).
+    /// @dev Calculate the economic value of assets in the ARM, external withdrawal queue,
+    /// and active lending market. Queued redemption shares stay in totalSupply() so no subtraction
+    /// for the withdrawal queue is needed; the share price already reflects all outstanding claims.
     /// The active lending market is valued using convertToAssets() so market valuation remains
     /// consistent across ERC-4626 implementations even when current redeemable liquidity differs.
     /// This does not exclude any accrued swap fees.
-    /// @return availableAssets Gross asset value owned by the ARM (all sources combined).
-    /// @return outstandingShares Cumulative shares queued but not yet claimed.
-    function _availableAssets() internal view returns (uint256 availableAssets, uint256 outstandingShares) {
+    function _availableAssets() internal view returns (uint256 availableAssets, uint256 outstandingWithdrawals) {
         // Convert the base assets in the ARM to the amount of liquidity assets
         uint256 baseConvertedToLiquid = _convert(baseAsset, IERC20(baseAsset).balanceOf(address(this)));
 
         // Liquidity assets, eg WETH, in the ARM and lending markets are valued at 1.0.
-        // Base assets, eg stETH, in the external withdrawal queue are valued at the amount of liquidity assets that are expected to be returned.
-        // Base assets, eg stETH, in the ARM are converted to liquidity assets and then the cross price applied. The cross price
+        // Base assets, eg stETH, in the withdrawal queue are valued at the amount of liquidity assets that are expected to be returned.
+        // Base assets, eg stETH, in the ARM is converted to liquidity assets and then the cross price applied. The cross price
         // is the discounted price for the redemption time delay. This ensures the ARM's assets per share does not decrease if the ARM
         // sells base assets at a discount (less than 1). That's because the base sell price is greater than or equal to the cross price.
-        uint256 assets = IERC20(liquidityAsset).balanceOf(address(this)) + _externalWithdrawQueue()
+        availableAssets = IERC20(liquidityAsset).balanceOf(address(this)) + _externalWithdrawQueue()
             + baseConvertedToLiquid * crossPrice / PRICE_SCALE;
 
         address activeMarketMem = activeMarket;
@@ -886,11 +857,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             // Add the economic value of assets in the active lending market.
             // Liquidity-aware functions such as claimable() and _allocate() continue to use maxWithdraw,
             // maxRedeem, withdraw and redeem when current liquidity matters.
-            assets += IERC4626(activeMarketMem).convertToAssets(allShares);
+            availableAssets += IERC4626(activeMarketMem).convertToAssets(allShares);
         }
 
-        outstandingShares = withdrawsQueuedShares - withdrawsClaimedShares;
-        availableAssets = assets;
+        // The amount of liquidity assets, eg WETH, reserved for the withdrawal queue (upper bound)
+        outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
     }
 
     /// @dev Hook for calculating the amount of liquidity assets in an external withdrawal queue like Lido or OETH.
@@ -1075,20 +1046,17 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     }
 
     function _allocate() internal returns (int256 targetLiquidityDelta, int256 actualLiquidityDelta) {
-        (uint256 availableAssets,) = _availableAssets();
+        (uint256 availableAssets, uint256 outstandingWithdrawals) = _availableAssets();
         if (availableAssets == 0) return (0, 0);
-
-        // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
-        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
-
-        // Net assets available after reserving for the queue. The buffer is sized against the net amount.
-        uint256 netAvailable = availableAssets > reservedAssets ? availableAssets - reservedAssets : 0;
+        // Net of the withdrawal queue (queued shares stay in totalSupply but the buffer is sized
+        // against the liquid assets that actually back free LP shares)
+        uint256 netAvailable = availableAssets > outstandingWithdrawals ? availableAssets - outstandingWithdrawals : 0;
         uint256 targetArmLiquidity = netAvailable * armBuffer / 1e18;
 
         // The current liquidity available in swap is the liquidity asset balance less
-        // the assets reserved for the ARM's withdrawal queue.
+        // any outstanding withdrawals from the ARM's withdrawal queue
         int256 currentArmLiquidity = SafeCast.toInt256(IERC20(liquidityAsset).balanceOf(address(this)))
-            - SafeCast.toInt256(reservedAssets);
+            - SafeCast.toInt256(outstandingWithdrawals);
 
         targetLiquidityDelta = currentArmLiquidity - SafeCast.toInt256(targetArmLiquidity);
 

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -84,11 +84,15 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// This is also the price the base assets, eg stETH, in the ARM contract are priced at in `totalAssets`.
     uint256 public crossPrice;
 
-    /// @notice Cumulative total of all redeemed shares ever queued in this ARM's withdrawal queue.
-    /// @dev Loss-sharing model: denominated in SHARES, not assets. Storage slot reused; semantics changed.
+    /// @notice Cumulative `request.assets` ever queued in this ARM's withdrawal queue.
+    /// @dev Asset-denominated, same semantics as the original deployed contract. The pair
+    /// `withdrawsQueued - withdrawsClaimed` is an upper bound on the WETH the queue can still
+    /// withdraw (each payout is `min(request.assets, convertToAssets(shares)) ≤ request.assets`),
+    /// which lets the swap-side reservation avoid an expensive `convertToAssets` / Morpho call.
     uint128 public withdrawsQueued;
-    /// @notice Cumulative total of all redeemed shares that have been claimed (and burned).
-    /// @dev Loss-sharing model: denominated in SHARES, not assets. Storage slot reused; semantics changed.
+    /// @notice Cumulative `request.assets` ever claimed.
+    /// @dev Incremented by `request.assets` (the upper bound), NOT by the actual reduced payout,
+    /// so that the gap with `withdrawsQueued` stays a true upper bound on the queue's liability.
     uint128 public withdrawsClaimed;
     /// @notice Index of the next withdrawal request starting at 0.
     uint256 public nextWithdrawalIndex;
@@ -138,15 +142,14 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Accrued swap fees denominated in the liquidity asset.
     uint128 public feesAccrued;
 
-    /// @notice Cumulative `request.assets` ever queued in this ARM's withdrawal queue.
-    /// @dev Asset-denominated mirror of `withdrawsQueued`, used for the swap-side liquidity reservation.
-    /// `withdrawsQueuedAssets - withdrawsClaimedAssets` is an upper bound on the WETH the queue can still
-    /// withdraw (each payout is min(request.assets, convertToAssets(shares)) ≤ request.assets), which lets
-    /// the swap path avoid an expensive convertToAssets / Morpho call.
-    uint128 public withdrawsQueuedAssets;
-    /// @notice Cumulative `request.assets` ever claimed (each claim increments by request.assets, NOT by
-    /// the actual reduced payout, so the difference with `withdrawsQueuedAssets` stays a true upper bound).
-    uint128 public withdrawsClaimedAssets;
+    /// @notice Cumulative shares ever queued in this ARM's withdrawal queue.
+    /// @dev Shares-denominated, used by the FIFO gate at claim time
+    /// (`convertToAssets(request.queued - withdrawsClaimedShares) <= claimable()`).
+    /// New storage slot (added with the loss-sharing model).
+    uint128 public withdrawsQueuedShares;
+    /// @notice Cumulative shares ever claimed and burned.
+    /// @dev Shares-denominated mirror of `withdrawsClaimed`. New storage slot.
+    uint128 public withdrawsClaimedShares;
 
     uint256[34] private _gap;
 
@@ -385,7 +388,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // Upper bound on what the queue can still withdraw. Cheap (no convertToAssets / Morpho call):
         // each payout is min(request.assets, convertToAssets(shares)) ≤ request.assets, so the cumulative
         // request.assets gap is always ≥ the actual remaining liability.
-        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
+        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
         uint256 requiredLiquidity = amount + reservedAssets;
 
         // If there is enough liquidity in the ARM to cover the swap after reserving liquidity for withdrawals
@@ -542,7 +545,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @return reserve1 The available liquidity for token1
     function getReserves() external view returns (uint256 reserve0, uint256 reserve1) {
         // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
-        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
+        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
 
         uint256 liquidityAssetsBalance = IERC20(liquidityAsset).balanceOf(address(this));
         address activeMarketMem = activeMarket;
@@ -662,7 +665,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // (queued shares stay in totalSupply). The only pathological case is when totalAssets has hit the
         // MIN_TOTAL_SUPPLY floor (near-total wipeout) AND there are still escrowed redemption shares;
         // depositing then would be diluted to near zero. Block the deposit in that extreme case.
-        require(totalAssets() > MIN_TOTAL_SUPPLY || withdrawsQueued == withdrawsClaimed, "ARM: insolvent");
+        require(totalAssets() > MIN_TOTAL_SUPPLY || withdrawsQueuedShares == withdrawsClaimedShares, "ARM: insolvent");
 
         // Calculate the amount of shares to mint after accrued swap fees have been excluded,
         // and before new assets are deposited.
@@ -705,12 +708,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         nextWithdrawalIndex = requestId + 1;
 
         // Cumulative SHARES queued including this request. Used for the FIFO gate at claim time.
-        uint128 queued = SafeCast.toUint128(withdrawsQueued + shares);
-        withdrawsQueued = queued;
+        uint128 queued = SafeCast.toUint128(withdrawsQueuedShares + shares);
+        withdrawsQueuedShares = queued;
 
         // Cumulative ASSETS queued. Used for the cheap swap-side liquidity reservation
         // (request.assets is an upper bound on the actual payout, by construction of the min cap).
-        withdrawsQueuedAssets = SafeCast.toUint128(withdrawsQueuedAssets + assets);
+        withdrawsQueued = SafeCast.toUint128(withdrawsQueued + assets);
 
         uint40 claimTimestamp = uint40(block.timestamp + claimDelay);
 
@@ -749,7 +752,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // FIFO gate: enough current liquidity to satisfy every unclaimed earlier request and this one,
         // valued at the current (loss-adjusted) share price. This is conservative for the gain case
         // (overestimates payouts that are then capped at request.assets) but never causes a deadlock.
-        uint256 pendingShares = request.queued - withdrawsClaimed;
+        uint256 pendingShares = request.queued - withdrawsClaimedShares;
         require(convertToAssets(pendingShares) <= claimable(), "Queue pending liquidity");
 
         // Payout is min(request.assets, current value of the escrowed shares).
@@ -761,12 +764,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
 
         withdrawalRequests[requestId].claimed = true;
-        // Shares-denominated cumulative (matches withdrawsQueued and request.queued, used by the FIFO gate).
-        withdrawsClaimed += request.shares;
+        // Shares-denominated cumulative (matches withdrawsQueuedShares and request.queued, used by the FIFO gate).
+        withdrawsClaimedShares += request.shares;
         // Assets-denominated cumulative incremented by request.assets (the upper bound), NOT by the
-        // actual capped payout. This keeps `withdrawsQueuedAssets - withdrawsClaimedAssets` a valid
+        // actual capped payout. This keeps `withdrawsQueued - withdrawsClaimed` a valid
         // upper bound on the queue's remaining liability for the cheap swap-side reservation.
-        withdrawsClaimedAssets += request.assets;
+        withdrawsClaimed += request.assets;
 
         // Burn the escrowed shares now that they have been valued and are being paid out.
         // Doing this after computing `assets` keeps the conversion consistent.
@@ -819,7 +822,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     // the ARM to collect the accrued fees, then the fee collector will have to wait until there is enough liquidity assets.
     function _requireLiquidityAvailable(uint256 amount) internal view {
         // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
-        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
+        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
 
         // Save gas on the balanceOf call if there is nothing reserved for the queue
         if (reservedAssets == 0) return;
@@ -886,7 +889,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             assets += IERC4626(activeMarketMem).convertToAssets(allShares);
         }
 
-        outstandingShares = withdrawsQueued - withdrawsClaimed;
+        outstandingShares = withdrawsQueuedShares - withdrawsClaimedShares;
         availableAssets = assets;
     }
 
@@ -1076,7 +1079,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         if (availableAssets == 0) return (0, 0);
 
         // Upper bound on the queue's remaining liability. See _ensureLiquidityAvailableForSwap.
-        uint256 reservedAssets = withdrawsQueuedAssets - withdrawsClaimedAssets;
+        uint256 reservedAssets = withdrawsQueued - withdrawsClaimed;
 
         // Net assets available after reserving for the queue. The buffer is sized against the net amount.
         uint256 netAvailable = availableAssets > reservedAssets ? availableAssets - reservedAssets : 0;

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -84,9 +84,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// This is also the price the base assets, eg stETH, in the ARM contract are priced at in `totalAssets`.
     uint256 public crossPrice;
 
-    /// @notice Cumulative total of all withdrawal requests including the ones that have already been claimed.
+    /// @notice Cumulative total of all redeemed shares ever queued in this ARM's withdrawal queue.
+    /// @dev Loss-sharing model: denominated in SHARES, not assets. Storage slot reused; semantics changed.
     uint128 public withdrawsQueued;
-    /// @notice Total of all the withdrawal requests that have been claimed.
+    /// @notice Cumulative total of all redeemed shares that have been claimed (and burned).
+    /// @dev Loss-sharing model: denominated in SHARES, not assets. Storage slot reused; semantics changed.
     uint128 public withdrawsClaimed;
     /// @notice Index of the next withdrawal request starting at 0.
     uint256 public nextWithdrawalIndex;
@@ -96,12 +98,13 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         bool claimed;
         // When the withdrawal can be claimed
         uint40 claimTimestamp;
-        // Amount of liquidity assets to withdraw. eg WETH
+        // Snapshot of the asset value of the redeemed shares at request time. Informational only.
+        // The actual payout at claim time uses the share price at that moment and may differ
+        // (lower if a loss occurred, higher if assets per share appreciated).
         uint128 assets;
-        // Cumulative total of all withdrawal requests including this one when the redeem request was made.
+        // Cumulative SHARES queued including this request, used for the FIFO gate.
         uint128 queued;
-        // The amount of shares that were burned at the time of this request.
-        // This has been added with a contract upgrade so may be zero for older requests.
+        // The amount of shares escrowed in the contract for this request. Burned at claim.
         uint128 shares;
     }
 
@@ -369,8 +372,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param amount The amount of liquidity assets being sent out of the ARM.
     function _ensureLiquidityAvailableForSwap(uint256 amount) internal {
         uint256 liquidityBalance = IERC20(liquidityAsset).balanceOf(address(this));
-        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
-        uint256 requiredLiquidity = amount + outstandingWithdrawals;
+        // Reserve liquidity for queued redemptions, valued at current (loss-adjusted) share price.
+        uint256 outstandingShares = withdrawsQueued - withdrawsClaimed;
+        uint256 reservedAssets = outstandingShares == 0 ? 0 : convertToAssets(outstandingShares);
+        uint256 requiredLiquidity = amount + reservedAssets;
 
         // If there is enough liquidity in the ARM to cover the swap after reserving liquidity for withdrawals
         if (requiredLiquidity <= liquidityBalance) return;
@@ -525,8 +530,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @return reserve0 The available liquidity for token0
     /// @return reserve1 The available liquidity for token1
     function getReserves() external view returns (uint256 reserve0, uint256 reserve1) {
-        // The amount of liquidity assets (WETH) that is still to be claimed in the withdrawal queue
-        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
+        // Liquidity reserved for queued redemptions, valued at current (loss-adjusted) share price.
+        uint256 outstandingShares = withdrawsQueued - withdrawsClaimed;
+        uint256 reservedAssets = outstandingShares == 0 ? 0 : convertToAssets(outstandingShares);
 
         uint256 liquidityAssetsBalance = IERC20(liquidityAsset).balanceOf(address(this));
         address activeMarketMem = activeMarket;
@@ -534,8 +540,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             liquidityAssetsBalance += IERC4626(activeMarketMem).maxWithdraw(address(this));
         }
 
-        // Ensure there is no negative reserves when there are more outstanding withdrawals than liquidity assets in the ARM
-        reserve0 = outstandingWithdrawals > liquidityAssetsBalance ? 0 : liquidityAssetsBalance - outstandingWithdrawals;
+        // Ensure there is no negative reserves when reserved liquidity exceeds available liquidity
+        reserve0 = reservedAssets > liquidityAssetsBalance ? 0 : liquidityAssetsBalance - reservedAssets;
         reserve1 = IERC20(baseAsset).balanceOf(address(this));
 
         // The previous assignment assumed token0 is be the liquidity asset.
@@ -642,7 +648,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @dev Internal logic for depositing liquidity assets in exchange for liquidity provider (LP) shares.
     function _deposit(uint256 assets, address receiver) internal returns (uint256 shares) {
-        // Do not allow deposits if the ARM can not meet all its withdrawal obligations.
+        // Safety guard: under the loss-sharing model, share price already reflects all outstanding claims
+        // (queued shares stay in totalSupply). The only pathological case is when totalAssets has hit the
+        // MIN_TOTAL_SUPPLY floor (near-total wipeout) AND there are still escrowed redemption shares;
+        // depositing then would be diluted to near zero. Block the deposit in that extreme case.
         require(totalAssets() > MIN_TOTAL_SUPPLY || withdrawsQueued == withdrawsClaimed, "ARM: insolvent");
 
         // Calculate the amount of shares to mint after accrued swap fees have been excluded,
@@ -670,27 +679,27 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         assets = convertToAssets(shares);
     }
 
-    /// @notice Request to redeem liquidity provider shares for liquidity assets
-    /// @param shares The amount of shares the redeemer wants to burn for liquidity assets
+    /// @notice Request to redeem liquidity provider shares for liquidity assets.
+    /// Shares are escrowed in the contract (not burned) and remain part of totalSupply()
+    /// so that any losses or gains between the request and the claim are absorbed pro-rata.
+    /// @param shares The amount of shares the redeemer wants to redeem
     /// @return requestId The index of the withdrawal request
-    /// @return assets The max amount of liquidity assets that will be claimable by the redeemer.
-    /// The amount can be less at claim time if ARM's assets per share has decreased. This can happen
-    /// from a significant slashing event on the base asset, eg stETH.
+    /// @return assets The asset value of the redeemed shares at request time. Informational only.
+    /// The actual payout at claim time will reflect the share price at that moment and may be
+    /// lower (after a loss) or higher (after appreciation).
     function requestRedeem(uint256 shares) external returns (uint256 requestId, uint256 assets) {
-        // Calculate the amount of assets to transfer to the redeemer
+        // Snapshot of the asset value at request time. Informational; payout uses claim-time price.
         assets = convertToAssets(shares);
 
         requestId = nextWithdrawalIndex;
-        // Store the next withdrawal request
         nextWithdrawalIndex = requestId + 1;
 
-        uint128 queued = SafeCast.toUint128(withdrawsQueued + assets);
-        // Store the updated queued amount which reserves liquidity assets (WETH) in the withdrawal queue
+        // Cumulative SHARES queued including this request. Used for the FIFO gate at claim time.
+        uint128 queued = SafeCast.toUint128(withdrawsQueued + shares);
         withdrawsQueued = queued;
 
         uint40 claimTimestamp = uint40(block.timestamp + claimDelay);
 
-        // Store requests
         withdrawalRequests[requestId] = WithdrawalRequest({
             withdrawer: msg.sender,
             claimed: false,
@@ -700,69 +709,69 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             shares: SafeCast.toUint128(shares)
         });
 
-        // burn redeemer's shares
-        _burn(msg.sender, shares);
+        // Escrow the redeemer's shares. They stay in totalSupply() so the share price keeps
+        // reflecting the full set of claims on the ARM, including this queued one.
+        _transfer(msg.sender, address(this), shares);
 
         emit RedeemRequested(msg.sender, requestId, assets, queued, claimTimestamp);
     }
 
     /// @notice Claim liquidity assets from a previous withdrawal request after the claim delay has passed.
     /// This will try and withdraw from the active lending market if there are not enough liquidity assets in the ARM.
-    /// If there is not enough liquidity in the ARM and lending market the transaction will revert.
-    /// If the lending market has enough liquidity but has high utilization preventing the withdrawal, the transaction will revert.
-    /// If the assets per shares has decreased since the redeem request, the asset value of the redeemed shares at claim is used.
+    /// The payout is the current (loss-adjusted) asset value of the redeemed shares: any loss or gain
+    /// between the request and the claim is absorbed pro-rata across all share holders.
+    /// The FIFO gate prevents skipping ahead: this claim only succeeds if there is enough current liquidity
+    /// to also satisfy every earlier unclaimed request, valued at the same current share price.
     /// @param requestId The index of the withdrawal request
     /// @return assets The amount of liquidity assets that were transferred to the redeemer
     function claimRedeem(uint256 requestId) external returns (uint256 assets) {
-        // Load the struct from storage into memory
         WithdrawalRequest memory request = withdrawalRequests[requestId];
 
         require(request.claimTimestamp <= block.timestamp, "Claim delay not met");
-        // Is there enough liquidity in the ARM and lending market to claim this request?
-        require(request.queued <= claimable(), "Queue pending liquidity");
         require(request.withdrawer == msg.sender, "Not requester");
         require(request.claimed == false, "Already claimed");
 
-        // In the scenario where the ARM has made a loss from after the redeem request, the asset value of
-        // the redeemed shares at the time of the claim is used.
-        // This can happen if there was a significant slashing event on the base asset, eg stETH, after the redeem request was made.
-        uint256 assetsAtClaim = request.shares > 0 ? convertToAssets(request.shares) : request.assets;
-        // Use the minimum of the asset value of the redeemed shares at request or claim.
-        assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
+        // FIFO gate: enough current liquidity to satisfy every unclaimed earlier request and this one,
+        // valued at the current (loss-adjusted) share price. This prevents claim ordering games while
+        // remaining consistent with the actual payout below (no phantom liquidity required).
+        uint256 pendingShares = request.queued - withdrawsClaimed;
+        require(convertToAssets(pendingShares) <= claimable(), "Queue pending liquidity");
 
-        // Store the request as claimed
+        // Payout is the current asset value of the redeemer's escrowed shares.
+        assets = convertToAssets(request.shares);
+
         withdrawalRequests[requestId].claimed = true;
-        // Store the updated claimed amount
-        // The asset value at the time of the request is used instead of the value at the time of claim
-        // as the queued amount used the value at the time of the request.
-        withdrawsClaimed += SafeCast.toUint128(request.assets);
+        // Cumulative claimed counter is in shares (matches the unit of withdrawsQueued and request.queued).
+        withdrawsClaimed += request.shares;
+
+        // Burn the escrowed shares now that they have been valued and are being paid out.
+        // Doing this after computing `assets` keeps the conversion consistent.
+        _burn(address(this), request.shares);
 
         // If there is not enough liquidity assets in the ARM, get from the active market if one is configured.
-        // Read the active market address from storage once to save gas.
         address activeMarketMem = activeMarket;
         if (activeMarketMem != address(0)) {
             uint256 liquidityInARM = IERC20(liquidityAsset).balanceOf(address(this));
 
             if (assets > liquidityInARM) {
                 uint256 liquidityFromMarket = assets - liquidityInARM;
-                // This should work as we have checked earlier the claimable() amount which includes the active market
+                // This should work as we checked earlier that claimable() (= ARM balance + market) covers the claim
                 IERC4626(activeMarketMem).withdraw(liquidityFromMarket, address(this), address(this));
             }
         }
 
-        // transfer the liquidity asset to the withdrawer
         IERC20(liquidityAsset).transfer(msg.sender, assets);
 
         emit RedeemClaimed(msg.sender, requestId, assets);
     }
 
-    /// @notice Used to work out if an ARM's withdrawal request can be claimed.
-    /// If the withdrawal request's `queued` amount is less than or equal to the returned `claimableAmount`, then
-    /// the withdrawal request can be claimed.
-    /// @return claimableAmount The ARM's already claimed withdrawal requests plus the liquidity in the ARM
-    /// and liquidity that is withdrawable from the lending market.
+    /// @notice The current liquidity available to satisfy redemption claims.
+    /// @return claimableAmount The ARM's liquidity asset balance plus what can be withdrawn from the active lending market.
+    /// @dev Compared in claimRedeem against `convertToAssets(pendingShares)` rather than a cumulative
+    /// asset counter, since under the loss-sharing model the queue is denominated in shares and revalued
+    /// at claim time.
     function claimable() public view returns (uint256 claimableAmount) {
-        claimableAmount = withdrawsClaimed + IERC20(liquidityAsset).balanceOf(address(this));
+        claimableAmount = IERC20(liquidityAsset).balanceOf(address(this));
 
         // if there is an active lending market, add to the claimable amount
         address activeMarketMem = activeMarket;
@@ -777,41 +786,39 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     ///         Asset amount functions
     ////////////////////////////////////////////////////
 
-    /// @dev Checks if there is enough liquidity asset (WETH) in the ARM is not reserved for the withdrawal queue.
+    /// @dev Checks if there is enough liquidity asset (WETH) in the ARM that is not reserved for the withdrawal queue.
     // That is, the amount of liquidity assets (WETH) that is available to be swapped or collected as fees.
-    // If no outstanding withdrawals, no check will be done of the amount against the balance of the liquidity assets in the ARM.
+    // If no outstanding shares are queued, no check will be done of the amount against the balance of the liquidity assets in the ARM.
     // This is a gas optimization for swaps.
     // The ARM can swap out liquidity assets that are also used to collect accrued swap fees for the fee collector.
     // There is no liquidity guarantee for the fee collector. If there is not enough liquidity assets (WETH) in
     // the ARM to collect the accrued fees, then the fee collector will have to wait until there is enough liquidity assets.
     function _requireLiquidityAvailable(uint256 amount) internal view {
-        // The amount of liquidity assets (WETH) that is still to be claimed in the withdrawal queue
-        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
+        // Outstanding shares queued for redemption, valued at current (loss-adjusted) share price.
+        uint256 outstandingShares = withdrawsQueued - withdrawsClaimed;
 
-        // Save gas on an external balanceOf call if there are no outstanding withdrawals
-        if (outstandingWithdrawals == 0) return;
+        // Save gas on the conversion and balanceOf call if there are no outstanding redemption shares
+        if (outstandingShares == 0) return;
 
-        // If there is not enough liquidity assets in the ARM to cover the outstanding withdrawals and the amount
+        uint256 reservedAssets = convertToAssets(outstandingShares);
+
         require(
-            amount + outstandingWithdrawals <= IERC20(liquidityAsset).balanceOf(address(this)),
+            amount + reservedAssets <= IERC20(liquidityAsset).balanceOf(address(this)),
             "ARM: Insufficient liquidity"
         );
     }
 
-    /// @notice The economic value of assets in the ARM, active lending market and external withdrawal queue,
-    /// less the liquidity assets reserved for the ARM's withdrawal queue and accrued swap fees.
+    /// @notice The gross economic value of assets in the ARM, active lending market and external withdrawal queue,
+    /// less only the accrued swap fees. Queued redemption shares are still part of totalSupply() so the share
+    /// price already reflects all outstanding claims; no separate subtraction is needed here.
     /// The active lending market is valued using ERC-4626 share conversion rather than current redeemable liquidity.
     /// @return The total amount of assets in the ARM
     function totalAssets() public view virtual returns (uint256) {
         (uint256 newAvailableAssets,) = _availableAssets();
 
-        // total assets should only go up from the initial deposit amount that is burnt
-        // but in case of something unforeseen, return at least MIN_TOTAL_SUPPLY.
-        // An example scenario that will return MIN_TOTAL_SUPPLY is:
-        // First LP deposits and then requests a redeem of all their ARM shares.
-        // While waiting to claim their request, the ARM suffer a loss of assets. eg lending market loss.
-        // When they claim their request, the newAvailableAssets will be zero as
-        // the ARM assets will be less than the outstanding withdrawal request that was calculated before the loss.
+        // Floor at MIN_TOTAL_SUPPLY to prevent division by zero in convertToShares / convertToAssets.
+        // In the loss-sharing model, the floor only triggers in the extreme case where almost all assets
+        // have been wiped out. The pro-rata distribution still applies up to that point.
         uint256 feesAccruedMem = feesAccrued;
         if (feesAccruedMem + MIN_TOTAL_SUPPLY >= newAvailableAssets) return MIN_TOTAL_SUPPLY;
 
@@ -826,18 +833,22 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         return liquidityAsset;
     }
 
-    /// @dev Calculate the economic value of assets in the ARM, external withdrawal queue,
-    /// and active lending market, less liquidity assets reserved for the ARM's withdrawal queue.
+    /// @dev Calculate the gross economic value of assets in the ARM, external withdrawal queue,
+    /// and active lending market. This does NOT subtract anything for the queued redemption shares:
+    /// those shares remain in totalSupply() under the loss-sharing model, so the share price already
+    /// represents the per-share value across all outstanding shares (free + escrowed for redemption).
     /// The active lending market is valued using convertToAssets() so market valuation remains
     /// consistent across ERC-4626 implementations even when current redeemable liquidity differs.
     /// This does not exclude any accrued swap fees.
-    function _availableAssets() internal view returns (uint256 availableAssets, uint256 outstandingWithdrawals) {
+    /// @return availableAssets Gross asset value owned by the ARM (all sources combined).
+    /// @return outstandingShares Cumulative shares queued but not yet claimed.
+    function _availableAssets() internal view returns (uint256 availableAssets, uint256 outstandingShares) {
         // Convert the base assets in the ARM to the amount of liquidity assets
         uint256 baseConvertedToLiquid = _convert(baseAsset, IERC20(baseAsset).balanceOf(address(this)));
 
         // Liquidity assets, eg WETH, in the ARM and lending markets are valued at 1.0.
-        // Base assets, eg stETH, in the withdrawal queue are valued at the amount of liquidity assets that are expected to be returned.
-        // Base assets, eg stETH, in the ARM is converted to liquidity assets and then the cross price applied. The cross price
+        // Base assets, eg stETH, in the external withdrawal queue are valued at the amount of liquidity assets that are expected to be returned.
+        // Base assets, eg stETH, in the ARM are converted to liquidity assets and then the cross price applied. The cross price
         // is the discounted price for the redemption time delay. This ensures the ARM's assets per share does not decrease if the ARM
         // sells base assets at a discount (less than 1). That's because the base sell price is greater than or equal to the cross price.
         uint256 assets = IERC20(liquidityAsset).balanceOf(address(this)) + _externalWithdrawQueue()
@@ -853,17 +864,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             assets += IERC4626(activeMarketMem).convertToAssets(allShares);
         }
 
-        // The amount of liquidity assets, eg WETH, that is still to be claimed in the withdrawal queue
-        outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
-
-        // If the ARM becomes insolvent enough that the available assets in the ARM and external withdrawal queue
-        // is less than the outstanding withdrawals and accrued fees.
-        if (assets < outstandingWithdrawals) {
-            return (0, outstandingWithdrawals);
-        }
-
-        // Need to remove the liquidity assets that have been reserved for the withdrawal queue
-        availableAssets = assets - outstandingWithdrawals;
+        outstandingShares = withdrawsQueued - withdrawsClaimed;
+        availableAssets = assets;
     }
 
     /// @dev Hook for calculating the amount of liquidity assets in an external withdrawal queue like Lido or OETH.
@@ -1048,14 +1050,20 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     }
 
     function _allocate() internal returns (int256 targetLiquidityDelta, int256 actualLiquidityDelta) {
-        (uint256 availableAssets, uint256 outstandingWithdrawals) = _availableAssets();
+        (uint256 availableAssets, uint256 outstandingShares) = _availableAssets();
         if (availableAssets == 0) return (0, 0);
-        uint256 targetArmLiquidity = availableAssets * armBuffer / 1e18;
+
+        // Reserved liquidity for queued redemptions, valued at current (loss-adjusted) share price.
+        uint256 reservedAssets = outstandingShares == 0 ? 0 : convertToAssets(outstandingShares);
+
+        // Net assets available after reserving for the queue. The buffer is sized against the net amount.
+        uint256 netAvailable = availableAssets > reservedAssets ? availableAssets - reservedAssets : 0;
+        uint256 targetArmLiquidity = netAvailable * armBuffer / 1e18;
 
         // The current liquidity available in swap is the liquidity asset balance less
-        // any outstanding withdrawals from the ARM's withdrawal queue
+        // the assets reserved for the ARM's withdrawal queue.
         int256 currentArmLiquidity = SafeCast.toInt256(IERC20(liquidityAsset).balanceOf(address(this)))
-            - SafeCast.toInt256(outstandingWithdrawals);
+            - SafeCast.toInt256(reservedAssets);
 
         targetLiquidityDelta = currentArmLiquidity - SafeCast.toInt256(targetArmLiquidity);
 

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -718,8 +718,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @notice Claim liquidity assets from a previous withdrawal request after the claim delay has passed.
     /// This will try and withdraw from the active lending market if there are not enough liquidity assets in the ARM.
-    /// The payout is the current (loss-adjusted) asset value of the redeemed shares: any loss or gain
-    /// between the request and the claim is absorbed pro-rata across all share holders.
+    /// The payout is the lower of `request.assets` (the snapshot at request time) and the current asset value
+    /// of the escrowed shares. This caps any upside accrued during the wait (which is redistributed to the
+    /// remaining LPs) while still passing on any loss pro-rata to the redeemer.
     /// The FIFO gate prevents skipping ahead: this claim only succeeds if there is enough current liquidity
     /// to also satisfy every earlier unclaimed request, valued at the same current share price.
     /// @param requestId The index of the withdrawal request
@@ -732,13 +733,18 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         require(request.claimed == false, "Already claimed");
 
         // FIFO gate: enough current liquidity to satisfy every unclaimed earlier request and this one,
-        // valued at the current (loss-adjusted) share price. This prevents claim ordering games while
-        // remaining consistent with the actual payout below (no phantom liquidity required).
+        // valued at the current (loss-adjusted) share price. This is conservative for the gain case
+        // (overestimates payouts that are then capped at request.assets) but never causes a deadlock.
         uint256 pendingShares = request.queued - withdrawsClaimed;
         require(convertToAssets(pendingShares) <= claimable(), "Queue pending liquidity");
 
-        // Payout is the current asset value of the redeemer's escrowed shares.
-        assets = convertToAssets(request.shares);
+        // Payout is min(request.assets, current value of the escrowed shares).
+        // - If the share price dropped: assets = current value (loss is absorbed pro-rata).
+        // - If the share price rose: assets = request.assets (upside is forfeited to remaining LPs).
+        // This removes the free-timing-option the redeemer would otherwise have between claimDelay
+        // expiry and an arbitrarily later claim moment.
+        uint256 assetsAtClaim = convertToAssets(request.shares);
+        assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
 
         withdrawalRequests[requestId].claimed = true;
         // Cumulative claimed counter is in shares (matches the unit of withdrawsQueued and request.queued).


### PR DESCRIPTION
## Context

A recent audit finding ([[OZ AI audit](https://github.com/33e84d46f53c80b49635fb2609928432?pvs=25#34584d46f53c808a83acf270cb3ed2b4)](/33e84d46f53c80b49635fb2609928432?pvs=25#34584d46f53c808a83acf270cb3ed2b4)) shows that the ARM withdrawal queue can become permanently unclaimable after a loss, because the FIFO gate is denominated in pre-loss assets while the payout is reduced by min(request.assets, convertToAssets(request.shares)). Before patching the bug, we need to step back and decide which loss-socialization model the ARM should follow. There are exactly two coherent options.

## Model A — Pro-rata loss sharing

- The redeemer's shares are escrowed (not burned) between request and claim. They remain part of `totalSupply()`.
- Any loss on ARM assets is absorbed proportionally by every share holder, queued or not.
- Any gain accrued between request and claim is forfeited to the remaining LPs at claim time.
- The payout at claim time is `min(request.assets, convertToAssets(shares))`: capped at the request-time snapshot, reduced if a loss happened.
- No "first to request" advantage. No bank-run incentive on bad news. No free-timing-option for the redeemer (the cap removes any reason to delay).
- Trade-off: the redeemer carries downside but keeps no upside during the wait.

## Model B — Senior debt queue

- `requestRedeem` locks in a fixed asset amount (`request.assets`).
- That amount is paid in full at claim time, regardless of subsequent losses.
- Losses are absorbed first by LPs still holding shares, then (if the loss is large enough) by the *last* requesters in the FIFO queue.
- Simple semantics for users and integrators: "you will receive X."
- Trade-off: any rumor of loss triggers a race to `requestRedeem` (bank run). Latecomers eat the loss in full.

The current ARM withdrawal queue uses a hybrid loss-handling model that mixes Model B accounting (burn at request, lock in `request.assets`) with a Model A-style payout reduction (`min(request.assets, convertToAssets(request.shares))`). This combination is the root cause of the audit finding "Withdrawal queue can become unclaimable after losses": the FIFO gate is denominated in pre-loss assets while the payout has been reduced, and `withdrawsClaimed` advances by the pre-loss amount — leaving a phantom liquidity gap that can permanently deadlock the queue.

Full discussion: https://www.notion.so/originprotocol/ARM-How-to-handle-losses-35784d46f53c80e18d70d78cab6c1d52

## What this PR is

This PR is **a reference implementation of Model A** (pro-rata loss sharing via escrow + claim-time pricing). It is meant to make the alternative concrete so the team can compare it side by side with Model B before deciding.

**Model B is the recommended fix** (see the doc). This PR is not the proposed merge path — it exists to ground the discussion.

## Behavioral changes

- Losses (and gains) between request and claim are absorbed pro-rata across every share holder, queued or not.
- No bank-run incentive on bad news: requesting redeem early no longer freezes a payout amount.
- The redeemer no longer sees a fixed `request.assets` — that field becomes a request-time estimate only.
- The FIFO deadlock from the audit finding disappears: the gate and the payout are denominated in the same unit at the same price.

## Code changes (single file: `src/contracts/AbstractARM.sol`)

- **Storage semantics.** `withdrawsQueued`, `withdrawsClaimed`, and `WithdrawalRequest.queued` are re-denominated from assets to **shares**. Storage layout preserved; meaning changed. ⚠ Upgrading a live deployment requires draining the queue first (non-zero pending values would be reinterpreted incorrectly).
- **`requestRedeem`** escrows shares via `_transfer(msg.sender, address(this), shares)` instead of `_burn`. Shares stay in `totalSupply()` so the share price reflects all outstanding claims.
- **`claimRedeem`** pays `convertToAssets(request.shares)` at claim time, burns the escrowed shares right after, and increments `withdrawsClaimed` by `request.shares`.
- **FIFO gate** is now `convertToAssets(pendingShares) <= claimable()`. Same unit, same price, no phantom liquidity gap.
- **`claimable()`** becomes a liquidity snapshot: `balance + maxWithdraw(activeMarket)`. The cumulative `withdrawsClaimed` term is gone.
- **`_availableAssets()`** returns gross assets (no subtraction for outstanding withdrawals). Outstanding shares are now part of `totalSupply()`, so the share price already accounts for them.
- **Liquidity reservation** is dynamic: `_requireLiquidityAvailable`, `_ensureLiquidityAvailableForSwap`, `getReserves`, `_allocate` compute reserved liquidity as `convertToAssets(outstandingShares)` at the current share price.

## Trade-off vs Model B

The main reason **not** to merge this PR is gas:

- `_ensureLiquidityAvailableForSwap` now calls `convertToAssets` → `totalAssets()` → `_availableAssets()` → on a Morpho-backed ARM, `IERC4626(morpho).convertToAssets(allShares)`.
- Morpho's `convertToAssets` is expensive (full market state read, interest accrual, several storage slots).
- Every buy-side swap with a non-empty queue pays this cost. The prior path was zero external calls beyond `balanceOf`.

For an ARM whose value proposition is cheap swaps, this is a meaningful recurring overhead.

## Tests

Tests are intentionally not updated. Many will fail because:

- `withdrawsQueued`/`withdrawsClaimed`/`request.queued` change unit (asset → share)
- The `RedeemRequested` event's `queued` field changes unit
- Payout behavior changes (pro-rata at claim time instead of `min`)

If we ever take this direction, tests would be updated in a follow-up.

## Status

**Reference / discussion. Do not merge.** The proposed fix for the audit finding is the minimal Model B change (drop the `min(...)` in `claimRedeem` so the FIFO gate and the payout become consistent again).