### PR TITLE
Custom errors for Operator and Admin functions

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -17,6 +17,28 @@ import {IAssetAdapter, IERC20, ICapManager} from "./Interfaces.sol";
  * @author Origin Protocol Inc
  */
 abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
+    error UnsupportedAsset();
+    error InvalidAsset();
+    error InvalidAdapter();
+    error AssetAlreadySupported();
+    error InvalidAssetDecimals();
+    error InvalidAdapterAsset();
+    error InvalidBuyPrice();
+    error SellPriceTooLow();
+    error CrossPriceTooLow();
+    error CrossPriceTooHigh();
+    error TooManyBaseAssets();
+    error FeeTooHigh();
+    error InvalidFeeCollector();
+    error InvalidMarket();
+    error InvalidMarketAsset();
+    error MarketAlreadySupported();
+    error MarketNotSupported();
+    error MarketActive();
+    error InvalidARMBuffer();
+    error AlreadyMigrated();
+    error LegacyWithdrawalsPending();
+
     ////////////////////////////////////////////////////
     ///                 Constants
     ////////////////////////////////////////////////////
@@ -539,13 +561,13 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         uint256 newCrossPrice,
         bool peggedToLiquidityAsset
     ) external onlyOwner {
-        require(newBaseAsset != address(0), "ARM: invalid asset");
-        require(adapter != address(0), "ARM: invalid adapter");
-        require(baseAssetConfigs[newBaseAsset].adapter == address(0), "ARM: asset already supported");
-        require(IERC20(newBaseAsset).decimals() == 18, "ARM: invalid asset decimals");
-        require(IAssetAdapter(adapter).asset() == liquidityAsset, "ARM: invalid adapter asset");
-        require(newCrossPrice >= PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION, "ARM: cross price too low");
-        require(newCrossPrice <= PRICE_SCALE, "ARM: cross price too high");
+        if (newBaseAsset == address(0)) revert InvalidAsset();
+        if (adapter == address(0)) revert InvalidAdapter();
+        if (baseAssetConfigs[newBaseAsset].adapter != address(0)) revert AssetAlreadySupported();
+        if (IERC20(newBaseAsset).decimals() != 18) revert InvalidAssetDecimals();
+        if (IAssetAdapter(adapter).asset() != liquidityAsset) revert InvalidAdapterAsset();
+        if (newCrossPrice < PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION) revert CrossPriceTooLow();
+        if (newCrossPrice > PRICE_SCALE) revert CrossPriceTooHigh();
         _validatePrices(buyPrice, sellPrice, newCrossPrice);
 
         baseAssets.push(newBaseAsset);
@@ -583,7 +605,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         uint256 sellAmount
     ) external onlyOperatorOrOwner {
         BaseAssetConfig storage config = baseAssetConfigs[priceBaseAsset];
-        require(config.adapter != address(0), "ARM: unsupported asset");
+        if (config.adapter == address(0)) revert UnsupportedAsset();
         _validatePrices(buyPrice, sellPrice, config.crossPrice);
 
         config.buyPrice = SafeCast.toUint128(buyPrice);
@@ -595,8 +617,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     }
 
     function _validatePrices(uint256 buyPrice, uint256 sellPrice, uint256 crossPrice) internal pure {
-        require(sellPrice >= crossPrice, "ARM: sell price too low");
-        require(buyPrice >= MAX_CROSS_PRICE_DEVIATION && buyPrice < crossPrice, "ARM: invalid buy price");
+        if (sellPrice < crossPrice) revert SellPriceTooLow();
+        if (buyPrice < MAX_CROSS_PRICE_DEVIATION || buyPrice >= crossPrice) revert InvalidBuyPrice();
     }
 
     /// @notice Set the valuation price that buy and sell prices may not cross for a base asset.
