### PR TITLE
Value base assets in the base withdrawal queue at the cross price

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -884,8 +884,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
                 _convertToAssets(config, IERC20(supportedBaseAsset).balanceOf(address(this)));
             availableAssets += baseConvertedToLiquid * config.crossPrice / PRICE_SCALE;
             // Pending adapter redemptions are already tracked in liquidity terms and represent assets
-            // expected back from protocol withdrawal queues.
-            availableAssets += config.pendingRedeemAssets;
+            // expected back from protocol withdrawal queues. Value them at the live cross price so moving
+            // base assets into a withdrawal queue does not create an immediate assets-per-share increase.
+            availableAssets += uint256(config.pendingRedeemAssets) * config.crossPrice / PRICE_SCALE;
         }
 
         address activeMarketMem = activeMarket;

--- a/test/unit/OriginARM/TotalAssets.sol
+++ b/test/unit/OriginARM/TotalAssets.sol
@@ -21,6 +21,64 @@ contract Unit_Concrete_OriginARM_TotalAssets_Test_ is Unit_Shared_Test {
         assertEq(originARM.totalAssets(), totalAssetsBefore, "Wrong total assets");
     }
 
+    function test_TotalAssets_ValuesPendingBaseRedeemsAtCrossPrice() public {
+        uint256 crossPrice = 0.999e36;
+        uint256 amount = DEFAULT_AMOUNT;
+
+        vm.prank(governor);
+        originARM.setCrossPrice(address(oeth), crossPrice);
+        deal(address(oeth), address(originARM), amount);
+
+        uint256 totalAssetsBefore = originARM.totalAssets();
+        assertEq(totalAssetsBefore, MIN_TOTAL_SUPPLY + amount * crossPrice / 1e36, "total assets before");
+
+        vm.prank(governor);
+        originARM.requestBaseAssetRedeem(address(oeth), amount);
+
+        assertEq(originARM.totalAssets(), totalAssetsBefore, "total assets after request");
+    }
+
+    function test_TotalAssets_PendingBaseRedeemsUseLiveCrossPrice() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 crossPrice = 0.999e36;
+        uint256 newCrossPrice = 0.998e36;
+
+        vm.prank(governor);
+        originARM.setCrossPrice(address(oeth), crossPrice);
+        deal(address(oeth), address(originARM), amount);
+
+        vm.prank(governor);
+        originARM.requestBaseAssetRedeem(address(oeth), amount);
+
+        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY + amount * crossPrice / 1e36, "initial pending value");
+
+        vm.prank(governor);
+        originARM.setCrossPrice(address(oeth), newCrossPrice);
+
+        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY + amount * newCrossPrice / 1e36, "repriced pending value");
+    }
+
+    function test_TotalAssets_ClaimedPendingBaseRedeemsUseActualLiquidityReceived() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 crossPrice = 0.999e36;
+
+        vm.prank(governor);
+        originARM.setCrossPrice(address(oeth), crossPrice);
+        deal(address(oeth), address(originARM), amount);
+
+        vm.prank(governor);
+        originARM.requestBaseAssetRedeem(address(oeth), amount);
+
+        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY + amount * crossPrice / 1e36, "pending value");
+
+        deal(address(weth), address(vault), amount);
+
+        vm.prank(governor);
+        originARM.claimBaseAssetRedeem(address(oeth), amount);
+
+        assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY + amount, "claimed value");
+    }
+
     /// allocating to a market should have no impact on total assets
     function test_TotalAssets_When_ActiveMarket() public addMarket(address(market)) setActiveMarket(address(market)) {
         assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "Wrong total assets");


### PR DESCRIPTION
## Summary

Value pending base-asset redemptions at the live `crossPrice` in `totalAssets()` so moving base assets into an adapter withdrawal queue does not create an immediate NAV bump.

## Changes

- Updated `AbstractARM._availableAssets()` to discount `pendingRedeemAssets` by `crossPrice`.
- Kept `pendingRedeemAssets` storage semantics unchanged as the undiscounted liquidity-denominated expected redemption amount.
- Added unit tests covering:
  - queued base redemptions valued at cross price
  - live cross-price repricing while redemptions are pending
  - claim transition from discounted pending value to actual received liquidity

## Motivation

On-hand base assets were already valued at `crossPrice`, but pending adapter redemptions were previously valued at full expected liquidity. That meant requesting a base-asset redemption could immediately increase ARM NAV, creating an opportunity for new LPs to capture value from sudden yield jumps before redemption completes.

This change keeps queued base assets valued consistently with on-hand base assets.

## Test Plan

- `forge test --match-path test/unit/OriginARM/TotalAssets.sol`
- `forge test --match-path test/fork/LidoARM/TotalAssets.t.sol`
- `forge test --match-path test/fork/OriginARM/VaultInteractions.sol`
- `forge test --match-path test/fork/EtherFiARM/RequestWithdraw.t.sol`
- `forge test --match-path test/fork/EthenaARM/RequestWithdraw.t.sol`
- `forge fmt --check src/contracts/AbstractARM.sol test/unit/OriginARM/TotalAssets.sol`
- `git diff --check -- src/contracts/AbstractARM.sol test/unit/OriginARM/TotalAssets.sol`