### PR TITLE
Pro-rata losses to redeemers and remaining LPs

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -362,7 +362,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             // base input expressed in liquidity terms, multiply by buyPrice to get liquidity output.
             amountOut = convertedAmountIn * config.buyPrice / PRICE_SCALE;
 
-            _accrueSwapFee(config.buyPrice, amountOut);
+            _accrueSwapFee(config.buyPrice, config.crossPrice, amountOut);
             _ensureLiquidityAvailableForSwap(amountOut);
         }
 
@@ -405,7 +405,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             // Divide the exact liquidity output by buyPrice to solve for the required base input.
             amountIn = convertedAmountOut * PRICE_SCALE / config.buyPrice + 3;
 
-            _accrueSwapFee(config.buyPrice, amountOut);
+            _accrueSwapFee(config.buyPrice, config.crossPrice, amountOut);
             _ensureLiquidityAvailableForSwap(amountOut);
         }
 
@@ -486,12 +486,13 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         return IAssetAdapter(config.adapter).convertToShares(assets);
     }
 
-    /// @dev Accrue fees on discounted buy-side swaps using the executed base buy price.
+    /// @dev Accrue fees on discounted buy-side swaps using the recognized NAV gain.
     /// @param buyPrice Price the ARM paid for the base asset.
+    /// @param crossPrice Price used to value the base asset in totalAssets().
     /// @param amountOut Liquidity asset amount paid out by the ARM.
-    function _accrueSwapFee(uint256 buyPrice, uint256 amountOut) internal {
+    function _accrueSwapFee(uint256 buyPrice, uint256 crossPrice, uint256 amountOut) internal {
         uint256 feeMultiplier =
-            buyPrice == 0 ? 0 : (PRICE_SCALE - buyPrice) * uint256(fee) * PRICE_SCALE / (buyPrice * FEE_SCALE);
+            buyPrice == 0 ? 0 : (crossPrice - buyPrice) * uint256(fee) * PRICE_SCALE / (buyPrice * FEE_SCALE);
         feesAccrued = SafeCast.toUint128(feesAccrued + amountOut * feeMultiplier / PRICE_SCALE);
     }
 

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -59,10 +59,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     uint256 internal _deprecatedTraderate1;
     uint256 internal _deprecatedCrossPrice;
 
-    /// @notice Cumulative total of all LP withdrawal requests, including claimed requests.
-    uint128 public withdrawsQueued;
-    /// @notice Cumulative total of all LP withdrawal requests that have been claimed.
-    uint128 public withdrawsClaimed;
+    /// @notice Maximum liquidity assets reserved for outstanding LP withdrawal requests.
+    /// @dev Reuses the legacy packed `withdrawsQueued`/`withdrawsClaimed` storage slot.
+    uint256 public reservedWithdrawLiquidity;
     /// @notice Index of the next LP withdrawal request.
     uint256 public nextWithdrawalIndex;
 
@@ -74,9 +73,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         uint40 claimTimestamp;
         /// @notice Liquidity assets requested at request time.
         uint128 assets;
-        /// @notice Cumulative queued liquidity assets including this request.
+        /// @notice Cumulative queued LP shares including this request.
         uint128 queued;
-        /// @notice LP shares burned when this request was made.
+        /// @notice LP shares escrowed when this request was made.
         uint128 shares;
     }
 
@@ -129,7 +128,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Base asset configuration. A zero adapter means unsupported.
     mapping(address asset => BaseAssetConfig) public baseAssetConfigs;
 
-    uint256[35] private _gap;
+    /// @notice Cumulative LP shares queued for redemption, used by the FIFO gate.
+    uint128 public withdrawsQueuedShares;
+    /// @notice Cumulative LP shares claimed and burned.
+    uint128 public withdrawsClaimedShares;
+
+    uint256[34] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Events
@@ -437,8 +441,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param amount Liquidity asset amount needed by the swap.
     function _ensureLiquidityAvailableForSwap(uint256 amount) internal {
         uint256 liquidityBalance = IERC20(liquidityAsset).balanceOf(address(this));
-        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
-        uint256 requiredLiquidity = amount + outstandingWithdrawals;
+        uint256 requiredLiquidity = amount + reservedWithdrawLiquidity;
         if (requiredLiquidity <= liquidityBalance) return;
 
         address activeMarketMem = activeMarket;
@@ -673,7 +676,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param receiver Account that receives minted LP shares.
     /// @return shares LP shares minted.
     function _deposit(uint256 assets, address receiver) internal returns (uint256 shares) {
-        require(totalAssets() > MIN_TOTAL_SUPPLY || withdrawsQueued == withdrawsClaimed, "ARM: insolvent");
+        require(totalAssets() > MIN_TOTAL_SUPPLY || reservedWithdrawLiquidity == 0, "ARM: insolvent");
         shares = convertToShares(assets);
 
         // Transfer liquidity from the depositor before minting LP shares.
@@ -706,9 +709,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         // Store the next withdrawal request id.
         nextWithdrawalIndex = requestId + 1;
 
-        // Reserve liquidity assets in the LP withdrawal queue.
-        uint128 queued = SafeCast.toUint128(withdrawsQueued + assets);
-        withdrawsQueued = queued;
+        // Cumulative shares queued including this request, used for the FIFO gate at claim.
+        uint128 queued = SafeCast.toUint128(withdrawsQueuedShares + shares);
+        withdrawsQueuedShares = queued;
+        // Reserve the request-time maximum liquidity payout.
+        reservedWithdrawLiquidity += assets;
 
         uint40 claimTimestamp = uint40(block.timestamp + claimDelay);
         withdrawalRequests[requestId] = WithdrawalRequest({
@@ -720,8 +725,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             shares: SafeCast.toUint128(shares)
         });
 
-        // Burn the redeemer's shares at request time.
-        _burn(msg.sender, shares);
+        // Escrow the redeemer's shares so they stay in totalSupply() and share losses/gains pro-rata.
+        _transfer(msg.sender, address(this), shares);
         emit RedeemRequested(msg.sender, requestId, assets, queued, claimTimestamp);
     }
 
@@ -747,9 +752,13 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
         // Store the request as claimed.
         withdrawalRequests[requestId].claimed = true;
-        // Store the updated claimed amount. The asset value at the time of the request is used instead of
-        // the value at the time of claim as the queued amount used the value at the time of the request.
-        withdrawsClaimed += SafeCast.toUint128(request.assets);
+        // Release the full request-time reservation, even when a loss-adjusted payout is lower.
+        reservedWithdrawLiquidity -= request.assets;
+        // Cumulative claimed amount in shares, used by the FIFO gate above.
+        withdrawsClaimedShares += request.shares;
+
+        // Burn the escrowed shares after `assets` was computed so conversion uses the pre-claim supply.
+        _burn(address(this), request.shares);
 
         // If there is not enough liquidity assets in the ARM, get from the active market if one is configured.
         // Read the active market address from storage once to save gas.
@@ -758,7 +767,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             uint256 liquidityInARM = IERC20(liquidityAsset).balanceOf(address(this));
             if (assets > liquidityInARM) {
                 uint256 liquidityFromMarket = assets - liquidityInARM;
-                // This should work as we have checked earlier the claimable() amount which includes the active market.
+                // This should work as we have checked earlier the claimable liquidity which includes the active market.
                 IERC4626(activeMarketMem).withdraw(liquidityFromMarket, address(this), address(this));
             }
         }
@@ -772,19 +781,20 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     ///                 Accounting
     ////////////////////////////////////////////////////
 
-    /// @notice Liquidity currently available to satisfy LP withdrawal claims.
-    /// @dev Includes claimed queue offset, on-hand liquidity, and currently withdrawable active market liquidity.
-    /// @return claimableAmount Claimed queue offset plus currently claimable liquidity.
-    function claimable() public view returns (uint256 claimableAmount) {
-        claimableAmount = withdrawsClaimed + IERC20(liquidityAsset).balanceOf(address(this));
+    /// @notice Cumulative share queue frontier currently backed by claimable liquidity.
+    /// @return claimableShares Requests with `queued <= claimableShares` can be claimed once their delay has elapsed.
+    function claimable() public view returns (uint256 claimableShares) {
+        uint256 claimableLiquidity = IERC20(liquidityAsset).balanceOf(address(this));
 
         // If there is an active lending market, add to the claimable amount.
         address activeMarketMem = activeMarket;
         if (activeMarketMem != address(0)) {
             // maxWithdraw is used as during periods of high utilization or temporary pauses,
             // maxWithdraw may return less than convertToAssets.
-            claimableAmount += IERC4626(activeMarketMem).maxWithdraw(address(this));
+            claimableLiquidity += IERC4626(activeMarketMem).maxWithdraw(address(this));
         }
+
+        claimableShares = withdrawsClaimedShares + convertToShares(claimableLiquidity);
     }
 
     /// @notice Get available liquidity and base asset reserves for a supported base asset.
@@ -798,7 +808,6 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     {
         require(baseAssetConfigs[reserveBaseAsset].adapter != address(0), "ARM: unsupported asset");
 
-        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
         liquidityAssets = IERC20(liquidityAsset).balanceOf(address(this));
 
         address activeMarketMem = activeMarket;
@@ -807,7 +816,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             liquidityAssets += IERC4626(activeMarketMem).maxWithdraw(address(this));
         }
 
-        liquidityAssets = outstandingWithdrawals > liquidityAssets ? 0 : liquidityAssets - outstandingWithdrawals;
+        uint256 reservedWithdrawLiquidityMem = reservedWithdrawLiquidity;
+        liquidityAssets =
+            reservedWithdrawLiquidityMem > liquidityAssets ? 0 : liquidityAssets - reservedWithdrawLiquidityMem;
         baseAssetReserve = IERC20(reserveBaseAsset).balanceOf(address(this));
     }
 
@@ -818,21 +829,21 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param amount Liquidity asset amount that must be unreserved.
     function _requireLiquidityAvailable(uint256 amount) internal view {
         // Liquidity assets still reserved for unclaimed LP withdrawal requests.
-        uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
+        uint256 reservedWithdrawLiquidityMem = reservedWithdrawLiquidity;
         // Save gas on an external balanceOf call if there are no outstanding withdrawals.
-        if (outstandingWithdrawals == 0) return;
+        if (reservedWithdrawLiquidityMem == 0) return;
 
         // Ensure the ARM can cover both the requested amount and outstanding LP withdrawals.
         require(
-            amount + outstandingWithdrawals <= IERC20(liquidityAsset).balanceOf(address(this)),
+            amount + reservedWithdrawLiquidityMem <= IERC20(liquidityAsset).balanceOf(address(this)),
             "ARM: Insufficient liquidity"
         );
     }
 
