### PR TITLE
Reentrancy protection on swaps

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
@@ -16,7 +17,7 @@ import {IAssetAdapter, IERC20, ICapManager} from "./Interfaces.sol";
  * legacy single-base storage so Lido, EtherFi, Ethena, and Origin ARMs can share this implementation.
  * @author Origin Protocol Inc
  */
-abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
+abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGuardUpgradeable {
     ////////////////////////////////////////////////////
     ///                 Constants
     ////////////////////////////////////////////////////
@@ -211,6 +212,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     ) internal {
         _initOwnableOperable(_operator);
         __ERC20_init(_name, _symbol);
+        __ReentrancyGuard_init();
 
         // Transfer a small bit of liquidity from the initializer to this contract.
         IERC20(liquidityAsset).transferFrom(msg.sender, address(this), MIN_TOTAL_SUPPLY);
@@ -242,7 +244,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         uint256 amountIn,
         uint256 amountOutMin,
         address to
-    ) external virtual returns (uint256[] memory amounts) {
+    ) external virtual nonReentrant returns (uint256[] memory amounts) {
         uint256 amountOut = _swapExactTokensForTokens(inToken, outToken, amountIn, to);
         require(amountOut >= amountOutMin, "ARM: Insufficient output amount");
 
@@ -264,7 +266,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         address[] calldata path,
         address to,
         uint256 deadline
-    ) external virtual returns (uint256[] memory amounts) {
+    ) external virtual nonReentrant returns (uint256[] memory amounts) {
         require(path.length == 2, "ARM: Invalid path length");
         _inDeadline(deadline);
 
@@ -289,7 +291,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         uint256 amountOut,
         uint256 amountInMax,
         address to
-    ) external virtual returns (uint256[] memory amounts) {
+    ) external virtual nonReentrant returns (uint256[] memory amounts) {
         uint256 amountIn = _swapTokensForExactTokens(inToken, outToken, amountOut, to);
         require(amountIn <= amountInMax, "ARM: Excess input amount");
 
@@ -311,7 +313,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         address[] calldata path,
         address to,
         uint256 deadline
-    ) external virtual returns (uint256[] memory amounts) {
+    ) external virtual nonReentrant returns (uint256[] memory amounts) {
         require(path.length == 2, "ARM: Invalid path length");
         _inDeadline(deadline);
 
@@ -951,7 +953,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @notice Transfer accrued swap fees to the fee collector.
     /// @return fees Liquidity assets transferred to the fee collector.
-    function collectFees() public returns (uint256 fees) {
+    function collectFees() public nonReentrant returns (uint256 fees) {
         fees = feesAccrued;
         if (fees == 0) return 0;
 

--- a/test/unit/OriginARM/Reentrancy.sol
+++ b/test/unit/OriginARM/Reentrancy.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {MockERC20} from "@solmate/test/utils/mocks/MockERC20.sol";
+
+import {IERC20} from "contracts/Interfaces.sol";
+import {OriginARM} from "contracts/OriginARM.sol";
+import {OriginAssetAdapter} from "contracts/adapters/OriginAssetAdapter.sol";
+import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
+import {MockVault} from "test/unit/mocks/MockVault.sol";
+
+contract Unit_Concrete_OriginARM_Reentrancy_Test_ is Unit_Shared_Test {
+    function test_RevertWhen_BuySideTransferFromReentersSwap() public deposit(alice, 4 * DEFAULT_AMOUNT) {
+        ReentrantBaseToken reentrantBase = new ReentrantBaseToken();
+        OriginAssetAdapter adapter = new OriginAssetAdapter(
+            address(originARM),
+            address(reentrantBase),
+            address(weth),
+            address(new MockVault(IERC20(address(reentrantBase)), weth))
+        );
+
+        vm.prank(governor);
+        originARM.addBaseAsset(
+            address(reentrantBase),
+            address(adapter),
+            992 * 1e33,
+            1001 * 1e33,
+            type(uint128).max,
+            type(uint128).max,
+            1e36,
+            true
+        );
+
+        uint256 sharesToRedeem = originARM.balanceOf(alice) / 2;
+        vm.prank(alice);
+        originARM.requestRedeem(sharesToRedeem);
+
+        address swapper = makeAddr("reentrant swapper");
+        reentrantBase.mint(swapper, DEFAULT_AMOUNT);
+        reentrantBase.mint(address(reentrantBase), DEFAULT_AMOUNT);
+        reentrantBase.configure(originARM, weth, swapper, DEFAULT_AMOUNT);
+
+        vm.startPrank(swapper);
+        reentrantBase.approve(address(originARM), type(uint256).max);
+
+        vm.expectRevert(ReentrancyGuardUpgradeable.ReentrancyGuardReentrantCall.selector);
+        originARM.swapTokensForExactTokens(
+            IERC20(address(reentrantBase)), weth, DEFAULT_AMOUNT, type(uint256).max, swapper
+        );
+
+        vm.stopPrank();
+    }
+}
+
+contract ReentrantBaseToken is MockERC20 {
+    OriginARM public arm;
+    IERC20 public outToken;
+    address public recipient;
+    uint256 public amountOut;
+    bool public reenter;
+
+    constructor() MockERC20("Reentrant OETH", "rOETH", 18) {}
+
+    function configure(OriginARM _arm, IERC20 _outToken, address _recipient, uint256 _amountOut) external {
+        arm = _arm;
+        outToken = _outToken;
+        recipient = _recipient;
+        amountOut = _amountOut;
+        reenter = true;
+        allowance[address(this)][address(_arm)] = type(uint256).max;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        if (reenter) {
+            reenter = false;
+            arm.swapTokensForExactTokens(IERC20(address(this)), outToken, amountOut, type(uint256).max, recipient);
+        }
+
+        return super.transferFrom(from, to, amount);
+    }
+}


### PR DESCRIPTION
**Summary**

Adds reentrancy protection around ARM liquidity-moving entrypoints to prevent nested swap callbacks from reusing the same pre-payout liquidity balance during buy-side swaps.

**Changes**

- Inherits `ReentrancyGuardUpgradeable` in `AbstractARM`.
- Initializes the guard during ARM initialization.
- Applies `nonReentrant` to:
  - both `swapExactTokensForTokens` entrypoints
  - both `swapTokensForExactTokens` entrypoints
  - `collectFees`
- Adds a focused regression test using a callback-capable mock base token that attempts to reenter a buy-side swap during `transferFrom`.

**Verification**

- `forge test --match-path test/unit/OriginARM/Reentrancy.sol`
- `forge test --match-path 'test/unit/OriginARM/*.sol'`

**Notes**

`forge build --sizes` shows `OriginARM` remains under the EIP-170 limit, but `LidoARM` and `EtherFiARM` exceed it, so this fix may need a smaller mitigation before merging for all ARM implementations.