@@ -607,16 +629,16 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// eg 1e36 values the base asset at 1 liquidity asset.
     function setCrossPrice(address priceBaseAsset, uint256 newCrossPrice) external onlyOwner {
         BaseAssetConfig storage config = baseAssetConfigs[priceBaseAsset];
-        require(config.adapter != address(0), "ARM: unsupported asset");
-        require(newCrossPrice >= PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION, "ARM: cross price too low");
-        require(newCrossPrice <= PRICE_SCALE, "ARM: cross price too high");
-        require(config.sellPrice >= newCrossPrice, "ARM: sell price too low");
-        require(config.buyPrice < newCrossPrice, "ARM: invalid buy price");
+        if (config.adapter == address(0)) revert UnsupportedAsset();
+        if (newCrossPrice < PRICE_SCALE - MAX_CROSS_PRICE_DEVIATION) revert CrossPriceTooLow();
+        if (newCrossPrice > PRICE_SCALE) revert CrossPriceTooHigh();
+        if (config.sellPrice < newCrossPrice) revert SellPriceTooLow();
+        if (config.buyPrice >= newCrossPrice) revert InvalidBuyPrice();
 
         if (newCrossPrice < config.crossPrice) {
             uint256 baseAssetExposure =
                 _convertToAssets(config, IERC20(priceBaseAsset).balanceOf(address(this))) + config.pendingRedeemAssets;
-            require(baseAssetExposure < MIN_TOTAL_SUPPLY, "ARM: too many base assets");
+            if (baseAssetExposure >= MIN_TOTAL_SUPPLY) revert TooManyBaseAssets();
         }
 
         config.crossPrice = SafeCast.toUint128(newCrossPrice);
@@ -639,7 +661,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         returns (uint256 sharesRequested, uint256 assetsExpected)
     {
         BaseAssetConfig storage config = baseAssetConfigs[redeemBaseAsset];
-        require(config.adapter != address(0), "ARM: unsupported asset");
+        if (config.adapter == address(0)) revert UnsupportedAsset();
 
         (sharesRequested, assetsExpected) = IAssetAdapter(config.adapter).requestRedeem(shares);
         // Track the liquidity-denominated value expected back from the adapter queue.
@@ -660,7 +682,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         returns (uint256 sharesClaimed, uint256 assetsExpected, uint256 assetsReceived)
     {
         BaseAssetConfig storage config = baseAssetConfigs[redeemBaseAsset];
-        require(config.adapter != address(0), "ARM: unsupported asset");
+        if (config.adapter == address(0)) revert UnsupportedAsset();
 
         (sharesClaimed, assetsExpected, assetsReceived) = IAssetAdapter(config.adapter).redeem(shares);
         // Remove expected queue value. Any received shortfall remains reflected in totalAssets().
@@ -939,7 +961,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// 10,000 = 100% fee
     /// 500 = 5% fee
     function _setFee(uint256 _fee) internal {
-        require(_fee <= FEE_SCALE / 2, "ARM: fee too high");
+        if (_fee > FEE_SCALE / 2) revert FeeTooHigh();
         collectFees();
         fee = SafeCast.toUint16(_fee);
         emit FeeUpdated(_fee);
@@ -947,7 +969,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
 
     /// @param _feeCollector Account or contract that receives accrued swap fees.
     function _setFeeCollector(address _feeCollector) internal {
-        require(_feeCollector != address(0), "ARM: invalid fee collector");
+        if (_feeCollector == address(0)) revert InvalidFeeCollector();
         feeCollector = _feeCollector;
         emit FeeCollectorUpdated(_feeCollector);
     }
@@ -978,9 +1000,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     function addMarkets(address[] calldata _markets) external onlyOwner {
         for (uint256 i = 0; i < _markets.length; ++i) {
             address market = _markets[i];
-            require(market != address(0), "ARM: invalid market");
-            require(!supportedMarkets[market], "ARM: market already supported");
-            require(IERC4626(market).asset() == liquidityAsset, "ARM: invalid market asset");
+            if (market == address(0)) revert InvalidMarket();
+            if (supportedMarkets[market]) revert MarketAlreadySupported();
+            if (IERC4626(market).asset() != liquidityAsset) revert InvalidMarketAsset();
 
             supportedMarkets[market] = true;
             emit MarketAdded(market);
@@ -990,9 +1012,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Remove a supported ERC-4626 lending market.
     /// @param _market Market address to remove.
     function removeMarket(address _market) external onlyOwner {
-        require(_market != address(0), "ARM: invalid market");
-        require(supportedMarkets[_market], "ARM: market not supported");
-        require(_market != activeMarket, "ARM: market in active");
+        if (_market == address(0)) revert InvalidMarket();
+        if (!supportedMarkets[_market]) revert MarketNotSupported();
+        if (_market == activeMarket) revert MarketActive();
 
         supportedMarkets[_market] = false;
         emit MarketRemoved(_market);
@@ -1002,7 +1024,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @dev Redeems all shares from the previous market before switching.
     /// @param _market Supported market to activate, or address(0) to disable active allocation.
     function setActiveMarket(address _market) external onlyOperatorOrOwner {
-        require(_market == address(0) || supportedMarkets[_market], "ARM: market not supported");
+        if (_market != address(0) && !supportedMarkets[_market]) revert MarketNotSupported();
         // Read once from storage to save gas and make it clear this is the previous active market.
         address previousActiveMarket = activeMarket;
         // Don't revert if the previous active market is the same as the new one.
@@ -1110,7 +1132,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// 1e18 = 100% buffer
     /// 0.1e18 = 10% buffer
     function setARMBuffer(uint256 _armBuffer) external onlyOperatorOrOwner {
-        require(_armBuffer <= 1e18, "ARM: invalid arm buffer");
+        if (_armBuffer > 1e18) revert InvalidARMBuffer();
         armBuffer = _armBuffer;
         emit ARMBufferUpdated(_armBuffer);
     }
@@ -1122,12 +1144,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     function migrateLegacyWithdrawQueue() external onlyOwner reinitializer(2) {
         _checkNoLegacyWithdrawQueue();
 
-        require(withdrawsQueuedShares == 0 && withdrawsClaimedShares == 0, "ARM: already migrated");
+        if (withdrawsQueuedShares != 0 || withdrawsClaimedShares != 0) revert AlreadyMigrated();
 
         uint256 packedLegacyQueue = reservedWithdrawLiquidity;
         uint128 legacyQueued = uint128(packedLegacyQueue);
         uint128 legacyClaimed = uint128(packedLegacyQueue >> 128);
-        require(legacyQueued == legacyClaimed, "ARM: legacy withdrawals pending");
+        if (legacyQueued != legacyClaimed) revert LegacyWithdrawalsPending();
 
         reservedWithdrawLiquidity = 0;
     }

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -17,28 +17,6 @@ import {IAssetAdapter, IERC20, ICapManager} from "./Interfaces.sol";
  * @author Origin Protocol Inc
  */
 abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
-    error UnsupportedAsset();
-    error InvalidAsset();
-    error InvalidAdapter();
-    error AssetAlreadySupported();
-    error InvalidAssetDecimals();
-    error InvalidAdapterAsset();
-    error InvalidBuyPrice();
-    error SellPriceTooLow();
-    error CrossPriceTooLow();
-    error CrossPriceTooHigh();
-    error TooManyBaseAssets();
-    error FeeTooHigh();
-    error InvalidFeeCollector();
-    error InvalidMarket();
-    error InvalidMarketAsset();
-    error MarketAlreadySupported();
-    error MarketNotSupported();
-    error MarketActive();
-    error InvalidARMBuffer();
-    error AlreadyMigrated();
-    error LegacyWithdrawalsPending();
-
     ////////////////////////////////////////////////////
     ///                 Constants
     ////////////////////////////////////////////////////
@@ -156,6 +134,28 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     uint128 public withdrawsClaimedShares;
 
     uint256[34] private _gap;
+
+    error UnsupportedAsset();
+    error InvalidAsset();
+    error InvalidAdapter();
+    error AssetAlreadySupported();
+    error InvalidAssetDecimals();
+    error InvalidAdapterAsset();
+    error InvalidBuyPrice();
+    error SellPriceTooLow();
+    error CrossPriceTooLow();
+    error CrossPriceTooHigh();
+    error TooManyBaseAssets();
+    error FeeTooHigh();
+    error InvalidFeeCollector();
+    error InvalidMarket();
+    error InvalidMarketAsset();
+    error MarketAlreadySupported();
+    error MarketNotSupported();
+    error MarketActive();
+    error InvalidARMBuffer();
+    error AlreadyMigrated();
+    error LegacyWithdrawalsPending();
 
     ////////////////////////////////////////////////////
     ///                 Events

--- a/src/contracts/CapManager.sol
+++ b/src/contracts/CapManager.sol
@@ -12,6 +12,8 @@ import {ILiquidityProviderARM} from "./Interfaces.sol";
  * @author Origin Protocol Inc
  */
 contract CapManager is Initializable, OwnableOperable {
+    error AccountCapAlreadySet();
+
     /// @notice The address of the linked Automated Redemption Manager (ARM).
     address public immutable arm;
 
@@ -81,7 +83,7 @@ contract CapManager is Initializable, OwnableOperable {
 
     /// @notice Enable or disable the account cap.
     function setAccountCapEnabled(bool _accountCapEnabled) external onlyOwner {
-        require(accountCapEnabled != _accountCapEnabled, "LPC: Account cap already set");
+        if (accountCapEnabled == _accountCapEnabled) revert AccountCapAlreadySet();
 
         accountCapEnabled = _accountCapEnabled;
 

--- a/src/contracts/Ownable.sol
+++ b/src/contracts/Ownable.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.8.23;
  * @author Origin Protocol Inc
  */
 contract Ownable {
+    error OnlyOwner();
+
     /// @notice The slot used to store the owner of the contract.
     /// This is also used as the proxy admin.
     /// keccak256(“eip1967.proxy.admin”) - 1 per EIP 1967
@@ -47,7 +49,7 @@ contract Ownable {
     }
 
     function _onlyOwner() internal view {
-        require(msg.sender == _owner(), "ARM: Only owner can call this function.");
+        if (msg.sender != _owner()) revert OnlyOwner();
     }
 
     modifier onlyOwner() {

--- a/src/contracts/OwnableOperable.sol
+++ b/src/contracts/OwnableOperable.sol
@@ -8,6 +8,8 @@ import {Ownable} from "./Ownable.sol";
  * @author Origin Protocol Inc
  */
 contract OwnableOperable is Ownable {
+    error OnlyOperatorOrOwner();
+
     /// @notice The account that can request and claim withdrawals.
     address public operator;
 
@@ -32,7 +34,7 @@ contract OwnableOperable is Ownable {
     }
 
     modifier onlyOperatorOrOwner() {
-        require(msg.sender == operator || msg.sender == _owner(), "ARM: Only operator or owner can call this function.");
+        if (msg.sender != operator && msg.sender != _owner()) revert OnlyOperatorOrOwner();
         _;
     }
 }

--- a/test/deploy/EthenaUpgradeGuards.t.sol
+++ b/test/deploy/EthenaUpgradeGuards.t.sol
@@ -80,7 +80,7 @@ contract EthenaUpgradeGuardsTest is Test {
         proxy.upgradeTo(address(newImpl));
 
         vm.prank(makeAddr("not owner"));
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         EthenaARM(address(proxy)).migrateLegacyWithdrawQueue();
     }
 

--- a/test/deploy/EtherFiUpgradeGuards.t.sol
+++ b/test/deploy/EtherFiUpgradeGuards.t.sol
@@ -80,7 +80,7 @@ contract EtherFiUpgradeGuardsTest is Test {
         proxy.upgradeTo(address(newImpl));
 
         vm.prank(makeAddr("not owner"));
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         EtherFiARM(payable(address(proxy))).migrateLegacyWithdrawQueue();
     }
 

--- a/test/deploy/LidoUpgradeGuards.t.sol
+++ b/test/deploy/LidoUpgradeGuards.t.sol
@@ -80,7 +80,7 @@ contract LidoUpgradeGuardsTest is Test {
         proxy.upgradeTo(address(newImpl));
 
         vm.prank(makeAddr("not owner"));
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         LidoARM(payable(address(proxy))).migrateLegacyWithdrawQueue();
     }
 

--- a/test/fork/EthenaARM/RequestWithdraw.t.sol
+++ b/test/fork/EthenaARM/RequestWithdraw.t.sol
@@ -138,7 +138,7 @@ contract Fork_Concrete_EthenaARM_RequestWithdraw_Test_ is Fork_Shared_Test {
     }
 
     function test_RevertWhen_RequestWithdraw_NotOperatorOrOwner() public {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         ethenaARM.requestBaseAssetRedeem(address(susde), AMOUNT_IN);
     }
 

--- a/test/fork/Harvester/Setters.sol
+++ b/test/fork/Harvester/Setters.sol
@@ -10,7 +10,7 @@ contract Fork_Concrete_Harvester_Setters_Test_ is Fork_Shared_Test {
     /// --- REVERTS
     ////////////////////////////////////////////////////
     function test_RevertWhen_SetAllowedSlippage_Because_NotOwner() public {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         harvester.setAllowedSlippage(1000);
     }
@@ -22,13 +22,13 @@ contract Fork_Concrete_Harvester_Setters_Test_ is Fork_Shared_Test {
     }
 
     function test_RevertWhen_SetPriceProvider_Because_NotOwner() public {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         harvester.setPriceProvider(address(0));
     }
 
     function test_RevertWhen_SetRewardRecipient_Because_NotOwner() public {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         harvester.setRewardRecipient(address(0x1));
     }
@@ -40,7 +40,7 @@ contract Fork_Concrete_Harvester_Setters_Test_ is Fork_Shared_Test {
     }
 
     function test_RevertWhen_SetSupportedStrategy_Because_NotOwner() public {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         harvester.setSupportedStrategy(address(0x1234), true);
     }

--- a/test/fork/LidoARM/Proxy.t.sol
+++ b/test/fork/LidoARM/Proxy.t.sol
@@ -25,16 +25,16 @@ contract Fork_Concrete_LidoARM_Proxy_Test_ is Fork_Shared_Test_ {
     //////////////////////////////////////////////////////
     function test_RevertWhen_UnauthorizedAccess() public {
         vm.startPrank(address(0x123));
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoProxy.setOwner(deployer);
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoProxy.initialize(address(this), address(this), "");
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoProxy.upgradeTo(address(this));
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoProxy.upgradeToAndCall(address(this), "");
         vm.stopPrank();
     }

--- a/test/fork/LidoARM/RequestStETHWithdrawalForETH.t.sol
+++ b/test/fork/LidoARM/RequestStETHWithdrawalForETH.t.sol
@@ -26,7 +26,7 @@ contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = DEFAULT_AMOUNT;
 
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         lidoARM.requestBaseAssetRedeem(address(steth), amounts[0]);
     }
 

--- a/test/fork/LidoARM/SetCrossPrice.t.sol
+++ b/test/fork/LidoARM/SetCrossPrice.t.sol
@@ -19,29 +19,29 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
     /// --- REVERTING TESTS
     //////////////////////////////////////////////////////
     function test_RevertWhen_SetCrossPrice_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setCrossPrice(address(steth), 0.9998e36);
     }
 
     function test_RevertWhen_SetCrossPrice_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setCrossPrice(address(steth), 0.9998e36);
     }
 
     function test_RevertWhen_SetCrossPrice_Because_CrossPriceTooLow() public {
-        vm.expectRevert("ARM: cross price too low");
+        vm.expectRevert(bytes4(keccak256("CrossPriceTooLow()")));
         lidoARM.setCrossPrice(address(steth), 0);
     }
 
     function test_RevertWhen_SetCrossPrice_Because_CrossPriceTooHigh() public {
         uint256 priceScale = 10 ** 36;
-        vm.expectRevert("ARM: cross price too high");
+        vm.expectRevert(bytes4(keccak256("CrossPriceTooHigh()")));
         lidoARM.setCrossPrice(address(steth), priceScale + 1);
     }
 
     function test_RevertWhen_SetCrossPrice_Because_BuyPriceTooHigh() public {
         lidoARM.setPrices(address(steth), 1e36 - 20e32 + 1, 1000 * 1e33 + 1, type(uint128).max, type(uint128).max);
-        vm.expectRevert("ARM: invalid buy price");
+        vm.expectRevert(bytes4(keccak256("InvalidBuyPrice()")));
         lidoARM.setCrossPrice(address(steth), 1e36 - 20e32);
     }
 
@@ -56,13 +56,13 @@ contract Fork_Concrete_LidoARM_SetCrossPrice_Test_ is Fork_Shared_Test_ {
         lidoARM.setPrices(address(steth), 1e36 - 20e32, 1e36 - 20e32 + 1, type(uint128).max, type(uint128).max);
 
         // Then we try to set cross price above the sell price
-        vm.expectRevert("ARM: sell price too low");
+        vm.expectRevert(bytes4(keccak256("SellPriceTooLow()")));
         lidoARM.setCrossPrice(address(steth), 1e36 - 20e32 + 2);
     }
 
     function test_RevertWhen_SetCrossPrice_Because_TooManyBaseAssets() public {
         deal(address(steth), address(lidoARM), MIN_TOTAL_SUPPLY + STETH_ERROR_ROUNDING);
-        vm.expectRevert("ARM: too many base assets");
+        vm.expectRevert(bytes4(keccak256("TooManyBaseAssets()")));
         lidoARM.setCrossPrice(address(steth), 1e36 - 1);
     }
 

--- a/test/fork/LidoARM/Setters.t.sol
+++ b/test/fork/LidoARM/Setters.t.sol
@@ -26,33 +26,33 @@ contract Fork_Concrete_LidoARM_Setters_Test_ is Fork_Shared_Test_ {
     /// --- PERFORMANCE FEE - REVERTING TEST
     //////////////////////////////////////////////////////
     function test_RevertWhen_PerformanceFee_SetFee_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setFee(0);
     }
 
     function test_RevertWhen_PerformanceFee_SetFee_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setFee(0);
     }
 
     function test_RevertWhen_PerformanceFee_SetFee_Because_FeeIsTooHigh() public asLidoARMOwner {
         uint256 max = FEE_SCALE;
-        vm.expectRevert("ARM: fee too high");
+        vm.expectRevert(bytes4(keccak256("FeeTooHigh()")));
         lidoARM.setFee(max + 1);
     }
 
     function test_RevertWhen_PerformanceFee_SetFeeCollector_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setFeeCollector(address(0));
     }
 
     function test_RevertWhen_PerformanceFee_SetFeeCollector_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setFeeCollector(address(0));
     }
 
     function test_RevertWhen_PerformanceFee_SetFeeCollector_Because_FeeCollectorIsZero() public asLidoARMOwner {
-        vm.expectRevert("ARM: invalid fee collector");
+        vm.expectRevert(bytes4(keccak256("InvalidFeeCollector()")));
         lidoARM.setFeeCollector(address(0));
     }
 
@@ -90,40 +90,40 @@ contract Fork_Concrete_LidoARM_Setters_Test_ is Fork_Shared_Test_ {
     //////////////////////////////////////////////////////
     function test_RevertWhen_SetPrices_Because_PriceRange_Operator() public asOperator {
         // buy price 1 basis points higher than 1.0
-        vm.expectRevert("ARM: invalid buy price");
+        vm.expectRevert(bytes4(keccak256("InvalidBuyPrice()")));
         lidoARM.setPrices(address(steth), 1.0001 * 1e36, 1.002 * 1e36, type(uint128).max, type(uint128).max);
 
         // sell price 11 basis points lower than 1.0
-        vm.expectRevert("ARM: sell price too low");
+        vm.expectRevert(bytes4(keccak256("SellPriceTooLow()")));
         lidoARM.setPrices(address(steth), 0.998 * 1e36, 0.9989 * 1e36, type(uint128).max, type(uint128).max);
 
         // Forgot to scale up to 36 decimals
-        vm.expectRevert("ARM: sell price too low");
+        vm.expectRevert(bytes4(keccak256("SellPriceTooLow()")));
         lidoARM.setPrices(address(steth), 1e18, 1e18, type(uint128).max, type(uint128).max);
     }
 
     function test_RevertWhen_SetPrices_Because_PriceRange_Owner() public asLidoARMOwner {
         // buy price 1 basis points higher than 1.0
-        vm.expectRevert("ARM: invalid buy price");
+        vm.expectRevert(bytes4(keccak256("InvalidBuyPrice()")));
         lidoARM.setPrices(address(steth), 1.0001 * 1e36, 1.002 * 1e36, type(uint128).max, type(uint128).max);
 
         // sell price 11 basis points lower than 1.0
-        vm.expectRevert("ARM: sell price too low");
+        vm.expectRevert(bytes4(keccak256("SellPriceTooLow()")));
         lidoARM.setPrices(address(steth), 0.998 * 1e36, 0.9989 * 1e36, type(uint128).max, type(uint128).max);
     }
 
     function test_RevertWhen_SetPrices_Because_NotOwnerOrOperator() public asRandomAddress {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         lidoARM.setPrices(address(steth), 0, 0, type(uint128).max, type(uint128).max);
     }
 
     function test_RevertWhen_SetPrices_Because_SellPriceCannotCrossOneByMoreThanTenBps() public asOperator {
-        vm.expectRevert("ARM: sell price too low");
+        vm.expectRevert(bytes4(keccak256("SellPriceTooLow()")));
         lidoARM.setPrices(address(steth), 0.998 * 1e36, 0.9989 * 1e36, type(uint128).max, type(uint128).max);
     }
 
     function test_RevertWhen_SetPrices_Because_BuyPriceCannotCrossOneByMoreThanTenBps() public asOperator {
-        vm.expectRevert("ARM: invalid buy price");
+        vm.expectRevert(bytes4(keccak256("InvalidBuyPrice()")));
         lidoARM.setPrices(address(steth), 1.0011 * 1e36, 1.002 * 1e36, type(uint128).max, type(uint128).max);
     }
 
@@ -153,22 +153,22 @@ contract Fork_Concrete_LidoARM_Setters_Test_ is Fork_Shared_Test_ {
     /// --- OWNABLE - REVERTING TESTS
     //////////////////////////////////////////////////////
     function test_RevertWhen_Ownable_SetOwner_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setOwner(address(0));
     }
 
     function test_RevertWhen_Ownable_SetOwner_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setOwner(address(0));
     }
 
     function test_RevertWhen_Ownable_SetOperator_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setOperator(address(0));
     }
 
     function test_RevertWhen_Ownable_SetOperator_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setOperator(address(0));
     }
 
@@ -176,12 +176,12 @@ contract Fork_Concrete_LidoARM_Setters_Test_ is Fork_Shared_Test_ {
     /// --- LIQUIIDITY PROVIDER CONTROLLER - REVERTING TESTS
     //////////////////////////////////////////////////////
     function test_RevertWhen_CapManager_SetLiquidityProvider_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setCapManager(address(0));
     }
 
     function test_RevertWhen_CapManager_SetLiquidityProvider_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setCapManager(address(0));
     }
 
@@ -202,17 +202,17 @@ contract Fork_Concrete_LidoARM_Setters_Test_ is Fork_Shared_Test_ {
     /// --- AccountCapEnabled - REVERTING TEST
     //////////////////////////////////////////////////////
     function test_RevertWhen_CapManager_SetAccountCapEnabled_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         capManager.setAccountCapEnabled(false);
     }
 
     function test_RevertWhen_CapManager_SetAccountCapEnabled_Because_Operator() public asOperator {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         capManager.setAccountCapEnabled(false);
     }
 
     function test_RevertWhen_CapManager_SetAccountCapEnabled_Because_AlreadySet() public enableCaps asLidoARMOwner {
-        vm.expectRevert("LPC: Account cap already set");
+        vm.expectRevert(bytes4(keccak256("AccountCapAlreadySet()")));
         capManager.setAccountCapEnabled(true);
     }
 
@@ -231,7 +231,7 @@ contract Fork_Concrete_LidoARM_Setters_Test_ is Fork_Shared_Test_ {
     /// --- TotalAssetsCap - REVERTING TEST
     //////////////////////////////////////////////////////
     function test_RevertWhen_CapManager_SetTotalAssetsCap_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         capManager.setTotalAssetsCap(100 ether);
     }
 
@@ -258,7 +258,7 @@ contract Fork_Concrete_LidoARM_Setters_Test_ is Fork_Shared_Test_ {
     /// --- LiquidityProviderCaps - REVERTING TEST
     //////////////////////////////////////////////////////
     function test_RevertWhen_CapManager_SetLiquidityProviderCaps_Because_NotOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         capManager.setLiquidityProviderCaps(testProviders, 50 ether);
     }
 

--- a/test/fork/OriginARM/VaultInteractions.sol
+++ b/test/fork/OriginARM/VaultInteractions.sol
@@ -5,7 +5,7 @@ import {Fork_Shared_Test} from "test/fork/OriginARM/shared/Shared.sol";
 
 contract Fork_Concrete_OriginARM_VaultInteractions_Test_ is Fork_Shared_Test {
     function test_RevertWhen_RequestingOriginWithdrawal_IfNotOperator() public asNotOperatorNorGovernor {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         originARM.requestBaseAssetRedeem(address(os), DEFAULT_AMOUNT);
     }
 

--- a/test/fork/Zapper/RescueToken.sol
+++ b/test/fork/Zapper/RescueToken.sol
@@ -9,7 +9,7 @@ import {ZapperLidoARM} from "contracts/ZapperLidoARM.sol";
 
 contract Fork_Concrete_ZapperLidoARM_RescueToken_Test_ is Fork_Shared_Test_ {
     function test_RevertWhen_RescueToken_CalledByNonOwner() public asRandomAddress {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         zapperLidoARM.rescueERC20(address(badToken), DEFAULT_AMOUNT);
     }
 

--- a/test/invariants/EthenaARM/TargetFunctions.sol
+++ b/test/invariants/EthenaARM/TargetFunctions.sol
@@ -327,7 +327,11 @@ abstract contract TargetFunctions is Setup, StdUtils {
         crossPrice = _bound(crossPrice, minCrossPrice, maxCrossPrice);
 
         uint256 susdeBalance = susde.balanceOf(address(arm));
-        if (_crossPrice() > crossPrice && susdeBalance > 0) {
+        (,,,,, uint120 pendingRedeemAssets,,) = arm.baseAssetConfigs(address(susde));
+        bool loweringCrossPrice = _crossPrice() > crossPrice;
+        if (loweringCrossPrice && assume(uint256(pendingRedeemAssets) < DEFAULT_MIN_TOTAL_SUPPLY)) return;
+
+        if (loweringCrossPrice && susdeBalance > 0) {
             // If there is more than 100 susde in ARM, do nothing
             if (assume(susdeBalance < 1e20)) return;
 
@@ -356,6 +360,12 @@ abstract contract TargetFunctions is Setup, StdUtils {
 
             sumUSDeSwapIn += obtained[0];
             sumSUSDeSwapOut += obtained[1];
+        }
+        if (
+            loweringCrossPrice
+                && assume(susde.balanceOf(address(arm)) + uint256(pendingRedeemAssets) < DEFAULT_MIN_TOTAL_SUPPLY)
+        ) {
+            return;
         }
 
         vm.prank(governor);

--- a/test/invariants/LidoARM/TargetFunction.sol
+++ b/test/invariants/LidoARM/TargetFunction.sol
@@ -295,7 +295,13 @@ abstract contract TargetFunction is Properties {
             _bound(newCrossPrice, max(priceScale - MAX_CROSS_PRICE_DEVIATION, buy) + 1, min(priceScale, sell));
 
         uint256 stethBalance = steth.balanceOf(address(lidoARM));
-        if (_lidoCrossPrice() > newCrossPrice && stethBalance > 0) {
+        (,,,,, uint120 pendingRedeemAssets,,) = lidoARM.baseAssetConfigs(address(steth));
+        bool loweringCrossPrice = _lidoCrossPrice() > newCrossPrice;
+        if (loweringCrossPrice) {
+            vm.assume(uint256(pendingRedeemAssets) < MIN_TOTAL_SUPPLY);
+        }
+
+        if (loweringCrossPrice && stethBalance > 0) {
             // If there is more than 100 stETH in ARM, do nothing
             if (stethBalance >= 1e20) return;
 
@@ -309,6 +315,9 @@ abstract contract TargetFunction is Properties {
 
             sum_weth_swap_in += amounts[0];
             sum_steth_swap_out += amounts[1];
+        }
+        if (loweringCrossPrice) {
+            vm.assume(steth.balanceOf(address(lidoARM)) + uint256(pendingRedeemAssets) < MIN_TOTAL_SUPPLY);
         }
 
         // Prank owner

--- a/test/invariants/OriginARM/TargetFunction.sol
+++ b/test/invariants/OriginARM/TargetFunction.sol
@@ -237,7 +237,13 @@ abstract contract TargetFunction is Properties {
         newCrossPrice = uint120(_bound(newCrossPrice, lowerBound, upperBound));
 
         uint256 osBalance = os.balanceOf(address(originARM));
-        if (_crossPrice() > newCrossPrice && osBalance > 0) {
+        (,,,,, uint120 pendingRedeemAssets,,) = originARM.baseAssetConfigs(address(os));
+        bool loweringCrossPrice = _crossPrice() > newCrossPrice;
+        if (loweringCrossPrice) {
+            vm.assume(uint256(pendingRedeemAssets) < MIN_TOTAL_SUPPLY);
+        }
+
+        if (loweringCrossPrice && osBalance > 0) {
             // If there is more than 100 OS in ARM, do nothing
             vm.assume(osBalance < 1e20);
 
@@ -250,6 +256,9 @@ abstract contract TargetFunction is Properties {
 
             sum_ws_swapIn += outputs[0];
             sum_os_swapOut += outputs[1];
+        }
+        if (loweringCrossPrice) {
+            vm.assume(os.balanceOf(address(originARM)) + uint256(pendingRedeemAssets) < MIN_TOTAL_SUPPLY);
         }
 
         // Console log data

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -175,16 +175,16 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         vm.startPrank(RANDOM_ADDRESS);
 
         // Proxy's restricted methods.
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.setOwner(RANDOM_ADDRESS);
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.initialize(address(this), address(this), "");
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.upgradeTo(address(this));
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -175,20 +175,20 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         vm.startPrank(RANDOM_ADDRESS);
 
         // Proxy's restricted methods.
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.setOwner(RANDOM_ADDRESS);
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.initialize(address(this), address(this), "");
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.upgradeTo(address(this));
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         ethenaARM.setOwner(RANDOM_ADDRESS);
     }
 
@@ -200,7 +200,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
     }
 
     function test_nonOwnerCannotSetOperator() external {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         ethenaARM.setOperator(operator);
     }

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -188,7 +188,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         armProxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         ethenaARM.setOwner(RANDOM_ADDRESS);
     }
 

--- a/test/smoke/EtherFiARMSmokeTest.t.sol
+++ b/test/smoke/EtherFiARMSmokeTest.t.sol
@@ -172,20 +172,20 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         vm.startPrank(RANDOM_ADDRESS);
 
         // Proxy's restricted methods.
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.setOwner(RANDOM_ADDRESS);
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.initialize(address(this), address(this), "");
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.upgradeTo(address(this));
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         armProxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         etherFiARM.setOwner(RANDOM_ADDRESS);
     }
 
@@ -205,7 +205,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
     }
 
     function test_nonOwnerCannotSetOperator() external {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         etherFiARM.setOperator(operator);
     }

--- a/test/smoke/EtherFiARMSmokeTest.t.sol
+++ b/test/smoke/EtherFiARMSmokeTest.t.sol
@@ -172,16 +172,16 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         vm.startPrank(RANDOM_ADDRESS);
 
         // Proxy's restricted methods.
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.setOwner(RANDOM_ADDRESS);
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.initialize(address(this), address(this), "");
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.upgradeTo(address(this));
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         armProxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.

--- a/test/smoke/EtherFiARMSmokeTest.t.sol
+++ b/test/smoke/EtherFiARMSmokeTest.t.sol
@@ -185,7 +185,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         armProxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         etherFiARM.setOwner(RANDOM_ADDRESS);
     }
 

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -183,7 +183,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         proxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert("OSwap: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         lidoARM.setOwner(RANDOM_ADDRESS);
     }
 

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -203,7 +203,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
     }
 
     function test_nonOwnerCannotSetOperator() external {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         lidoARM.setOperator(operator);
     }

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -183,7 +183,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         proxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("OSwap: Only owner can call this function.");
         lidoARM.setOwner(RANDOM_ADDRESS);
     }
 

--- a/test/smoke/OethARMSmokeTest.t.sol
+++ b/test/smoke/OethARMSmokeTest.t.sol
@@ -279,7 +279,7 @@ contract Fork_OriginARM_Smoke_Test is AbstractSmokeTest {
         proxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         originARM.setOwner(RANDOM_ADDRESS);
         vm.stopPrank();
 

--- a/test/smoke/OethARMSmokeTest.t.sol
+++ b/test/smoke/OethARMSmokeTest.t.sol
@@ -266,16 +266,16 @@ contract Fork_OriginARM_Smoke_Test is AbstractSmokeTest {
         vm.startPrank(RANDOM_ADDRESS);
 
         // Proxy's restricted methods.
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         proxy.setOwner(RANDOM_ADDRESS);
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         proxy.initialize(address(this), address(this), "");
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         proxy.upgradeTo(address(this));
 
-        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
+        vm.expectRevert("ARM: Only owner can call this function.");
         proxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.

--- a/test/smoke/OethARMSmokeTest.t.sol
+++ b/test/smoke/OethARMSmokeTest.t.sol
@@ -266,24 +266,24 @@ contract Fork_OriginARM_Smoke_Test is AbstractSmokeTest {
         vm.startPrank(RANDOM_ADDRESS);
 
         // Proxy's restricted methods.
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         proxy.setOwner(RANDOM_ADDRESS);
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         proxy.initialize(address(this), address(this), "");
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         proxy.upgradeTo(address(this));
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         proxy.upgradeToAndCall(address(this), "");
 
         // Implementation's restricted methods.
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.setOwner(RANDOM_ADDRESS);
         vm.stopPrank();
 
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         vm.prank(operator);
         originARM.setOperator(operator);
     }

--- a/test/unit/OriginARM/ManageMarket.sol
+++ b/test/unit/OriginARM/ManageMarket.sol
@@ -23,12 +23,12 @@ contract Unit_Concrete_OriginARM_ManageMarket_Test_ is Unit_Shared_Test {
     /// --- REVERTS
     ////////////////////////////////////////////////////
     function test_RevertWhen_AddMarkets_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.addMarkets(new address[](0));
     }
 
     function test_RevertWhen_AddMarkets_Because_AddressZero() public asGovernor {
-        vm.expectRevert("ARM: invalid market");
+        vm.expectRevert(bytes4(keccak256("InvalidMarket()")));
         originARM.addMarkets(new address[](1));
     }
 
@@ -41,7 +41,7 @@ contract Unit_Concrete_OriginARM_ManageMarket_Test_ is Unit_Shared_Test {
     {
         address[] memory strategies = new address[](1);
         strategies[0] = address(market);
-        vm.expectRevert("ARM: market already supported");
+        vm.expectRevert(bytes4(keccak256("MarketAlreadySupported()")));
         originARM.addMarkets(strategies);
     }
 
@@ -50,22 +50,22 @@ contract Unit_Concrete_OriginARM_ManageMarket_Test_ is Unit_Shared_Test {
         strategies[0] = address(0x123);
         // Using mockCall to simulate the asset() function on a simple address
         vm.mockCall(strategies[0], abi.encodeWithSignature("asset()"), abi.encode(address(0)));
-        vm.expectRevert("ARM: invalid market asset");
+        vm.expectRevert(bytes4(keccak256("InvalidMarketAsset()")));
         originARM.addMarkets(strategies);
     }
 
     function test_RevertWhen_RemoveMarket_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.removeMarket(address(market));
     }
 
     function test_RevertWhen_RemoveMarket_Because_MarketIsAddressZero() public asGovernor {
-        vm.expectRevert("ARM: invalid market");
+        vm.expectRevert(bytes4(keccak256("InvalidMarket()")));
         originARM.removeMarket(address(0));
     }
 
     function test_RevertWhen_RemoveMarket_Because_MarketNotSupported() public asGovernor {
-        vm.expectRevert("ARM: market not supported");
+        vm.expectRevert(bytes4(keccak256("MarketNotSupported()")));
         originARM.removeMarket(address(market));
     }
 
@@ -76,17 +76,17 @@ contract Unit_Concrete_OriginARM_ManageMarket_Test_ is Unit_Shared_Test {
         setActiveMarket(address(market))
         asGovernor
     {
-        vm.expectRevert("ARM: market in active");
+        vm.expectRevert(bytes4(keccak256("MarketActive()")));
         originARM.removeMarket(address(market));
     }
 
     function test_RevertWhen_SetActiveMarket_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         originARM.setActiveMarket(address(market));
     }
 
     function test_RevertWhen_SetActiveMarket_Because_MarketNotSupported() public asGovernor {
-        vm.expectRevert("ARM: market not supported");
+        vm.expectRevert(bytes4(keccak256("MarketNotSupported()")));
         originARM.setActiveMarket(address(market));
     }
 

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -8,7 +8,7 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
     using stdStorage for StdStorage;
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.migrateLegacyWithdrawQueue();
     }
 
@@ -31,7 +31,7 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_LegacyWithdrawalsPending() public asGovernor {
         _writeLegacyWithdrawQueue(5 ether, 4 ether);
 
-        vm.expectRevert("ARM: legacy withdrawals pending");
+        vm.expectRevert(bytes4(keccak256("LegacyWithdrawalsPending()")));
         originARM.migrateLegacyWithdrawQueue();
     }
 
@@ -43,7 +43,7 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
         originARM.requestRedeem(DEFAULT_AMOUNT);
 
         vm.prank(governor);
-        vm.expectRevert("ARM: already migrated");
+        vm.expectRevert(bytes4(keccak256("AlreadyMigrated()")));
         originARM.migrateLegacyWithdrawQueue();
     }
 

--- a/test/unit/OriginARM/Setters.sol
+++ b/test/unit/OriginARM/Setters.sol
@@ -9,60 +9,60 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
     /// --- REVERT
     ////////////////////////////////////////////////////
     function test_RevertWhen_SetFeeCollector_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.setFeeCollector(address(0));
     }
 
     function test_RevertWhen_SetFeeCollector_Because_FeeCollectorIsZero() public asGovernor {
-        vm.expectRevert("ARM: invalid fee collector");
+        vm.expectRevert(bytes4(keccak256("InvalidFeeCollector()")));
         originARM.setFeeCollector(address(0));
     }
 
     function test_RevertWhen_SetFee_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.setFee(0);
     }
 
     function test_RevertWhen_SetFee_Because_FeeIsTooHigh() public asGovernor {
-        vm.expectRevert("ARM: fee too high");
+        vm.expectRevert(bytes4(keccak256("FeeTooHigh()")));
         originARM.setFee(FEE_SCALE / 2 + 1);
     }
 
     function test_RevertWhen_SetCapManager_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.setCapManager(address(0));
     }
 
     function test_RevertWhen_SetARMBuffer_Because_NotGovernorNorOperator() public asRandomCaller {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         originARM.setARMBuffer(0);
     }
 
     function test_RevertWhen_SetARMBuffer_Because_Above1e18() public asGovernor {
-        vm.expectRevert("ARM: invalid arm buffer");
+        vm.expectRevert(bytes4(keccak256("InvalidARMBuffer()")));
         originARM.setARMBuffer(1e18 + 1);
     }
 
     function test_RevertWhen_SetPrices_Because_NotOperator() public asNotOperatorNorGovernor {
-        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOperatorOrOwner()")));
         originARM.setPrices(address(oeth), 0, 0, 0, 0);
     }
 
     function test_RevertWhen_SetPrices_Because_SellPriceTooLow() public asOperator {
         uint256 crossPrice = _crossPrice();
-        vm.expectRevert("ARM: sell price too low");
+        vm.expectRevert(bytes4(keccak256("SellPriceTooLow()")));
         originARM.setPrices(address(oeth), 0, crossPrice - 1, 0, 0);
     }
 
     function test_RevertWhen_SetPrices_Because_BuyPriceTooHigh() public asOperator {
         uint256 crossPrice = _crossPrice();
-        vm.expectRevert("ARM: invalid buy price");
+        vm.expectRevert(bytes4(keccak256("InvalidBuyPrice()")));
         originARM.setPrices(address(oeth), crossPrice, crossPrice, 0, 0);
     }
 
     function test_RevertWhen_SetPrices_Because_BuyPriceTooLow() public asOperator {
         uint256 crossPrice = _crossPrice();
-        vm.expectRevert("ARM: invalid buy price");
+        vm.expectRevert(bytes4(keccak256("InvalidBuyPrice()")));
         originARM.setPrices(address(oeth), MAX_CROSS_PRICE_DEVIATION - 1, crossPrice, 0, 0);
     }
 
@@ -76,30 +76,30 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
     }
 
     function test_RevertWhen_SetCrossPrice_Because_NotGovernor() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         originARM.setCrossPrice(address(oeth), 0);
     }
 
     function test_RevertWhen_SetCrossPrice_Because_CrossPriceTooLow() public asGovernor {
         // Far bellow the limit
-        vm.expectRevert("ARM: cross price too low");
+        vm.expectRevert(bytes4(keccak256("CrossPriceTooLow()")));
         originARM.setCrossPrice(address(oeth), 0);
 
         // Just below the limit
         uint256 priceScale = PRICE_SCALE;
         uint256 maxCrossPriceDeviation = MAX_CROSS_PRICE_DEVIATION;
-        vm.expectRevert("ARM: cross price too low");
+        vm.expectRevert(bytes4(keccak256("CrossPriceTooLow()")));
         originARM.setCrossPrice(address(oeth), priceScale - maxCrossPriceDeviation - 1);
     }
 
     function test_RevertWhen_SetCrossPrice_Because_CrossPriceTooHigh() public asGovernor {
         // Far above the limit
-        vm.expectRevert("ARM: cross price too high");
+        vm.expectRevert(bytes4(keccak256("CrossPriceTooHigh()")));
         originARM.setCrossPrice(address(oeth), type(uint256).max);
 
         // Just above the limit
         uint256 priceScale = PRICE_SCALE;
-        vm.expectRevert("ARM: cross price too high");
+        vm.expectRevert(bytes4(keccak256("CrossPriceTooHigh()")));
         originARM.setCrossPrice(address(oeth), priceScale + 1);
     }
 
@@ -116,7 +116,7 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
 
         // Now we have enough space between PRICE_SCALE and sellT1 to set the cross price to a wrong value
         uint256 sellT1 = _sellPrice();
-        vm.expectRevert("ARM: sell price too low");
+        vm.expectRevert(bytes4(keccak256("SellPriceTooLow()")));
         originARM.setCrossPrice(address(oeth), sellT1 + 1);
     }
 
@@ -133,7 +133,7 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
         originARM.setPrices(address(oeth), crossPrice - 1, priceScale, type(uint128).max, type(uint128).max);
 
         // Now we have enough space between PRICE_SCALE and buyT1 to set the cross price to a wrong value
-        vm.expectRevert("ARM: invalid buy price");
+        vm.expectRevert(bytes4(keccak256("InvalidBuyPrice()")));
         originARM.setCrossPrice(address(oeth), priceScale - maxCrossPriceDeviation);
     }
 
@@ -142,7 +142,7 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
 
         // Simlate OETH in the ARM.
         deal(address(oeth), address(originARM), 1e18);
-        vm.expectRevert("ARM: too many base assets");
+        vm.expectRevert(bytes4(keccak256("TooManyBaseAssets()")));
         originARM.setCrossPrice(address(oeth), crossPrice - 1);
     }
 
@@ -154,7 +154,7 @@ contract Unit_Concrete_OriginARM_Setters_Test_ is Unit_Shared_Test {
         originARM.requestBaseAssetRedeem(address(oeth), 1e18);
         assertEq(oeth.balanceOf(address(originARM)), 0, "ARM OETH balance");
 
-        vm.expectRevert("ARM: too many base assets");
+        vm.expectRevert(bytes4(keccak256("TooManyBaseAssets()")));
         originARM.setCrossPrice(address(oeth), crossPrice - 1);
     }
 

--- a/test/unit/SiloMarket/SiloMarket.sol
+++ b/test/unit/SiloMarket/SiloMarket.sol
@@ -56,7 +56,7 @@ contract Unit_Concrete_OriginARM_SiloMarket_Test_ is Unit_Shared_Test {
     }
 
     function test_RevertWhen_SetHarvester_Because_OnlyOwner() public asNotGovernor {
-        vm.expectRevert("ARM: Only owner can call this function.");
+        vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
         siloMarket.setHarvester(address(this));
     }
 


### PR DESCRIPTION
## Summary

- Replace admin/operator-only revert strings with custom errors across ARM ownership, operator, pricing, fee, market, migration, and cap-manager paths.
- Keep user-facing revert strings unchanged for swaps, deposits, LP redeem request/claim flows, and public fee collection.
- Update tests and invariant handlers to expect the new custom-error selectors where applicable.

# Contract Sizes

Current `forge build --sizes` ARM implementation sizes:

| Contract | Runtime size | Runtime margin |
|---|---:|---:|
| `OriginARM` | 22,484 B | 2,092 B |
| `EthenaARM` | 22,503 B | 2,073 B |
| `LidoARM` | 23,245 B | 1,331 B |
| `EtherFiARM` | 23,284 B | 1,292 B |

All four ARM implementations are under the 24,576 byte EIP-170 runtime limit.

`forge build --sizes` exited nonzero because some deploy/script contracts exceed the runtime limit, but the ARM contracts themselves are fine.