-    /// @notice Economic value of ARM assets net of LP withdrawal obligations and accrued swap fees.
+    /// @notice Economic value of ARM assets net of accrued swap fees.
     /// @return Total liquidity-denominated assets available to LP shares.
     function totalAssets() public view virtual returns (uint256) {
-        (uint256 newAvailableAssets,) = _availableAssets();
+        uint256 newAvailableAssets = _availableAssets();
         uint256 feesAccruedMem = feesAccrued;
         // total assets should only go up from the initial deposit amount that is burnt,
         // but in case of something unforeseen, return at least MIN_TOTAL_SUPPLY.
@@ -855,10 +866,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @dev Calculate ARM asset value before accrued swap fees are removed.
     /// Includes on-hand liquidity, active market value, base balances valued at cross price, and adapter queues.
-    /// @return availableAssets Liquidity-denominated assets after LP withdrawal obligations.
-    /// @return outstandingWithdrawals Liquidity assets reserved for unclaimed LP withdrawal requests.
-    function _availableAssets() internal view returns (uint256 availableAssets, uint256 outstandingWithdrawals) {
-        uint256 assets = IERC20(liquidityAsset).balanceOf(address(this));
+    /// Queued redemption shares stay in totalSupply(), so the share price already reflects outstanding claims.
+    /// @return availableAssets Liquidity-denominated assets before accrued swap fees.
+    function _availableAssets() internal view returns (uint256 availableAssets) {
+        availableAssets = IERC20(liquidityAsset).balanceOf(address(this));
 
         uint256 length = baseAssets.length;
         for (uint256 i = 0; i < length; ++i) {
@@ -870,10 +881,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             // sell price is greater than or equal to the cross price.
             uint256 baseConvertedToLiquid =
                 _convertToAssets(config, IERC20(supportedBaseAsset).balanceOf(address(this)));
-            assets += baseConvertedToLiquid * config.crossPrice / PRICE_SCALE;
+            availableAssets += baseConvertedToLiquid * config.crossPrice / PRICE_SCALE;
             // Pending adapter redemptions are already tracked in liquidity terms and represent assets
             // expected back from protocol withdrawal queues.
-            assets += config.pendingRedeemAssets;
+            availableAssets += config.pendingRedeemAssets;
         }
 
         address activeMarketMem = activeMarket;
@@ -883,16 +894,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             // Value active market shares economically, not by currently withdrawable liquidity.
             // Liquidity-aware functions such as claimable() and _allocate() continue to use maxWithdraw,
             // maxRedeem, withdraw and redeem when current liquidity matters.
-            assets += IERC4626(activeMarketMem).convertToAssets(allShares);
+            availableAssets += IERC4626(activeMarketMem).convertToAssets(allShares);
         }
-
-        // The amount of liquidity assets that is still to be claimed in the LP withdrawal queue.
-        outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
-        // If the ARM becomes insolvent enough that assets are less than outstanding withdrawals,
-        // report zero available assets and keep the outstanding withdrawal amount for allocation logic.
-        if (assets < outstandingWithdrawals) return (0, outstandingWithdrawals);
-        // Remove liquidity assets reserved for the LP withdrawal queue.
-        availableAssets = assets - outstandingWithdrawals;
     }
 
     /// @notice Convert liquidity assets to LP shares.
@@ -1037,14 +1040,14 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @return targetLiquidityDelta Desired liquidity movement. Positive means deposit, negative means withdraw.
     /// @return actualLiquidityDelta Actual liquidity movement. Positive means deposited, negative means withdrawn.
     function _allocate() internal returns (int256 targetLiquidityDelta, int256 actualLiquidityDelta) {
-        (uint256 availableAssets, uint256 outstandingWithdrawals) = _availableAssets();
+        uint256 availableAssets = _availableAssets();
         if (availableAssets == 0) return (0, 0);
 
         uint256 targetArmLiquidity = availableAssets * armBuffer / 1e18;
         // The current liquidity available to swap is the liquidity asset balance less
         // any outstanding withdrawals from the ARM's withdrawal queue.
         int256 currentArmLiquidity = SafeCast.toInt256(IERC20(liquidityAsset).balanceOf(address(this)))
-            - SafeCast.toInt256(outstandingWithdrawals);
+            - SafeCast.toInt256(reservedWithdrawLiquidity);
 
         targetLiquidityDelta = currentArmLiquidity - SafeCast.toInt256(targetArmLiquidity);
 
@@ -1103,5 +1106,20 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         require(_armBuffer <= 1e18, "ARM: invalid arm buffer");
         armBuffer = _armBuffer;
         emit ARMBufferUpdated(_armBuffer);
+    }
+
+    /// @notice Clear the legacy packed asset queue counter slot during the Model A upgrade.
+    /// @dev The reused slot previously packed `withdrawsQueued` in the low 128 bits and
+    /// `withdrawsClaimed` in the high 128 bits. It may be nonzero even when the old queue
+    /// is fully drained, so upgrade scripts should call this with `upgradeToAndCall`.
+    function migrateLegacyWithdrawQueue() external onlyOwner {
+        require(withdrawsQueuedShares == 0 && withdrawsClaimedShares == 0, "ARM: already migrated");
+
+        uint256 packedLegacyQueue = reservedWithdrawLiquidity;
+        uint128 legacyQueued = uint128(packedLegacyQueue);
+        uint128 legacyClaimed = uint128(packedLegacyQueue >> 128);
+        require(legacyQueued == legacyClaimed, "ARM: legacy withdrawals pending");
+
+        reservedWithdrawLiquidity = 0;
     }
 }

--- a/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
@@ -89,8 +89,8 @@ contract Fork_Concrete_EthenaARM_swapExactTokensForTokens_Test_ is Fork_Shared_T
         // Precompute expected amount out
         uint256 traderate = _buyPrice();
         uint256 expectedAmountOut = (susde.convertToAssets(AMOUNT_IN) * traderate) / 1e36;
-        uint256 expectedFee =
-            expectedAmountOut * _swapFeeMultiplier(_buyPrice(), ethenaARM.fee()) / ethenaARM.PRICE_SCALE();
+        uint256 expectedFee = expectedAmountOut * _swapFeeMultiplier(_buyPrice(), _crossPrice(), ethenaARM.fee())
+            / ethenaARM.PRICE_SCALE();
 
         // Expected events
         vm.expectEmit({emitter: address(susde)});

--- a/test/fork/EthenaARM/shared/Shared.sol
+++ b/test/fork/EthenaARM/shared/Shared.sol
@@ -119,10 +119,15 @@ abstract contract Fork_Shared_Test is Base_Test_ {
         sellPrice = sellPriceMem;
     }
 
-    function _swapFeeMultiplier(uint256 buyPrice, uint256 fee) internal view returns (uint256) {
+    function _crossPrice() internal view returns (uint256 crossPrice) {
+        (,,,, uint128 crossPriceMem,,,) = ethenaARM.baseAssetConfigs(address(susde));
+        crossPrice = crossPriceMem;
+    }
+
+    function _swapFeeMultiplier(uint256 buyPrice, uint256 crossPrice, uint256 fee) internal view returns (uint256) {
         uint256 priceScale = ethenaARM.PRICE_SCALE();
         if (buyPrice == 0 || fee == 0) return 0;
-        return (priceScale - buyPrice) * fee * priceScale / (buyPrice * ethenaARM.FEE_SCALE());
+        return (crossPrice - buyPrice) * fee * priceScale / (buyPrice * ethenaARM.FEE_SCALE());
     }
 
     function _ignite() internal virtual {

--- a/test/fork/LidoARM/ClaimRedeem.t.sol
+++ b/test/fork/LidoARM/ClaimRedeem.t.sol
@@ -58,7 +58,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         lidoARM.claimRedeem(0);
     }
 
-    function test_RevertWhen_ClaimRequest_Because_QueuePendingLiquidity_NoEnoughLiquidity()
+    function test_ClaimRequest_WithLossAdjustedLiquidity()
         public
         setTotalAssetsCap(DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY)
         setLiquidityProviderCap(address(this), DEFAULT_AMOUNT)
@@ -72,9 +72,11 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         // Time jump claim delay
         skip(delay);
 
-        // Expect revert
-        vm.expectRevert("Queue pending liquidity");
-        lidoARM.claimRedeem(0);
+        uint256 assets = lidoARM.claimRedeem(0);
+
+        assertLt(assets, DEFAULT_AMOUNT, "loss-adjusted payout");
+        assertEq(lidoARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(lidoARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "claimed shares");
     }
 
     function test_RevertWhen_ClaimRequest_Because_NotRequester()
@@ -124,9 +126,10 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(_lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, 2);
+        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT, 2);
         assertEq(lidoARM.balanceOf(address(this)), 0);
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
+        assertEq(lidoARM.balanceOf(address(lidoARM)), DEFAULT_AMOUNT);
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
         assertEqQueueMetadata(DEFAULT_AMOUNT, 0, 1);
         assertEqUserRequest(0, address(this), false, block.timestamp, DEFAULT_AMOUNT, DEFAULT_AMOUNT, DEFAULT_AMOUNT);
@@ -150,7 +153,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
-        assertEqQueueMetadata(DEFAULT_AMOUNT, DEFAULT_AMOUNT, 1);
+        assertEqQueueMetadata(0, DEFAULT_AMOUNT, 1);
         assertEqUserRequest(0, address(this), true, block.timestamp, DEFAULT_AMOUNT, DEFAULT_AMOUNT, DEFAULT_AMOUNT);
         assertEq(assets, DEFAULT_AMOUNT);
         assertEq(lidoARM.claimable(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
@@ -168,7 +171,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         // Same situation as above
 
         // Swap MIN_TOTAL_SUPPLY from WETH in STETH
-        deal(address(weth), address(lidoARM), DEFAULT_AMOUNT);
+        deal(address(weth), address(lidoARM), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY);
         deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY);
 
         // Handle lido rounding issue to ensure that balance is exactly MIN_TOTAL_SUPPLY
@@ -188,14 +191,14 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
 
         // Assertions after
         assertApproxEqAbs(steth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY, 2);
-        assertEq(weth.balanceOf(address(lidoARM)), 0);
+        assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY);
         assertEq(_lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, 2);
+        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY * 2, STETH_ERROR_ROUNDING);
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
-        assertEqQueueMetadata(DEFAULT_AMOUNT, DEFAULT_AMOUNT, 1);
+        assertEqQueueMetadata(0, DEFAULT_AMOUNT, 1);
         assertEqUserRequest(0, address(this), true, block.timestamp, DEFAULT_AMOUNT, DEFAULT_AMOUNT, DEFAULT_AMOUNT);
         assertEq(assets, DEFAULT_AMOUNT);
     }
@@ -215,11 +218,12 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT / 2);
         assertEq(_lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY));
+        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT / 2));
         assertEq(lidoARM.balanceOf(address(this)), 0);
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
+        assertEq(lidoARM.balanceOf(address(lidoARM)), DEFAULT_AMOUNT / 2);
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT / 2);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
-        assertEqQueueMetadata(DEFAULT_AMOUNT, DEFAULT_AMOUNT / 2, 2);
+        assertEqQueueMetadata(DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT / 2, 2);
         assertEqUserRequest(
             0, address(this), true, block.timestamp, DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT / 2
         );
@@ -247,7 +251,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.balanceOf(address(this)), 0);
         assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
-        assertEqQueueMetadata(DEFAULT_AMOUNT, DEFAULT_AMOUNT, 2);
+        assertEqQueueMetadata(0, DEFAULT_AMOUNT, 2);
         assertEqUserRequest(
             0, address(this), true, block.timestamp - delay, DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT / 2
         );

--- a/test/fork/LidoARM/Deposit.t.sol
+++ b/test/fork/LidoARM/Deposit.t.sol
@@ -333,7 +333,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
     /// @dev No fees accrued, withdrawal queue shortfall, and no performance fees generated
     function test_Deposit_NoFeesAccrued_WithdrawalRequestsOutstanding_SecondDepositDiffUser_NoPerfs()
         public
-        setTotalAssetsCap(DEFAULT_AMOUNT * 3 + MIN_TOTAL_SUPPLY)
+        setTotalAssetsCap(DEFAULT_AMOUNT * 3 + MIN_TOTAL_SUPPLY + STETH_ERROR_ROUNDING)
         setLiquidityProviderCap(address(this), DEFAULT_AMOUNT)
         setLiquidityProviderCap(alice, DEFAULT_AMOUNT * 5)
         depositInLidoARM(address(this), DEFAULT_AMOUNT)
@@ -379,13 +379,18 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued before deposit");
         assertApproxEqAbs(
             int256(lidoARM.totalAssets()),
-            int256(MIN_TOTAL_SUPPLY),
+            int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + 2),
             STETH_ERROR_ROUNDING,
             "last available assets before"
         );
         assertEq(lidoARM.balanceOf(alice), 0, "alice shares before deposit");
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply before deposit");
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + 1, "total assets before deposit");
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + firstUserShares, "total supply before deposit");
+        assertApproxEqAbs(
+            lidoARM.totalAssets(),
+            MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + 2,
+            STETH_ERROR_ROUNDING,
+            "total assets before deposit"
+        );
         if (ac) assertEq(capManager.liquidityProviderCaps(alice), DEFAULT_AMOUNT * 5, "lp cap before deposit");
         assertEqQueueMetadata(assetsRedeem, 0, 1);
         assertApproxEqAbs(assetsRedeem, DEFAULT_AMOUNT, STETH_ERROR_ROUNDING, "assets redeem before deposit");
@@ -393,7 +398,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         uint256 amount = DEFAULT_AMOUNT * 2;
 
         // Expected values
-        uint256 expectedShares = amount * MIN_TOTAL_SUPPLY / (MIN_TOTAL_SUPPLY + 1);
+        uint256 expectedShares = amount * lidoARM.totalSupply() / lidoARM.totalAssets();
 
         // Expected events
         vm.expectEmit({emitter: address(weth)});
@@ -418,13 +423,20 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.feesAccrued(), 0, "Fees accrued after deposit"); // No perfs so no fees
         assertApproxEqAbs(
             int256(lidoARM.totalAssets()),
-            int256(MIN_TOTAL_SUPPLY + amount),
+            int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + amount + 2),
             STETH_ERROR_ROUNDING,
             "last available assets after deposit"
         );
         assertEq(lidoARM.balanceOf(alice), shares, "alice shares after deposit");
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + expectedShares, "total supply after deposit");
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY + amount + 1, "total assets after deposit");
+        assertEq(
+            lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + firstUserShares + expectedShares, "total supply after deposit"
+        );
+        assertApproxEqAbs(
+            lidoARM.totalAssets(),
+            MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT + amount + 2,
+            STETH_ERROR_ROUNDING,
+            "total assets after deposit"
+        );
         if (ac) assertEq(capManager.liquidityProviderCaps(alice), DEFAULT_AMOUNT * 3, "alice cap after deposit"); // All the caps are used
         // withdrawal request is now claimable
         assertEqQueueMetadata(assetsRedeem, 0, 1);
@@ -509,12 +521,14 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
             weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 2, "ARM WETH balance after redeem"
         );
         assertEq(_lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue after redeem");
-        assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply after redeem");
-        assertApproxEqRel(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, 1e6, "total assets after redeem");
+        assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit + shares, "total supply after redeem");
+        assertApproxEqRel(
+            lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT, 1e6, "total assets after redeem"
+        );
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after redeem");
         assertApproxEqAbs(
             int256(lidoARM.totalAssets()),
-            int256(expectTotalAssetsBeforeDeposit),
+            int256(expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT),
             4e6,
             "last available assets after redeem"
         );
@@ -526,12 +540,17 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         lidoARM.collectFees();
 
         // Assertions after collect fees
-        assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit, "total supply after collect fees");
-        assertApproxEqRel(lidoARM.totalAssets(), expectTotalAssetsBeforeDeposit, 1e6, "total assets after collect fees");
+        assertEq(lidoARM.totalSupply(), expectedTotalSupplyBeforeDeposit + shares, "total supply after collect fees");
+        assertApproxEqRel(
+            lidoARM.totalAssets(),
+            expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT,
+            1e6,
+            "total assets after collect fees"
+        );
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after collect fees");
         assertApproxEqAbs(
             int256(lidoARM.totalAssets()),
-            int256(expectTotalAssetsBeforeDeposit),
+            int256(expectTotalAssetsBeforeDeposit + DEFAULT_AMOUNT),
             4e6,
             "last available assets after collect fees"
         );
@@ -574,9 +593,10 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(_lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY));
+        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT));
         assertEq(lidoARM.balanceOf(address(this)), 0); // Ensure no shares after
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY); // Minted to dead on deploy
+        assertEq(lidoARM.balanceOf(address(lidoARM)), shares);
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + shares); // Escrowed redeem shares remain in supply.
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // All the caps are used
         assertEqQueueMetadata(receivedAssets, 0, 1);
         assertEq(receivedAssets, DEFAULT_AMOUNT, "received assets");
@@ -637,13 +657,13 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued after redeem");
         assertApproxEqAbs(
             int256(lidoARM.totalAssets()),
-            // initial assets + user deposit + claimed asset gain - redeemed user assets
-            int256(MIN_TOTAL_SUPPLY + 2 * DEFAULT_AMOUNT) - int256(DEFAULT_AMOUNT + userBenef),
+            int256(MIN_TOTAL_SUPPLY + 2 * DEFAULT_AMOUNT),
             STETH_ERROR_ROUNDING,
             "last available assets after redeem"
         );
         assertEq(lidoARM.balanceOf(address(this)), 0, "user shares after"); // Ensure no shares after
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply after"); // Minted to dead on deploy
+        assertEq(lidoARM.balanceOf(address(lidoARM)), shares, "escrowed shares after");
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + shares, "total supply after"); // Escrowed redeem shares remain in supply.
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0, "user cap"); // All the caps are used
         assertEqQueueMetadata(receivedAssets, 0, 1);
     }

--- a/test/fork/LidoARM/RequestRedeem.t.sol
+++ b/test/fork/LidoARM/RequestRedeem.t.sol
@@ -46,7 +46,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         uint256 delay = lidoARM.claimDelay();
 
         vm.expectEmit({emitter: address(lidoARM)});
-        emit IERC20.Transfer(address(this), address(0), DEFAULT_AMOUNT);
+        emit IERC20.Transfer(address(this), address(lidoARM), DEFAULT_AMOUNT);
         vm.expectEmit({emitter: address(lidoARM)});
         emit AbstractARM.RedeemRequested(address(this), 0, DEFAULT_AMOUNT, DEFAULT_AMOUNT, block.timestamp + delay);
         // Main Call
@@ -63,9 +63,10 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(_lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY));
+        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT));
         assertEq(lidoARM.balanceOf(address(this)), 0);
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
+        assertEq(lidoARM.balanceOf(address(lidoARM)), DEFAULT_AMOUNT);
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
     }
 
@@ -82,16 +83,17 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(_lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 3 / 4));
+        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT * 3 / 4);
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 3 / 4);
+        assertEq(lidoARM.balanceOf(address(lidoARM)), DEFAULT_AMOUNT / 4);
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // Down only
         assertEqQueueMetadata(DEFAULT_AMOUNT / 4, 0, 1);
 
         uint256 delay = lidoARM.claimDelay();
 
         vm.expectEmit({emitter: address(lidoARM)});
-        emit IERC20.Transfer(address(this), address(0), DEFAULT_AMOUNT / 2);
+        emit IERC20.Transfer(address(this), address(lidoARM), DEFAULT_AMOUNT / 2);
         vm.expectEmit({emitter: address(lidoARM)});
         emit AbstractARM.RedeemRequested(
             address(this), 1, DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT * 3 / 4, block.timestamp + delay
@@ -116,9 +118,10 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         assertEq(_lidoWithdrawalQueueAmount(), 0);
         assertEq(lidoARM.feesAccrued(), 0); // No perfs so no fees
-        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 1 / 4));
+        assertEq(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT));
         assertEq(lidoARM.balanceOf(address(this)), DEFAULT_AMOUNT * 1 / 4);
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 1 / 4);
+        assertEq(lidoARM.balanceOf(address(lidoARM)), DEFAULT_AMOUNT * 3 / 4);
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0); // Down only
     }
 
@@ -140,7 +143,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
 
         // Expected Events
         vm.expectEmit({emitter: address(lidoARM)});
-        emit IERC20.Transfer(address(this), address(0), DEFAULT_AMOUNT);
+        emit IERC20.Transfer(address(this), address(lidoARM), DEFAULT_AMOUNT);
 
         // Main call
         (, uint256 actualAssetsFromRedeem) = lidoARM.requestRedeem(DEFAULT_AMOUNT);
@@ -156,14 +159,10 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), assetsAfterGain);
         assertEq(_lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue");
         assertEq(lidoARM.feesAccrued(), expectedFeeAccrued, "fees accrued");
-        assertApproxEqAbs(
-            int256(lidoARM.totalAssets()),
-            int256(assetsAfterGain) - int256(expectedAssetsFromRedeem),
-            1,
-            "last available assets after"
-        ); // 1 wei of error
+        assertApproxEqAbs(int256(lidoARM.totalAssets()), int256(assetsAfterGain), 1, "last available assets after"); // 1 wei of error
         assertEq(lidoARM.balanceOf(address(this)), 0);
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY);
+        assertEq(lidoARM.balanceOf(address(lidoARM)), DEFAULT_AMOUNT);
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
         assertEqQueueMetadata(expectedAssetsFromRedeem, 0, 1);
         assertEqUserRequest(
@@ -172,7 +171,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
             false,
             block.timestamp + lidoARM.claimDelay(),
             expectedAssetsFromRedeem,
-            expectedAssetsFromRedeem,
+            DEFAULT_AMOUNT,
             DEFAULT_AMOUNT
         );
     }
@@ -195,7 +194,7 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
 
         // Expected Events
         vm.expectEmit({emitter: address(lidoARM)});
-        emit IERC20.Transfer(address(this), address(0), DEFAULT_AMOUNT);
+        emit IERC20.Transfer(address(this), address(lidoARM), DEFAULT_AMOUNT);
 
         // Main call
         (, uint256 actualAssetsFromRedeem) = lidoARM.requestRedeem(DEFAULT_AMOUNT);
@@ -208,20 +207,15 @@ contract Fork_Concrete_LidoARM_RequestRedeem_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT - assetsLoss);
         assertEq(_lidoWithdrawalQueueAmount(), 0, "stETH in Lido withdrawal queue");
         assertEq(lidoARM.feesAccrued(), 0, "fees accrued");
-        assertApproxEqAbs(int256(lidoARM.totalAssets()), int256(MIN_TOTAL_SUPPLY), 1, "last available assets"); // 1 wei of error
+        assertApproxEqAbs(int256(lidoARM.totalAssets()), int256(assetsAfterLoss), 1, "last available assets"); // 1 wei of error
         assertEq(lidoARM.balanceOf(address(this)), 0, "user LP balance");
-        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY, "total supply");
-        assertApproxEqAbs(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, 1, "total assets");
+        assertEq(lidoARM.balanceOf(address(lidoARM)), DEFAULT_AMOUNT, "escrowed shares");
+        assertEq(lidoARM.totalSupply(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT, "total supply");
+        assertApproxEqAbs(lidoARM.totalAssets(), assetsAfterLoss, 1, "total assets");
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
         assertEqQueueMetadata(expectedAssetsFromRedeem, 0, 1);
         assertEqUserRequest(
-            0,
-            address(this),
-            false,
-            block.timestamp + delay,
-            expectedAssetsFromRedeem,
-            expectedAssetsFromRedeem,
-            DEFAULT_AMOUNT
+            0, address(this), false, block.timestamp + delay, expectedAssetsFromRedeem, DEFAULT_AMOUNT, DEFAULT_AMOUNT
         );
     }
 }

--- a/test/fork/LidoARM/SwapGasComparison.t.sol
+++ b/test/fork/LidoARM/SwapGasComparison.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, stdStorage, StdStorage} from "forge-std/Test.sol";
 
 import {LidoARM} from "contracts/LidoARM.sol";
 import {Proxy} from "contracts/Proxy.sol";
@@ -16,6 +16,8 @@ interface ILegacyLidoARM {
 }
 
 abstract contract Fork_LidoARM_SwapGasComparison_Base is Test {
+    using stdStorage for StdStorage;
+
     uint256 internal constant FORK_BLOCK = 24_846_066;
     uint256 internal constant PRICE_SCALE = 1e36;
     uint256 internal constant LIQUIDITY_DEPOSIT = 1_000 ether;
@@ -133,6 +135,13 @@ contract Fork_Concrete_LidoARM_SwapGasUpgraded_Test is Fork_LidoARM_SwapGasCompa
 
         vm.prank(lidoProxy.owner());
         lidoProxy.upgradeTo(address(upgradedImpl));
+
+        stdStorage.checked_write(
+            stdStorage.sig(stdStorage.target(stdstore, address(lidoProxy)), "reservedWithdrawLiquidity()"), uint256(0)
+        );
+
+        vm.prank(lidoProxy.owner());
+        lidoARM.migrateLegacyWithdrawQueue();
 
         uint256 sellT1 = PRICE_SCALE;
         address stethAdapter =

--- a/test/fork/LidoARM/TotalAssets.t.sol
+++ b/test/fork/LidoARM/TotalAssets.t.sol
@@ -123,7 +123,7 @@ contract Fork_Concrete_LidoARM_TotalAssets_Test_ is Fork_Shared_Test_ {
         // Simulate a loss of assets
         deal(address(weth), address(lidoARM), DEFAULT_AMOUNT - 1);
 
-        assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY);
+        assertEq(lidoARM.totalAssets(), DEFAULT_AMOUNT - 1);
     }
 
     function test_RevertWhen_TotalAssets_Because_MathError()

--- a/test/fork/OriginARM/AllocateWithAdapter.sol
+++ b/test/fork/OriginARM/AllocateWithAdapter.sol
@@ -209,10 +209,8 @@ contract Fork_Concrete_OriginARM_AllocateWithAdapter_Test_ is Fork_Shared_Test {
         uint256 targetArmLiquidity = availableAssets * armBuffer / 1e18;
 
         // ARM liquidity
-        uint256 withdrawQueued = originARM.withdrawsQueued();
-        uint256 withdrawClaimed = originARM.withdrawsClaimed();
-        uint256 outstandingWithdrawals = withdrawQueued - withdrawClaimed;
-        int256 armLiquidity = ws.balanceOf(address(originARM)).toInt256() - outstandingWithdrawals.toInt256();
+        uint256 reservedWithdrawLiquidity = originARM.reservedWithdrawLiquidity();
+        int256 armLiquidity = ws.balanceOf(address(originARM)).toInt256() - reservedWithdrawLiquidity.toInt256();
         return armLiquidity - targetArmLiquidity.toInt256();
     }
 }

--- a/test/fork/OriginARM/AllocateWithoutAdapter.sol
+++ b/test/fork/OriginARM/AllocateWithoutAdapter.sol
@@ -207,10 +207,8 @@ contract Fork_Concrete_OriginARM_AllocateWithoutAdapter_Test_ is Fork_Shared_Tes
         uint256 targetArmLiquidity = availableAssets * armBuffer / 1e18;
 
         // ARM liquidity
-        uint256 withdrawQueued = originARM.withdrawsQueued();
-        uint256 withdrawClaimed = originARM.withdrawsClaimed();
-        uint256 outstandingWithdrawals = withdrawQueued - withdrawClaimed;
-        int256 armLiquidity = ws.balanceOf(address(originARM)).toInt256() - outstandingWithdrawals.toInt256();
+        uint256 reservedWithdrawLiquidity = originARM.reservedWithdrawLiquidity();
+        int256 armLiquidity = ws.balanceOf(address(originARM)).toInt256() - reservedWithdrawLiquidity.toInt256();
         return armLiquidity - targetArmLiquidity.toInt256();
     }
 }

--- a/test/fork/OriginARM/ClaimRedeem.sol
+++ b/test/fork/OriginARM/ClaimRedeem.sol
@@ -13,7 +13,9 @@ contract Fork_Concrete_OriginARM_ClaimRedeem_Test_ is Fork_Shared_Test {
         timejump(CLAIM_DELAY)
     {
         // Assertions before claim
-        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets before");
+        assertEq(originARM.totalAssets(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "totalAssets before");
+        assertEq(originARM.reservedWithdrawLiquidity(), DEFAULT_AMOUNT, "reserved liquidity before");
+        assertEq(originARM.balanceOf(address(originARM)), DEFAULT_AMOUNT, "escrowed shares before");
         assertEq(ws.balanceOf(address(alice)), 0, "ws balance before");
 
         // Expected event
@@ -26,6 +28,9 @@ contract Fork_Concrete_OriginARM_ClaimRedeem_Test_ is Fork_Shared_Test {
 
         // Assertions after claim
         assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets after");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity after");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "claimed shares after");
+        assertEq(originARM.balanceOf(address(originARM)), 0, "escrowed shares after");
         assertEq(ws.balanceOf(address(alice)), DEFAULT_AMOUNT, "ws balance after");
     }
 
@@ -38,8 +43,12 @@ contract Fork_Concrete_OriginARM_ClaimRedeem_Test_ is Fork_Shared_Test {
         setActiveMarket(address(siloMarket))
         requestRedeemAll(alice)
     {
+        (,,, uint128 requestAssets,,) = originARM.withdrawalRequests(0);
+
         // Assertions before claim
-        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets before");
+        assertApproxEqAbs(originARM.totalAssets(), uint256(requestAssets) + MIN_TOTAL_SUPPLY, 1, "totalAssets before");
+        assertEq(originARM.reservedWithdrawLiquidity(), requestAssets, "reserved liquidity before");
+        assertEq(originARM.balanceOf(address(originARM)), DEFAULT_AMOUNT, "escrowed shares before");
         assertEq(ws.balanceOf(address(alice)), 0, "ws balance before");
 
         // Expected event
@@ -53,6 +62,9 @@ contract Fork_Concrete_OriginARM_ClaimRedeem_Test_ is Fork_Shared_Test {
 
         // Assertions after claim
         assertGt(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets after");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity after");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "claimed shares after");
+        assertEq(originARM.balanceOf(address(originARM)), 0, "escrowed shares after");
         assertApproxEqAbs(ws.balanceOf(address(alice)), DEFAULT_AMOUNT, 1, "ws balance after");
     }
 }

--- a/test/fork/utils/Helpers.sol
+++ b/test/fork/utils/Helpers.sol
@@ -34,13 +34,13 @@ abstract contract Helpers is Base_Test_ {
         }
     }
 
-    /// @notice Asserts the equality between value of `withdrawalQueueMetadata()` and the expected values.
-    function assertEqQueueMetadata(uint256 expectedQueued, uint256 expectedClaimed, uint256 expectedNextIndex)
+    /// @notice Asserts LP withdrawal queue reservation and claimed share metadata.
+    function assertEqQueueMetadata(uint256 expectedReserved, uint256 expectedClaimedShares, uint256 expectedNextIndex)
         public
         view
     {
-        assertEq(lidoARM.withdrawsQueued(), expectedQueued, "metadata queued");
-        assertEq(lidoARM.withdrawsClaimed(), expectedClaimed, "metadata claimed");
+        assertEq(lidoARM.reservedWithdrawLiquidity(), expectedReserved, "metadata reserved");
+        assertEq(lidoARM.withdrawsClaimedShares(), expectedClaimedShares, "metadata claimed shares");
         assertEq(lidoARM.nextWithdrawalIndex(), expectedNextIndex, "metadata nextWithdrawalIndex");
     }
 

--- a/test/invariants/EthenaARM/Base.sol
+++ b/test/invariants/EthenaARM/Base.sol
@@ -94,6 +94,8 @@ abstract contract Base_Test_ {
     uint256 internal sumUSDeUserDeposit;
     uint256 internal sumUSDeUserRedeem;
     uint256 internal sumUSDeUserRequest;
+    uint256 internal sumARMUserRequestShares;
+    uint256 internal sumARMUserRedeemShares;
     uint256 internal sumUSDeBaseRedeem;
     uint256 internal sumUSDeFeesCollected;
     uint256 internal sumUSDeMarketDeposit;

--- a/test/invariants/EthenaARM/Properties.sol
+++ b/test/invariants/EthenaARM/Properties.sol
@@ -37,11 +37,11 @@ abstract contract Properties is TargetFunctions {
     // [x] Invariant C: ∑shares > 0 due to initial deposit
     // [x] Invariant D: totalShares == ∑userShares + deadShares
     // [x] Invariant E: previewRedeem(∑shares) == totalAssets
-    // [x] Invariant F: withdrawsQueued == ∑requestRedeem.amount
-    // [x] Invariant G: withdrawsQueued >= withdrawsClaimed
-    // [x] Invariant H: withdrawsQueued == ∑request.assets
-    // [x] Invariant I: withdrawsClaimed >= ∑claimRedeem.amount
-    // [x] Invariant J: ∀ requestId, request.queued >= request.assets
+    // [x] Invariant F: reservedWithdrawLiquidity == ∑unclaimed request.assets
+    // [x] Invariant G: withdrawsQueuedShares >= withdrawsClaimedShares
+    // [x] Invariant H: withdrawsQueuedShares == ∑request.shares
+    // [x] Invariant I: withdrawsClaimedShares == ∑claimed request.shares
+    // [x] Invariant J: ARM escrowed shares == withdrawsQueuedShares - withdrawsClaimedShares
     // [x] Invariant K: ∑feesCollected == feeCollector.balance
     //
     // ╔══════════════════════════════════════════════════════════════════════════════╗
@@ -117,6 +117,7 @@ abstract contract Properties is TargetFunctions {
         for (uint256 i = 0; i < MAKERS_COUNT; i++) {
             totalUserShares += arm.balanceOf(makers[i]);
         }
+        totalUserShares += arm.balanceOf(address(arm));
         uint256 deadShares = 1e12;
         return Math.eq(arm.totalSupply(), totalUserShares + deadShares);
     }
@@ -126,36 +127,31 @@ abstract contract Properties is TargetFunctions {
     }
 
     function propertyF() public view returns (bool) {
-        return Math.eq(arm.withdrawsQueued(), sumUSDeUserRequest);
+        return Math.eq(arm.reservedWithdrawLiquidity(), sumOfUnclaimedRequestAssets());
     }
 
     function propertyG() public view returns (bool) {
-        return Math.gte(arm.withdrawsQueued(), arm.withdrawsClaimed());
+        return Math.gte(arm.withdrawsQueuedShares(), arm.withdrawsClaimedShares());
     }
 
     function propertyH() public view returns (bool) {
-        uint256 sum = 0;
-        uint256 len = arm.nextWithdrawalIndex();
-        for (uint256 i; i < len; i++) {
-            (,,, uint128 amount,,) = arm.withdrawalRequests(i);
-            sum += amount;
-        }
-        return Math.eq(arm.withdrawsQueued(), sum);
+        return Math.eq(arm.withdrawsQueuedShares(), sumARMUserRequestShares);
     }
 
     function propertyI() public view returns (bool) {
-        return Math.gte(arm.withdrawsClaimed(), sumUSDeUserRedeem);
+        return Math.eq(arm.withdrawsClaimedShares(), sumARMUserRedeemShares);
     }
 
     function propertyJ() public view returns (bool) {
+        return Math.eq(arm.balanceOf(address(arm)), arm.withdrawsQueuedShares() - arm.withdrawsClaimedShares());
+    }
+
+    function sumOfUnclaimedRequestAssets() public view returns (uint256 sum) {
         uint256 len = arm.nextWithdrawalIndex();
         for (uint256 i; i < len; i++) {
-            (,,, uint128 amount, uint128 queued,) = arm.withdrawalRequests(i);
-            if (queued < amount) {
-                return false;
-            }
+            (, bool claimed,, uint128 amount,,) = arm.withdrawalRequests(i);
+            if (!claimed) sum += amount;
         }
-        return true;
     }
 
     function propertyK() public view returns (bool) {

--- a/test/invariants/EthenaARM/TargetFunctions.sol
+++ b/test/invariants/EthenaARM/TargetFunctions.sol
@@ -82,7 +82,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
     }
 
     function targetARMDeposit(uint88 amount, uint256 randomAddressIndex) external ensureExchangeRateIncrease {
-        vm.assume(arm.totalAssets() > 1e12 || arm.withdrawsQueued() == arm.withdrawsClaimed());
+        vm.assume(arm.totalAssets() > 1e12 || arm.reservedWithdrawLiquidity() == 0);
         // Select a random user from makers
         address user = makers[randomAddressIndex % MAKERS_COUNT];
 
@@ -140,6 +140,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         }
 
         sumUSDeUserRequest += amount;
+        sumARMUserRequestShares += shareAmount;
     }
 
     function targetARMClaimRedeem(uint248 randomAddressIndex, uint248 randomArrayIndex)
@@ -195,6 +196,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
 
         // Claim redeem as user
         uint256 balanceBefore = usde.balanceOf(address(arm));
+        (,,,,, uint128 requestShares) = arm.withdrawalRequests(requestId);
         vm.prank(user);
         uint256 amount = arm.claimRedeem(requestId);
 
@@ -213,6 +215,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         }
 
         sumUSDeUserRedeem += amount;
+        sumARMUserRedeemShares += requestShares;
         if (balanceBefore < amount) {
             // This means we had to withdraw from market
             sumUSDeMarketWithdraw += amount - balanceBefore;
@@ -375,7 +378,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         uint256 maxAmountOut;
         if (address(tokenOut) == address(usde)) {
             uint256 balance = usde.balanceOf(address(arm));
-            uint256 outstandingWithdrawals = arm.withdrawsQueued() - arm.withdrawsClaimed();
+            uint256 outstandingWithdrawals = arm.reservedWithdrawLiquidity();
             maxAmountOut = outstandingWithdrawals >= balance ? 0 : balance - outstandingWithdrawals;
         } else {
             maxAmountOut = susde.balanceOf(address(arm));
@@ -449,7 +452,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         uint256 maxAmountOut;
         if (address(tokenOut) == address(usde)) {
             uint256 balance = usde.balanceOf(address(arm));
-            uint256 outstandingWithdrawals = arm.withdrawsQueued() - arm.withdrawsClaimed();
+            uint256 outstandingWithdrawals = arm.reservedWithdrawLiquidity();
             maxAmountOut = outstandingWithdrawals >= balance ? 0 : balance - outstandingWithdrawals;
         } else {
             maxAmountOut = susde.balanceOf(address(arm));
@@ -518,7 +521,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
     function targetARMCollectFees() external ensureExchangeRateIncrease {
         uint256 feesAccrued = arm.feesAccrued();
         uint256 balance = usde.balanceOf(address(arm));
-        uint256 outstandingWithdrawals = arm.withdrawsQueued() - arm.withdrawsClaimed();
+        uint256 outstandingWithdrawals = arm.reservedWithdrawLiquidity();
         if (assume(balance >= feesAccrued + outstandingWithdrawals)) return;
 
         uint256 feesCollected = arm.collectFees();
@@ -536,7 +539,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         uint256 feesAccrued = arm.feesAccrued();
         if (feesAccrued != 0) {
             uint256 balance = usde.balanceOf(address(arm));
-            uint256 outstandingWithdrawals = arm.withdrawsQueued() - arm.withdrawsClaimed();
+            uint256 outstandingWithdrawals = arm.reservedWithdrawLiquidity();
             if (assume(balance >= feesAccrued + outstandingWithdrawals)) return;
         }
 

--- a/test/invariants/LidoARM/Properties.sol
+++ b/test/invariants/LidoARM/Properties.sol
@@ -19,6 +19,8 @@ abstract contract Properties is Setup, Utils {
     uint256 sum_weth_deposit;
     uint256 sum_weth_request;
     uint256 sum_weth_withdraw;
+    uint256 sum_shares_request;
+    uint256 sum_shares_withdraw;
     uint256 sum_weth_donated;
     uint256 sum_weth_lido_redeem;
     uint256 sum_steth_lido_requested;
@@ -49,11 +51,11 @@ abstract contract Properties is Setup, Utils {
     // Invariant D: previewRedeem(shares) == (, uint256 assets) = previewRedeem(shares)
     // Invariant E: previewDeposit(amount) == uint256 shares = previewDeposit(amount)
     // Invariant F: nextWithdrawalIndex == requestRedeem call count
-    // Invariant G: withdrawsQueued == ∑requestRedeem.amount
-    // Invariant H: withdrawsQueued > withdrawsClaimed
-    // Invariant I: withdrawsQueued == ∑request.assets
-    // Invariant J: withdrawsClaimed >= ∑claimRedeem.amount
-    // Invariant K: ∀ requestId, request.queued >= request.assets
+    // Invariant G: reservedWithdrawLiquidity == ∑unclaimed request.assets
+    // Invariant H: withdrawsQueuedShares >= withdrawsClaimedShares
+    // Invariant I: withdrawsQueuedShares == ∑request.shares
+    // Invariant J: withdrawsClaimedShares == ∑claimed request.shares
+    // Invariant K: ARM escrowed shares == withdrawsQueuedShares - withdrawsClaimedShares
     // Invariant M: ∑feesCollected == feeCollector.balance
 
     // --- Lido Liquidity Management properties ---
@@ -113,36 +115,24 @@ abstract contract Properties is Setup, Utils {
     }
 
     function property_lp_G() public view returns (bool) {
-        return eq(lidoARM.withdrawsQueued(), sum_weth_request);
+        return eq(lidoARM.reservedWithdrawLiquidity(), sumOfUnclaimedRequestAssets());
     }
 
     function property_lp_H() public view returns (bool) {
-        return gte(lidoARM.withdrawsQueued(), lidoARM.withdrawsClaimed());
+        return gte(lidoARM.withdrawsQueuedShares(), lidoARM.withdrawsClaimedShares());
     }
 
     function property_lp_I() public view returns (bool) {
-        uint256 sum;
-        uint256 nextWithdrawalIndex = lidoARM.nextWithdrawalIndex();
-        for (uint256 i; i < nextWithdrawalIndex; i++) {
-            (,,, uint128 assets,,) = lidoARM.withdrawalRequests(i);
-            sum += assets;
-        }
-
-        return eq(lidoARM.withdrawsQueued(), sum);
+        return eq(lidoARM.withdrawsQueuedShares(), sum_shares_request);
     }
 
     function property_lp_invariant_J() public view returns (bool) {
-        return gte(lidoARM.withdrawsClaimed(), sum_weth_withdraw);
+        return eq(lidoARM.withdrawsClaimedShares(), sum_shares_withdraw);
     }
 
     function property_lp_invariant_K() public view returns (bool) {
-        uint256 nextWithdrawalIndex = lidoARM.nextWithdrawalIndex();
-        for (uint256 i; i < nextWithdrawalIndex; i++) {
-            (,,, uint128 assets, uint128 queued,) = lidoARM.withdrawalRequests(i);
-            if (queued < assets) return false;
-        }
-
-        return true;
+        return
+            eq(lidoARM.balanceOf(address(lidoARM)), lidoARM.withdrawsQueuedShares() - lidoARM.withdrawsClaimedShares());
     }
 
     function property_lp_invariant_M() public view returns (bool) {
@@ -190,9 +180,18 @@ abstract contract Properties is Setup, Utils {
             sum_shares += lidoARM.balanceOf(lps[i]);
         }
 
+        sum_shares += lidoARM.balanceOf(address(lidoARM));
         sum_shares += lidoARM.balanceOf(address(0xdEaD));
 
         return sum_shares;
+    }
+
+    function sumOfUnclaimedRequestAssets() public view returns (uint256 sum) {
+        uint256 nextWithdrawalIndex = lidoARM.nextWithdrawalIndex();
+        for (uint256 i; i < nextWithdrawalIndex; i++) {
+            (, bool claimed,, uint128 assets,,) = lidoARM.withdrawalRequests(i);
+            if (!claimed) sum += assets;
+        }
     }
 
     function _lidoWithdrawalQueueAmount() internal view returns (uint256 pendingRedeemAssets) {

--- a/test/invariants/LidoARM/TargetFunction.sol
+++ b/test/invariants/LidoARM/TargetFunction.sol
@@ -88,7 +88,7 @@ abstract contract TargetFunction is Properties {
     mapping(address => uint256[]) public requests;
 
     function handler_deposit(uint8 account, uint80 amount) public {
-        vm.assume(lidoARM.totalAssets() > MIN_TOTAL_SUPPLY || lidoARM.withdrawsQueued() == lidoARM.withdrawsClaimed());
+        vm.assume(lidoARM.totalAssets() > MIN_TOTAL_SUPPLY || lidoARM.reservedWithdrawLiquidity() == 0);
 
         // Select a random user
         address user = lps[account % lps.length];
@@ -138,6 +138,7 @@ abstract contract TargetFunction is Properties {
         // Update state
         requests[user].push(id);
         sum_weth_request += amount;
+        sum_shares_request += shares;
         ghost_lp_E = amount == expectedAmount;
         ghost_requestCounter++;
     }
@@ -159,10 +160,10 @@ abstract contract TargetFunction is Properties {
 
         if (user == address(0)) return;
 
-        (,, uint40 claimTimestamp,,, uint128 shares) = lidoARM.withdrawalRequests(requestId);
+        (,,, uint128 requestAssets, uint128 queued, uint128 shares) = lidoARM.withdrawalRequests(requestId);
+        (,, uint40 claimTimestamp,,,) = lidoARM.withdrawalRequests(requestId);
         vm.assume(block.timestamp + lidoARM.claimDelay() >= claimTimestamp);
-        vm.assume(lidoARM.withdrawsQueued() == lidoARM.withdrawsClaimed());
-        vm.assume(lidoARM.claimable() >= lidoARM.previewRedeem(shares));
+        vm.assume(lidoARM.claimable() >= queued);
 
         // Timejump to request deadline
         skip(lidoARM.claimDelay());
@@ -189,6 +190,8 @@ abstract contract TargetFunction is Properties {
 
         // Update ghost
         sum_weth_withdraw += amount;
+        sum_weth_request -= requestAssets;
+        sum_shares_withdraw += shares;
     }
 
     ////////////////////////////////////////////////////
@@ -361,7 +364,7 @@ abstract contract TargetFunction is Properties {
 
     function _availableWethLiquidity() internal view returns (uint256) {
         uint256 balance = weth.balanceOf(address(lidoARM));
-        uint256 outstandingWithdrawals = lidoARM.withdrawsQueued() - lidoARM.withdrawsClaimed();
+        uint256 outstandingWithdrawals = lidoARM.reservedWithdrawLiquidity();
         if (outstandingWithdrawals >= balance) return 0;
         return balance - outstandingWithdrawals;
     }

--- a/test/invariants/OriginARM/Properties.sol
+++ b/test/invariants/OriginARM/Properties.sol
@@ -29,11 +29,11 @@ abstract contract Properties is Setup, Helpers {
     // [x] Invariant D: previewRedeem(shares) == (, uint256 assets) *
     // [x] Invariant E: previewDeposit(amount) == uint256 shares *
     // [x] Invariant F: nextWithdrawalIndex == requestRedeem call count *
-    // [x] Invariant G: withdrawsQueued == ∑requestRedeem.amount
-    // [x] Invariant H: withdrawsQueued > withdrawsClaimed
-    // [x] Invariant I: withdrawsQueued == ∑request.assets
-    // [x] Invariant J: withdrawsClaimed == ∑claimRedeem.amount
-    // [x] Invariant K: ∀ requestId, request.queued >= request.assets
+    // [x] Invariant G: reservedWithdrawLiquidity == ∑unclaimed request.assets
+    // [x] Invariant H: withdrawsQueuedShares >= withdrawsClaimedShares
+    // [x] Invariant I: withdrawsQueuedShares == ∑request.shares
+    // [x] Invariant J: withdrawsClaimedShares == ∑claimed request.shares
+    // [x] Invariant K: ARM escrowed shares == withdrawsQueuedShares - withdrawsClaimedShares
     // [x] Invariant L: ∑feesCollected == feeCollector.balance
     // * invariants tested directly in the handlers.
 
@@ -51,6 +51,8 @@ abstract contract Properties is Setup, Helpers {
     uint256 public sum_ws_redeem;
     uint256 public sum_os_redeem;
     uint256 public sum_ws_user_claimed;
+    uint256 public sum_shares_redeem;
+    uint256 public sum_shares_claimed;
     uint256 public sum_ws_swapOut;
     uint256 public sum_os_swapOut;
     uint256 public sum_feesCollected;
@@ -84,30 +86,24 @@ abstract contract Properties is Setup, Helpers {
     }
 
     function property_lp_G() public view returns (bool) {
-        return originARM.withdrawsQueued() == sum_ws_redeem;
+        return originARM.reservedWithdrawLiquidity() == sumOfUnclaimedRequestRedeemAmount();
     }
 
     function property_lp_H() public view returns (bool) {
-        return originARM.withdrawsQueued() >= originARM.withdrawsClaimed();
+        return originARM.withdrawsQueuedShares() >= originARM.withdrawsClaimedShares();
     }
 
     function property_lp_I() public view returns (bool) {
-        return originARM.withdrawsQueued() == sumOfRequestRedeemAmount();
+        return originARM.withdrawsQueuedShares() == sum_shares_redeem;
     }
 
     function property_lp_J() public view returns (bool) {
-        return originARM.withdrawsClaimed() == sum_ws_user_claimed;
+        return originARM.withdrawsClaimedShares() == sum_shares_claimed;
     }
 
     function property_lp_K() public view returns (bool) {
-        uint256 len = originARM.nextWithdrawalIndex();
-        for (uint256 i; i < len; i++) {
-            (,,, uint128 amount, uint128 queued,) = originARM.withdrawalRequests(i);
-            if (queued < amount) {
-                return false;
-            }
-        }
-        return true;
+        return originARM.balanceOf(address(originARM))
+            == originARM.withdrawsQueuedShares() - originARM.withdrawsClaimedShares();
     }
 
     function property_lp_L() public view returns (bool) {
@@ -118,14 +114,15 @@ abstract contract Properties is Setup, Helpers {
         for (uint256 i; i < lps.length; i++) {
             usersShares += originARM.balanceOf(lps[i]);
         }
+        usersShares += originARM.balanceOf(address(originARM));
         usersShares += MIN_TOTAL_SUPPLY;
     }
 
-    function sumOfRequestRedeemAmount() public view returns (uint256 sum) {
+    function sumOfUnclaimedRequestRedeemAmount() public view returns (uint256 sum) {
         uint256 len = originARM.nextWithdrawalIndex();
         for (uint256 i; i < len; i++) {
-            (,,, uint128 amount,,) = originARM.withdrawalRequests(i);
-            sum += amount;
+            (, bool claimed,, uint128 amount,,) = originARM.withdrawalRequests(i);
+            if (!claimed) sum += amount;
         }
     }
 }

--- a/test/invariants/OriginARM/TargetFunction.sol
+++ b/test/invariants/OriginARM/TargetFunction.sol
@@ -77,7 +77,7 @@ abstract contract TargetFunction is Properties {
     }
 
     function handler_deposit(uint8 seed, uint88 amount) public {
-        vm.assume(originARM.totalAssets() > 1e12 || originARM.withdrawsQueued() == originARM.withdrawsClaimed());
+        vm.assume(originARM.totalAssets() > 1e12 || originARM.reservedWithdrawLiquidity() == 0);
 
         // Get a random user from the list of lps
         address user = getRandomLPs(seed);
@@ -120,6 +120,7 @@ abstract contract TargetFunction is Properties {
         require(id == expectedId, "Expected ID != received");
         require(amount == expectedAmount, "Expected amount != received");
         sum_ws_redeem += amount;
+        sum_shares_redeem += shares;
     }
 
     function handler_claimRedeem(uint8 seed, uint16 seed_id) public {
@@ -138,11 +139,13 @@ abstract contract TargetFunction is Properties {
 
         // Main call
         vm.prank(user);
-        originARM.claimRedeem(id);
+        uint256 assets = originARM.claimRedeem(id);
 
         // Remove the request from the list
         removeRequest(user, id);
-        sum_ws_user_claimed += expectedAmount;
+        sum_ws_user_claimed += assets;
+        (,,,,, uint128 requestShares) = originARM.withdrawalRequests(id);
+        sum_shares_claimed += requestShares;
     }
 
     function handler_setARMBuffer(uint64 pct) public {
@@ -573,9 +576,7 @@ abstract contract TargetFunction is Properties {
         if (token == address(os)) {
             return os.balanceOf(address(originARM));
         } else if (token == address(ws)) {
-            uint256 withdrawsQueued = originARM.withdrawsQueued();
-            uint256 withdrawsClaimed = originARM.withdrawsClaimed();
-            uint256 outstandingWithdrawals = withdrawsQueued - withdrawsClaimed;
+            uint256 outstandingWithdrawals = originARM.reservedWithdrawLiquidity();
             uint256 balance = ws.balanceOf(address(originARM));
             if (outstandingWithdrawals > balance) return 0;
 
@@ -608,10 +609,8 @@ abstract contract TargetFunction is Properties {
             assets += IERC4626(activeMarket).previewRedeem(IERC4626(activeMarket).balanceOf(address(originARM)));
         }
 
-        outstandingWithdrawals = originARM.withdrawsQueued() - originARM.withdrawsClaimed();
-        if (assets < outstandingWithdrawals) return (0, outstandingWithdrawals);
-
-        availableAssets = assets - outstandingWithdrawals;
+        outstandingWithdrawals = originARM.reservedWithdrawLiquidity();
+        availableAssets = assets;
     }
 
     function assertLpsAreUpOnly(uint256 tolerance) public view {

--- a/test/smoke/AbstractSmokeTest.sol
+++ b/test/smoke/AbstractSmokeTest.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.23;
 
 // Foundry imports
-import {Test} from "forge-std/Test.sol";
+import {stdStorage, StdStorage, Test} from "forge-std/Test.sol";
 
 import {DeployManager} from "script/deploy/DeployManager.s.sol";
 import {$028_UpgradeEthenaARMScript} from "script/deploy/mainnet/028_UpgradeEthenaARMScript.s.sol";
@@ -22,6 +22,8 @@ import {OriginAssetAdapter} from "contracts/adapters/OriginAssetAdapter.sol";
 import {WrappedOriginAssetAdapter} from "contracts/adapters/WrappedOriginAssetAdapter.sol";
 
 abstract contract AbstractSmokeTest is Test {
+    using stdStorage for StdStorage;
+
     /// @dev First derived-contract storage slot after AbstractARM's reserved gap.
     uint256 internal constant LEGACY_PENDING_AMOUNT_SLOT = 100;
     /// @dev Ethena ARM proxy from mainnet deployment history. `Mainnet` does not expose this address.
@@ -83,6 +85,9 @@ abstract contract AbstractSmokeTest is Test {
         vm.prank(proxy.owner());
         proxy.upgradeTo(address(impl));
 
+        _clearLegacyWithdrawQueueForSmoke(address(proxy));
+        _migrateLegacyWithdrawQueue(address(proxy));
+
         StETHAssetAdapter stethAdapterImpl =
             new StETHAssetAdapter(address(proxy), Mainnet.WETH, Mainnet.STETH, Mainnet.LIDO_WITHDRAWAL);
         resolver.addContract("LIDO_ARM_STETH_ADAPTER_IMPL", address(stethAdapterImpl));
@@ -118,6 +123,9 @@ abstract contract AbstractSmokeTest is Test {
 
         vm.prank(proxy.owner());
         proxy.upgradeTo(address(impl));
+
+        _clearLegacyWithdrawQueueForSmoke(address(proxy));
+        _migrateLegacyWithdrawQueue(address(proxy));
 
         EtherFiAssetAdapter eethAdapterImpl = new EtherFiAssetAdapter(
             address(proxy), Mainnet.EETH, Mainnet.WETH, Mainnet.ETHERFI_WITHDRAWAL, Mainnet.ETHERFI_WITHDRAWAL_NFT
@@ -177,6 +185,9 @@ abstract contract AbstractSmokeTest is Test {
         vm.prank(proxy.owner());
         proxy.upgradeTo(address(impl));
 
+        _clearLegacyWithdrawQueueForSmoke(address(proxy));
+        _migrateLegacyWithdrawQueue(address(proxy));
+
         OriginAssetAdapter oethAdapterImpl =
             new OriginAssetAdapter(address(proxy), Mainnet.OETH, Mainnet.WETH, Mainnet.OETH_VAULT);
         resolver.addContract("OETH_ARM_OETH_ADAPTER_IMPL", address(oethAdapterImpl));
@@ -205,6 +216,21 @@ abstract contract AbstractSmokeTest is Test {
         // Smoke tests exercise the post-upgrade ARM shape. Production upgrades still require
         // operators to drain legacy protocol queues before adapter-owned withdrawals are enabled.
         vm.store(arm, bytes32(LEGACY_PENDING_AMOUNT_SLOT), bytes32(0));
+    }
+
+    function _clearLegacyWithdrawQueueForSmoke(address arm) internal {
+        // The live fork can contain outstanding legacy LP withdrawals at the selected block.
+        // Smoke tests normalize that fork-only state so the strict production migration path can run.
+        stdstore.target(arm).sig("reservedWithdrawLiquidity()").checked_write(uint256(0));
+    }
+
+    function _migrateLegacyWithdrawQueue(address arm) internal {
+        (bool success, bytes memory result) = arm.staticcall(abi.encodeWithSignature("owner()"));
+        require(success, "owner lookup failed");
+
+        vm.prank(abi.decode(result, (address)));
+        (success,) = arm.call(abi.encodeWithSignature("migrateLegacyWithdrawQueue()"));
+        require(success, "legacy withdraw migration failed");
     }
 
     function _addBaseAssetIfMissing(

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -246,7 +246,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         vm.stopPrank();
 
         // Deal enough WETH to cover the outstanding withdrawal queue plus extra to deposit
-        uint256 outstandingWithdrawals = lidoARM.withdrawsQueued() - lidoARM.withdrawsClaimed();
+        uint256 outstandingWithdrawals = lidoARM.reservedWithdrawLiquidity();
         deal(address(weth), address(lidoARM), outstandingWithdrawals + 100 ether);
 
         uint256 armWethBefore = weth.balanceOf(address(lidoARM));
@@ -281,7 +281,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         vm.stopPrank();
 
         // Deal enough WETH to cover the outstanding withdrawal queue plus extra to deposit
-        uint256 outstandingWithdrawals = lidoARM.withdrawsQueued() - lidoARM.withdrawsClaimed();
+        uint256 outstandingWithdrawals = lidoARM.reservedWithdrawLiquidity();
         deal(address(weth), address(lidoARM), outstandingWithdrawals + 100 ether);
         vm.prank(Mainnet.ARM_RELAYER);
         lidoARM.setARMBuffer(0);

--- a/test/unit/OriginARM/Allocate.sol
+++ b/test/unit/OriginARM/Allocate.sol
@@ -71,8 +71,8 @@ contract Unit_Concrete_OriginARM_Allocate_Test_ is Unit_Shared_Test {
         assertEq(market.balanceOf(address(originARM)), 0, "Market balance should be zero");
         assertEq(
             originARM.totalAssets(),
-            DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
-            "Total assets should be DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY"
+            2 * DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
+            "Total assets should include escrowed shares"
         );
 
         // Allocate
@@ -85,8 +85,8 @@ contract Unit_Concrete_OriginARM_Allocate_Test_ is Unit_Shared_Test {
         );
         assertEq(
             originARM.totalAssets(),
-            DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
-            "Total assets should be DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY"
+            2 * DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY,
+            "Total assets should include escrowed shares"
         );
     }
 
@@ -109,8 +109,8 @@ contract Unit_Concrete_OriginARM_Allocate_Test_ is Unit_Shared_Test {
         );
         assertEq(
             originARM.totalAssets(),
-            MIN_TOTAL_SUPPLY + 3 * DEFAULT_AMOUNT,
-            "Total assets should be assets after redeem request"
+            MIN_TOTAL_SUPPLY + 4 * DEFAULT_AMOUNT,
+            "Total assets should include escrowed shares"
         );
         assertEq(weth.balanceOf(address(originARM)), 0, "ARM WETH balance should be zero");
 
@@ -119,17 +119,17 @@ contract Unit_Concrete_OriginARM_Allocate_Test_ is Unit_Shared_Test {
 
         assertEq(
             market.balanceOf(address(originARM)),
-            (MIN_TOTAL_SUPPLY + 3 * DEFAULT_AMOUNT) * 70 / 100,
+            (MIN_TOTAL_SUPPLY + 4 * DEFAULT_AMOUNT) * 70 / 100 - DEFAULT_AMOUNT,
             "Market balance should be 75% of the available liquidity"
         );
         assertEq(
             originARM.totalAssets(),
-            MIN_TOTAL_SUPPLY + 3 * DEFAULT_AMOUNT,
-            "Total assets should be assets after redeem request"
+            MIN_TOTAL_SUPPLY + 4 * DEFAULT_AMOUNT,
+            "Total assets should include escrowed shares"
         );
         assertEq(
             weth.balanceOf(address(originARM)),
-            (MIN_TOTAL_SUPPLY + 3 * DEFAULT_AMOUNT) * 30 / 100 + DEFAULT_AMOUNT,
+            (MIN_TOTAL_SUPPLY + 4 * DEFAULT_AMOUNT) * 30 / 100 + DEFAULT_AMOUNT,
             "ARM WETH balance should be 30% of the available liquidity plus pending redeem"
         );
     }
@@ -144,13 +144,17 @@ contract Unit_Concrete_OriginARM_Allocate_Test_ is Unit_Shared_Test {
         asRandomCaller
     {
         assertEq(market.balanceOf(address(originARM)), 0, "Market balance should be zero");
-        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "Total assets should be MIN_TOTAL_SUPPLY");
+        assertEq(
+            originARM.totalAssets(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Total assets should include escrowed shares"
+        );
 
         // Allocate
         originARM.allocate();
 
         assertEq(market.balanceOf(address(originARM)), 0, "Market balance should be 0");
-        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "Total assets should be MIN_TOTAL_SUPPLY");
+        assertEq(
+            originARM.totalAssets(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Total assets should include escrowed shares"
+        );
         assertEq(
             weth.balanceOf(address(originARM)), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "WETH balance should be increased"
         );

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -65,7 +65,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         (, bool claimed,,,,) = originARM.withdrawalRequests(0);
         // Assertions
         assertEq(claimed, true, "Claimed should be true");
-        assertEq(originARM.withdrawsClaimed(), DEFAULT_AMOUNT, "Claimed amount should be DEFAULT_AMOUNT");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "Reserved liquidity should be released");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
         assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }
@@ -88,7 +89,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         (, bool claimed,,,,) = originARM.withdrawalRequests(0);
         // Assertions
         assertEq(claimed, true, "Claimed should be true");
-        assertEq(originARM.withdrawsClaimed(), DEFAULT_AMOUNT, "Claimed amount should be DEFAULT_AMOUNT");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "Reserved liquidity should be released");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
         assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }
@@ -111,7 +113,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         (, bool claimed,,,,) = originARM.withdrawalRequests(0);
         // Assertions
         assertEq(claimed, true, "Claimed should be true");
-        assertEq(originARM.withdrawsClaimed(), DEFAULT_AMOUNT, "Claimed amount should be DEFAULT_AMOUNT");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "Reserved liquidity should be released");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
         assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }

--- a/test/unit/OriginARM/CollectFees.sol
+++ b/test/unit/OriginARM/CollectFees.sol
@@ -13,7 +13,8 @@ contract Unit_Concrete_OriginARM_CollectFees_Test_ is Unit_Shared_Test {
         vm.stopPrank();
 
         amountIn = amounts[0];
-        expectedFee = amountOut * _swapFeeMultiplier(_buyPrice(), originARM.fee()) / originARM.PRICE_SCALE();
+        expectedFee =
+            amountOut * _swapFeeMultiplier(_buyPrice(), _crossPrice(), originARM.fee()) / originARM.PRICE_SCALE();
     }
 
     function test_RevertWhen_CollectFees_Because_InsufficientLiquidity() public deposit(alice, DEFAULT_AMOUNT) {
@@ -60,5 +61,35 @@ contract Unit_Concrete_OriginARM_CollectFees_Test_ is Unit_Shared_Test {
 
         // Ensure there nothing has been allocated
         assertEq(weth.balanceOf(feeCollector), collectorBalance + expectedFees, "Collector balance should change");
+    }
+
+    function test_SwapFee_IsBoundedByCrossPriceNavGain() public {
+        uint256 crossPrice = 9998 * 1e32;
+        uint256 buyPrice = 9997 * 1e32;
+        uint256 amountIn = 100 ether;
+
+        vm.startPrank(governor);
+        originARM.setFee(originARM.FEE_SCALE() / 2);
+        originARM.setCrossPrice(address(oeth), crossPrice);
+        originARM.setPrices(address(oeth), buyPrice, crossPrice, type(uint128).max, type(uint128).max);
+        vm.stopPrank();
+
+        deal(address(weth), address(originARM), amountIn);
+        deal(address(oeth), bob, amountIn);
+        uint256 totalAssetsBefore = originARM.totalAssets();
+
+        vm.startPrank(bob);
+        oeth.approve(address(originARM), amountIn);
+        uint256[] memory amounts = originARM.swapExactTokensForTokens(oeth, weth, amountIn, 0, bob);
+        vm.stopPrank();
+
+        uint256 amountOut = amounts[1];
+        uint256 recognizedNavGain = amountOut * (crossPrice - buyPrice) / buyPrice;
+        uint256 expectedFee =
+            amountOut * _swapFeeMultiplier(buyPrice, crossPrice, originARM.fee()) / originARM.PRICE_SCALE();
+
+        assertEq(originARM.feesAccrued(), expectedFee, "Wrong bounded swap fee");
+        assertLe(originARM.feesAccrued(), recognizedNavGain, "Fee exceeds recognized NAV gain");
+        assertGe(originARM.totalAssets(), totalAssetsBefore, "Swap fee should not reduce total assets");
     }
 }

--- a/test/unit/OriginARM/Deposit.sol
+++ b/test/unit/OriginARM/Deposit.sol
@@ -215,46 +215,38 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
     }
 
     /// @notice Deposit reverts when the ARM is insolvent (totalAssets floored to MIN_TOTAL_SUPPLY)
-    /// and there are outstanding withdrawal requests (withdrawsQueued > withdrawsClaimed).
+    /// and there are outstanding withdrawal requests.
     function test_RevertWhen_Deposit_Because_Insolvent() public deposit(alice, DEFAULT_AMOUNT) requestRedeemAll(alice) {
         // Drain all WETH → rawTotal (0) < outstanding (DEFAULT_AMOUNT) → insolvent
         deal(address(weth), address(originARM), 0);
 
         assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets should be floored at MIN_TOTAL_SUPPLY");
-        assertGt(originARM.withdrawsQueued(), originARM.withdrawsClaimed(), "should have outstanding requests");
+        assertGt(originARM.reservedWithdrawLiquidity(), 0, "should have outstanding requests");
 
         vm.expectRevert("ARM: insolvent");
         vm.prank(alice);
         originARM.deposit(DEFAULT_AMOUNT);
     }
 
-    /// @notice Attacker deposit is blocked when the ARM is insolvent due to a partial WETH loss.
-    /// Scenario (Immunefi #67167):
-    ///   1. Alice deposits and immediately requests a full redeem.
-    ///   2. While Alice waits to claim, the ARM suffers a 10% loss (e.g., lending market slashing).
-    ///   3. An attacker tries to deposit to dilute Alice's claim — blocked by the insolvent guard.
-    /// Without the guard, the attacker would acquire nearly all shares at the floored price and
-    /// capture Alice's remaining WETH when Alice's claim pays min(request.assets, convertToAssets).
-    function test_RevertWhen_Deposit_Because_Insolvent_WithSmallLoss()
+    /// @notice Deposits remain priced from gross assets when escrowed redeem shares share a partial loss.
+    function test_Deposit_When_OutstandingRequestSharesShareSmallLoss()
         public
         deposit(alice, DEFAULT_AMOUNT)
         requestRedeemAll(alice)
     {
-        // Simulate a 10% loss on Alice's deposit (e.g., lending market slashing).
-        // rawTotal = MIN_TOTAL_SUPPLY + 0.9 * DEFAULT_AMOUNT < outstanding = DEFAULT_AMOUNT → insolvent
         uint256 wethAfterLoss = MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT * 9 / 10;
         deal(address(weth), address(originARM), wethAfterLoss);
 
-        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets should be floored at MIN_TOTAL_SUPPLY");
-        assertGt(originARM.withdrawsQueued(), originARM.withdrawsClaimed(), "should have outstanding requests");
+        assertEq(originARM.totalAssets(), wethAfterLoss, "totalAssets should remain gross");
+        assertGt(originARM.reservedWithdrawLiquidity(), 0, "should have outstanding requests");
 
-        // Attacker (bob) attempts to deposit to dilute Alice's claim — must be blocked
         deal(address(weth), bob, DEFAULT_AMOUNT);
         vm.startPrank(bob);
         weth.approve(address(originARM), DEFAULT_AMOUNT);
-        vm.expectRevert("ARM: insolvent");
-        originARM.deposit(DEFAULT_AMOUNT);
+        uint256 bobShares = originARM.deposit(DEFAULT_AMOUNT);
         vm.stopPrank();
+
+        assertGt(bobShares, 0, "bob should receive shares at the loss-adjusted price");
     }
 
     /// @notice Deposit is allowed when there are outstanding requests but the ARM remains solvent.
@@ -269,7 +261,7 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         // rawTotal = MIN_TOTAL_SUPPLY + 2*DEFAULT_AMOUNT, outstanding = DEFAULT_AMOUNT
         // totalAssets() = MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT > MIN_TOTAL_SUPPLY → solvent
         assertGt(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "should be solvent with LP equity");
-        assertGt(originARM.withdrawsQueued(), originARM.withdrawsClaimed(), "should have outstanding requests");
+        assertGt(originARM.reservedWithdrawLiquidity(), 0, "should have outstanding requests");
 
         deal(address(weth), bob, DEFAULT_AMOUNT);
         vm.startPrank(bob);

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
+import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
+
+contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared_Test {
+    using stdStorage for StdStorage;
+
+    function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_NotGovernor() public asNotGovernor {
+        vm.expectRevert("ARM: Only owner can call this function.");
+        originARM.migrateLegacyWithdrawQueue();
+    }
+
+    function test_MigrateLegacyWithdrawQueue_When_LegacyQueueIsZero() public asGovernor {
+        originARM.migrateLegacyWithdrawQueue();
+
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+    }
+
+    function test_MigrateLegacyWithdrawQueue_When_LegacyQueueIsFullyClaimed() public asGovernor {
+        uint128 legacyQueued = 5 ether;
+        uint128 legacyClaimed = legacyQueued;
+        _writeLegacyWithdrawQueue(legacyQueued, legacyClaimed);
+
+        originARM.migrateLegacyWithdrawQueue();
+
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+    }
+
+    function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_LegacyWithdrawalsPending() public asGovernor {
+        _writeLegacyWithdrawQueue(5 ether, 4 ether);
+
+        vm.expectRevert("ARM: legacy withdrawals pending");
+        originARM.migrateLegacyWithdrawQueue();
+    }
+
+    function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_NewQueueAlreadyUsed()
+        public
+        deposit(alice, DEFAULT_AMOUNT)
+    {
+        vm.prank(alice);
+        originARM.requestRedeem(DEFAULT_AMOUNT);
+
+        vm.prank(governor);
+        vm.expectRevert("ARM: already migrated");
+        originARM.migrateLegacyWithdrawQueue();
+    }
+
+    function _writeLegacyWithdrawQueue(uint128 legacyQueued, uint128 legacyClaimed) internal {
+        uint256 packedLegacyQueue = uint256(legacyQueued) | (uint256(legacyClaimed) << 128);
+
+        stdstore.target(address(originARM)).sig(originARM.reservedWithdrawLiquidity.selector)
+            .checked_write(packedLegacyQueue);
+
+        assertEq(originARM.reservedWithdrawLiquidity(), packedLegacyQueue, "packed legacy queue");
+    }
+}

--- a/test/unit/OriginARM/RequestRedeem.sol
+++ b/test/unit/OriginARM/RequestRedeem.sol
@@ -26,7 +26,7 @@ contract Unit_Concrete_OriginARM_RequestRedeem_Test_ is Unit_Shared_Test {
         uint256 expectedShares = originARM.convertToShares(DEFAULT_AMOUNT);
         uint256 expectedOETH = originARM.convertToAssets(expectedShares);
         uint256 requestIndex = originARM.nextWithdrawalIndex();
-        uint128 queued = originARM.withdrawsQueued();
+        uint128 queuedShares = originARM.withdrawsQueuedShares();
         uint256 lastAvailableAssets = originARM.totalAssets();
         uint256 previewRedeem = originARM.previewRedeem(DEFAULT_AMOUNT);
         assertEq(previewRedeem, expectedShares, "Preview redeem should match expected shares");
@@ -42,16 +42,15 @@ contract Unit_Concrete_OriginARM_RequestRedeem_Test_ is Unit_Shared_Test {
         (address withdrawer, bool claimed, uint256 requestTimestamp, uint256 amount, uint256 queued_, uint256 shares) =
             originARM.withdrawalRequests(0);
         // Assertions
-        assertEq(
-            originARM.totalAssets(), lastAvailableAssets - DEFAULT_AMOUNT, "Last available assets should be updated"
-        );
-        assertEq(originARM.withdrawsQueued(), queued + DEFAULT_AMOUNT, "Withdraws queued should be updated");
+        assertEq(originARM.totalAssets(), lastAvailableAssets, "Total assets should include escrowed shares");
+        assertEq(originARM.reservedWithdrawLiquidity(), DEFAULT_AMOUNT, "Reserved liquidity should be updated");
+        assertEq(originARM.withdrawsQueuedShares(), queuedShares + expectedShares, "Queued shares should be updated");
         assertEq(originARM.nextWithdrawalIndex(), requestIndex + 1, "Next withdrawal index should be updated");
         assertEq(withdrawer, alice, "Withdrawer should be Alice");
         assertEq(claimed, false, "Claimed should be false");
         assertEq(requestTimestamp, block.timestamp + CLAIM_DELAY, "Request timestamp should be updated");
         assertEq(amount, DEFAULT_AMOUNT, "Amount should be updated");
-        assertEq(queued_, queued + DEFAULT_AMOUNT, "Queued should be updated");
+        assertEq(queued_, queuedShares + expectedShares, "Queued should be updated");
         assertEq(shares, expectedShares, "Shares should be updated");
     }
 }

--- a/test/unit/OriginARM/Setters.sol
+++ b/test/unit/OriginARM/Setters.sol
@@ -161,8 +161,8 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
         originARM.setFee(newFee);
         assertEq(originARM.fee(), newFee, "Wrong fee");
         assertEq(
-            _swapFeeMultiplier(_buyPrice(), originARM.fee()),
-            _expectedSwapFeeMultiplier(_buyPrice(), newFee),
+            _swapFeeMultiplier(_buyPrice(), _crossPrice(), originARM.fee()),
+            _expectedSwapFeeMultiplier(_buyPrice(), _crossPrice(), newFee),
             "Wrong swap fee multiplier"
         );
         assertEq(weth.balanceOf(originARM.feeCollector()), feeCollectorBalanceBefore, "Wrong fee collector balance");
@@ -185,8 +185,8 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
         originARM.setFee(newFee);
         assertEq(originARM.fee(), newFee, "Wrong fee");
         assertEq(
-            _swapFeeMultiplier(_buyPrice(), originARM.fee()),
-            _expectedSwapFeeMultiplier(_buyPrice(), newFee),
+            _swapFeeMultiplier(_buyPrice(), _crossPrice(), originARM.fee()),
+            _expectedSwapFeeMultiplier(_buyPrice(), _crossPrice(), newFee),
             "Wrong swap fee multiplier"
         );
         assertEq(weth.balanceOf(feeCollector), feeCollectorBalanceBefore + feeToCollect, "Wrong fee collector balance");
@@ -250,8 +250,8 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
         assertEq(_buyLiquidityRemaining(), newBuyLiquidity, "Wrong buy liquidity");
         assertEq(_sellLiquidityRemaining(), newSellLiquidity, "Wrong sell liquidity");
         assertEq(
-            _swapFeeMultiplier(_buyPrice(), originARM.fee()),
-            _expectedSwapFeeMultiplier(newBuyPrice, originARM.fee()),
+            _swapFeeMultiplier(_buyPrice(), _crossPrice(), originARM.fee()),
+            _expectedSwapFeeMultiplier(newBuyPrice, _crossPrice(), originARM.fee()),
             "Wrong swap fee multiplier"
         );
     }
@@ -305,9 +305,13 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
         assertEq(_crossPrice(), crossPrice + 1, "Wrong cross price");
     }
 
-    function _expectedSwapFeeMultiplier(uint256 buyT1, uint256 fee) internal view returns (uint256) {
+    function _expectedSwapFeeMultiplier(uint256 buyT1, uint256 crossPrice, uint256 fee)
+        internal
+        view
+        returns (uint256)
+    {
         uint256 priceScale = originARM.PRICE_SCALE();
         if (buyT1 == 0 || fee == 0) return 0;
-        return (priceScale - buyT1) * fee * priceScale / (buyT1 * originARM.FEE_SCALE());
+        return (crossPrice - buyT1) * fee * priceScale / (buyT1 * originARM.FEE_SCALE());
     }
 }

--- a/test/unit/OriginARM/SwapLiquidityFromMarket.sol
+++ b/test/unit/OriginARM/SwapLiquidityFromMarket.sol
@@ -81,7 +81,7 @@ contract Unit_Concrete_OriginARM_SwapLiquidityFromMarket_Test_ is Unit_Shared_Te
         originARM.swapTokensForExactTokens(oeth, weth, amountOut, type(uint256).max, swapper);
         vm.stopPrank();
 
-        assertEq(originARM.withdrawsQueued() - originARM.withdrawsClaimed(), queuedAssets, "queued amount tracked");
+        assertEq(originARM.reservedWithdrawLiquidity(), queuedAssets, "reserved amount tracked");
         assertEq(weth.balanceOf(address(originARM)), queuedAssets, "queued redeem liquidity remains in ARM");
     }
 

--- a/test/unit/OriginARM/TotalAssets.sol
+++ b/test/unit/OriginARM/TotalAssets.sol
@@ -28,10 +28,10 @@ contract Unit_Concrete_OriginARM_TotalAssets_Test_ is Unit_Shared_Test {
 
     /// deposit then redeem should have no impact on total assets
     function test_TotalAssets_When_WithdrawQueue_IsNotZero() public deposit(alice, 1 ether) requestRedeemAll(alice) {
-        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "Wrong total assets");
+        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY + 1 ether, "Wrong total assets");
     }
 
-    /// market take a 100% loss, totalAssets should be MIN_TOTAL_SUPPLY
+    /// queued shares remain in total supply, so a market loss is shared pro-rata
     function test_TotalAssets_When_MarketLoseAll()
         public
         addMarket(address(market))
@@ -42,7 +42,7 @@ contract Unit_Concrete_OriginARM_TotalAssets_Test_ is Unit_Shared_Test {
         simulateMarketLoss(address(market), 1 ether)
         requestRedeem(alice, 1 ether)
     {
-        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "Wrong total assets");
+        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY + 1 ether, "Wrong total assets");
     }
 
     function test_TotalAssets_When_AssetIsLessThanOutstandingWithdrawals()

--- a/test/unit/shared/Shared.sol
+++ b/test/unit/shared/Shared.sol
@@ -168,9 +168,9 @@ abstract contract Unit_Shared_Test is Base_Test_, Modifiers {
         crossPrice = crossPriceMem;
     }
 
-    function _swapFeeMultiplier(uint256 buyPrice, uint256 fee) internal view returns (uint256) {
+    function _swapFeeMultiplier(uint256 buyPrice, uint256 crossPrice, uint256 fee) internal view returns (uint256) {
         uint256 priceScale = originARM.PRICE_SCALE();
         if (buyPrice == 0 || fee == 0) return 0;
-        return (priceScale - buyPrice) * fee * priceScale / (buyPrice * originARM.FEE_SCALE());
+        return (crossPrice - buyPrice) * fee * priceScale / (buyPrice * originARM.FEE_SCALE());
     }
 }


### PR DESCRIPTION
## Summary

Improves loss socialization for LP withdrawal requests so queued redeemers and remaining LPs share post-request gains/losses pro-rata.

Key behavior changes:
- LP redeem requests escrow shares in the ARM instead of burning them at request time.
- Queued redeem shares remain in `totalSupply()` until claim.
- `reservedWithdrawLiquidity` replaces the legacy asset-side cumulative queue counters.
- `withdrawsQueuedShares` / `withdrawsClaimedShares` now drive FIFO claim gating.
- `claimable()` now returns the cumulative claimable share frontier.
- `WithdrawalRequest.queued` is now cumulative queued shares.
- Claim payout remains capped at `min(request.assets, convertToAssets(request.shares))`.

## Changes

- Reworked `AbstractARM` withdrawal queue accounting around live reserved liquidity and share-denominated queue progress.
- Updated `totalAssets()` / `_availableAssets()` to report gross economic assets instead of subtracting LP withdrawal obligations.
- Updated allocation, reserve, swap-liquidity, and deposit solvency checks to read `reservedWithdrawLiquidity`.
- Added `migrateLegacyWithdrawQueue()` to clear the reused legacy packed queue slot during upgrade, requiring no outstanding legacy queued withdrawals.
- Updated unit, fork, smoke, and invariant tests for escrowed shares, gross assets, share queue counters, and reservation accounting.

## Testing

- `forge fmt`
- `forge build`
- `git diff --check`
- `forge test --match-path 'test/unit/OriginARM/*.sol'`
- `forge test --match-path 'test/fork/**/*.sol'`
- `forge test --match-path 'test/invariants/**/*.sol'`
- `forge test --match-path 'test/smoke/*.sol'`