### PR TITLE
Support claiming legacy redeem requests

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -137,8 +137,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     bool public paused;
     /// @notice Maximum liquidity assets reserved for outstanding LP withdrawal requests.
     uint256 public reservedWithdrawLiquidity;
+    /// @notice First withdrawal request id that uses the new share-escrow queue semantics.
+    uint256 public legacyWithdrawalRequestCount;
 
-    uint256[32] private _gap;
+    uint256[31] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Errors
@@ -816,7 +818,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         WithdrawalRequest memory request = withdrawalRequests[requestId];
 
         if (request.claimTimestamp > block.timestamp) revert ClaimDelayNotMet();
-        bool legacyRequest = request.shares == 0;
+        bool legacyRequest = requestId < legacyWithdrawalRequestCount;
         if (legacyRequest) {
             if (request.queued > _legacyClaimable()) revert QueuePendingLiquidity();
         } else {
@@ -1218,6 +1220,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         if (withdrawsQueuedShares != 0 || withdrawsClaimedShares != 0 || reservedWithdrawLiquidity != 0) {
             revert AlreadyMigrated();
         }
+        legacyWithdrawalRequestCount = nextWithdrawalIndex;
     }
 
     /// @dev Hook for protocol-specific legacy withdrawal queue checks before shared queue migration.

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -165,6 +165,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     error InvalidARMBuffer();
     error AlreadyMigrated();
     error ContractPaused();
+    error Insolvent();
+    error ZeroShares();
+    error ClaimDelayNotMet();
+    error QueuePendingLiquidity();
+    error NotRequesterOrOperator();
+    error AlreadyClaimed();
 
     ////////////////////////////////////////////////////
     ///                 Events
@@ -741,7 +747,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @param receiver Account that receives minted LP shares.
     /// @return shares LP shares minted.
     function _deposit(uint256 assets, address receiver) internal returns (uint256 shares) {
-        require(totalAssets() > MIN_TOTAL_SUPPLY || reservedWithdrawLiquidity == 0, "ARM: insolvent");
+        if (totalAssets() <= MIN_TOTAL_SUPPLY && reservedWithdrawLiquidity != 0) revert Insolvent();
         shares = convertToShares(assets);
 
         // Transfer liquidity from the depositor before minting LP shares.
@@ -768,8 +774,13 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @param shares LP shares to burn.
     /// @return requestId The LP withdrawal request id.
     /// @return assets The maximum liquidity assets claimable by the redeemer.
-    function requestRedeem(uint256 shares) external whenNotPaused nonReentrant returns (uint256 requestId, uint256 assets) {
-        require(shares > 0, "ARM: Zero shares");
+    function requestRedeem(uint256 shares)
+        external
+        whenNotPaused
+        nonReentrant
+        returns (uint256 requestId, uint256 assets)
+    {
+        if (shares == 0) revert ZeroShares();
 
         assets = convertToAssets(shares);
         requestId = nextWithdrawalIndex;
@@ -804,59 +815,45 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     function claimRedeem(uint256 requestId) external whenNotPaused nonReentrant returns (uint256 assets) {
         WithdrawalRequest memory request = withdrawalRequests[requestId];
 
-        require(request.claimTimestamp <= block.timestamp, "Claim delay not met");
-
-        if (request.shares == 0) {
-            assets = _claimLegacyRedeem(requestId, request);
+        if (request.claimTimestamp > block.timestamp) revert ClaimDelayNotMet();
+        bool legacyRequest = request.shares == 0;
+        if (legacyRequest) {
+            if (request.queued > _legacyClaimable()) revert QueuePendingLiquidity();
         } else {
-            assets = _claimRedeem(requestId, request);
+            if (request.queued > claimable()) revert QueuePendingLiquidity();
         }
+        if (request.withdrawer != msg.sender && msg.sender != operator) revert NotRequesterOrOperator();
+        if (request.claimed) revert AlreadyClaimed();
+
+        if (legacyRequest) {
+            assets = request.assets;
+            // Legacy requests used asset-denominated cumulative queue accounting.
+            _deprecatedWithdrawsClaimed += SafeCast.toUint128(assets);
+        } else {
+            // In the scenario where the ARM has made a loss after the redeem request, the asset value of
+            // the redeemed shares at the time of the claim is used.
+            // This can happen if there was a significant slashing event on the base asset, eg stETH,
+            // after the redeem request was made.
+            uint256 assetsAtClaim = convertToAssets(request.shares);
+            // Use the minimum of the asset value of the redeemed shares at request or claim.
+            assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
+
+            // Release the full request-time reservation, even when a loss-adjusted payout is lower.
+            reservedWithdrawLiquidity -= request.assets;
+            // Cumulative claimed amount in shares, used by the FIFO gate above.
+            withdrawsClaimedShares += request.shares;
+
+            // Burn the escrowed shares after `assets` was computed so conversion uses the pre-claim supply.
+            _burn(address(this), request.shares);
+        }
+
+        // Store the request as claimed.
+        withdrawalRequests[requestId].claimed = true;
+        _pullLiquidityForRedeem(assets);
 
         // Transfer the liquidity asset to the withdrawer.
         IERC20(liquidityAsset).transfer(request.withdrawer, assets);
         emit RedeemClaimed(request.withdrawer, requestId, assets);
-    }
-
-    /// @dev Claim a legacy asset-denominated withdrawal request created before share escrow was introduced.
-    function _claimLegacyRedeem(uint256 requestId, WithdrawalRequest memory request) private returns (uint256 assets) {
-        require(request.queued <= _legacyClaimable(), "Queue pending liquidity");
-        require(request.withdrawer == msg.sender || msg.sender == operator, "Not requester or operator");
-        require(request.claimed == false, "Already claimed");
-
-        assets = request.assets;
-        // Store the request as claimed.
-        withdrawalRequests[requestId].claimed = true;
-        // Legacy requests used asset-denominated cumulative queue accounting.
-        _deprecatedWithdrawsClaimed += SafeCast.toUint128(assets);
-
-        _pullLiquidityForRedeem(assets);
-    }
-
-    /// @dev Claim a share-escrowed withdrawal request created by this implementation.
-    function _claimRedeem(uint256 requestId, WithdrawalRequest memory request) private returns (uint256 assets) {
-        require(request.queued <= claimable(), "Queue pending liquidity");
-        require(request.withdrawer == msg.sender || msg.sender == operator, "Not requester or operator");
-        require(request.claimed == false, "Already claimed");
-
-        // In the scenario where the ARM has made a loss after the redeem request, the asset value of
-        // the redeemed shares at the time of the claim is used.
-        // This can happen if there was a significant slashing event on the base asset, eg stETH,
-        // after the redeem request was made.
-        uint256 assetsAtClaim = request.shares > 0 ? convertToAssets(request.shares) : request.assets;
-        // Use the minimum of the asset value of the redeemed shares at request or claim.
-        assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
-
-        // Store the request as claimed.
-        withdrawalRequests[requestId].claimed = true;
-        // Release the full request-time reservation, even when a loss-adjusted payout is lower.
-        reservedWithdrawLiquidity -= request.assets;
-        // Cumulative claimed amount in shares, used by the FIFO gate above.
-        withdrawsClaimedShares += request.shares;
-
-        // Burn the escrowed shares after `assets` was computed so conversion uses the pre-claim supply.
-        _burn(address(this), request.shares);
-
-        _pullLiquidityForRedeem(assets);
     }
 
     /// @dev Pull liquidity from the active market if the ARM does not hold enough to pay a redeem claim.

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -60,9 +60,9 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     uint256 internal _deprecatedTraderate1;
     uint256 internal _deprecatedCrossPrice;
 
-    /// @notice Maximum liquidity assets reserved for outstanding LP withdrawal requests.
-    /// @dev Reuses the legacy packed `withdrawsQueued`/`withdrawsClaimed` storage slot.
-    uint256 public reservedWithdrawLiquidity;
+    /// @dev Legacy asset-denominated queue counters retained for storage layout compatibility.
+    uint128 internal _deprecatedWithdrawsQueued;
+    uint128 internal _deprecatedWithdrawsClaimed;
     /// @notice Index of the next LP withdrawal request.
     uint256 public nextWithdrawalIndex;
 
@@ -135,8 +135,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     uint128 public withdrawsClaimedShares;
     /// @notice True when user-facing ARM actions are paused.
     bool public paused;
+    /// @notice Maximum liquidity assets reserved for outstanding LP withdrawal requests.
+    uint256 public reservedWithdrawLiquidity;
 
-    uint256[33] private _gap;
+    uint256[32] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Errors
@@ -162,7 +164,6 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     error MarketActive();
     error InvalidARMBuffer();
     error AlreadyMigrated();
-    error LegacyWithdrawalsPending();
     error ContractPaused();
 
     ////////////////////////////////////////////////////
@@ -768,6 +769,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @return requestId The LP withdrawal request id.
     /// @return assets The maximum liquidity assets claimable by the redeemer.
     function requestRedeem(uint256 shares) external whenNotPaused nonReentrant returns (uint256 requestId, uint256 assets) {
+        require(shares > 0, "ARM: Zero shares");
+
         assets = convertToAssets(shares);
         requestId = nextWithdrawalIndex;
         // Store the next withdrawal request id.
@@ -802,6 +805,35 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         WithdrawalRequest memory request = withdrawalRequests[requestId];
 
         require(request.claimTimestamp <= block.timestamp, "Claim delay not met");
+
+        if (request.shares == 0) {
+            assets = _claimLegacyRedeem(requestId, request);
+        } else {
+            assets = _claimRedeem(requestId, request);
+        }
+
+        // Transfer the liquidity asset to the withdrawer.
+        IERC20(liquidityAsset).transfer(request.withdrawer, assets);
+        emit RedeemClaimed(request.withdrawer, requestId, assets);
+    }
+
+    /// @dev Claim a legacy asset-denominated withdrawal request created before share escrow was introduced.
+    function _claimLegacyRedeem(uint256 requestId, WithdrawalRequest memory request) private returns (uint256 assets) {
+        require(request.queued <= _legacyClaimable(), "Queue pending liquidity");
+        require(request.withdrawer == msg.sender || msg.sender == operator, "Not requester or operator");
+        require(request.claimed == false, "Already claimed");
+
+        assets = request.assets;
+        // Store the request as claimed.
+        withdrawalRequests[requestId].claimed = true;
+        // Legacy requests used asset-denominated cumulative queue accounting.
+        _deprecatedWithdrawsClaimed += SafeCast.toUint128(assets);
+
+        _pullLiquidityForRedeem(assets);
+    }
+
+    /// @dev Claim a share-escrowed withdrawal request created by this implementation.
+    function _claimRedeem(uint256 requestId, WithdrawalRequest memory request) private returns (uint256 assets) {
         require(request.queued <= claimable(), "Queue pending liquidity");
         require(request.withdrawer == msg.sender || msg.sender == operator, "Not requester or operator");
         require(request.claimed == false, "Already claimed");
@@ -824,6 +856,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         // Burn the escrowed shares after `assets` was computed so conversion uses the pre-claim supply.
         _burn(address(this), request.shares);
 
+        _pullLiquidityForRedeem(assets);
+    }
+
+    /// @dev Pull liquidity from the active market if the ARM does not hold enough to pay a redeem claim.
+    function _pullLiquidityForRedeem(uint256 assets) private {
         // If there is not enough liquidity assets in the ARM, get from the active market if one is configured.
         // Read the active market address from storage once to save gas.
         address activeMarketMem = activeMarket;
@@ -835,10 +872,6 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
                 IERC4626(activeMarketMem).withdraw(liquidityFromMarket, address(this), address(this));
             }
         }
-
-        // Transfer the liquidity asset to the withdrawer.
-        IERC20(liquidityAsset).transfer(request.withdrawer, assets);
-        emit RedeemClaimed(request.withdrawer, requestId, assets);
     }
 
     ////////////////////////////////////////////////////
@@ -859,6 +892,16 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         }
 
         claimableShares = withdrawsClaimedShares + convertToShares(claimableLiquidity);
+    }
+
+    /// @dev Legacy asset-denominated queue frontier for pre-upgrade withdrawal requests.
+    function _legacyClaimable() internal view returns (uint256 claimableAmount) {
+        claimableAmount = _deprecatedWithdrawsClaimed + IERC20(liquidityAsset).balanceOf(address(this));
+
+        address activeMarketMem = activeMarket;
+        if (activeMarketMem != address(0)) {
+            claimableAmount += IERC4626(activeMarketMem).maxWithdraw(address(this));
+        }
     }
 
     /// @notice Get available liquidity and base asset reserves for a supported base asset.
@@ -1169,21 +1212,15 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         emit ARMBufferUpdated(_armBuffer);
     }
 
-    /// @notice Clear the legacy packed asset queue counter slot during the Model A upgrade.
-    /// @dev The reused slot previously packed `withdrawsQueued` in the low 128 bits and
-    /// `withdrawsClaimed` in the high 128 bits. It may be nonzero even when the old queue
-    /// is fully drained, so upgrade scripts should call this with `upgradeToAndCall`.
+    /// @notice Validate legacy queue compatibility during the Model A upgrade.
+    /// @dev The legacy packed asset queue counter slot is preserved so old pending withdrawal
+    /// requests can still be claimed after the upgrade.
     function migrateLegacyWithdrawQueue() external onlyOwner reinitializer(2) {
         _checkNoLegacyWithdrawQueue();
 
-        if (withdrawsQueuedShares != 0 || withdrawsClaimedShares != 0) revert AlreadyMigrated();
-
-        uint256 packedLegacyQueue = reservedWithdrawLiquidity;
-        uint128 legacyQueued = uint128(packedLegacyQueue);
-        uint128 legacyClaimed = uint128(packedLegacyQueue >> 128);
-        if (legacyQueued != legacyClaimed) revert LegacyWithdrawalsPending();
-
-        reservedWithdrawLiquidity = 0;
+        if (withdrawsQueuedShares != 0 || withdrawsClaimedShares != 0 || reservedWithdrawLiquidity != 0) {
+            revert AlreadyMigrated();
+        }
     }
 
     /// @dev Hook for protocol-specific legacy withdrawal queue checks before shared queue migration.

--- a/src/contracts/EtherFiARM.sol
+++ b/src/contracts/EtherFiARM.sol
@@ -14,6 +14,8 @@ import {AbstractARM} from "./AbstractARM.sol";
  * @author Origin Protocol Inc
  */
 contract EtherFiARM is Initializable, AbstractARM {
+    error LegacyEtherFiWithdrawalsPending();
+
     /// @dev Deprecated queue amount retained for storage layout compatibility.
     uint256 internal _deprecatedEtherfiWithdrawalQueueAmount;
 
@@ -61,7 +63,7 @@ contract EtherFiARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy EtherFi withdrawal requests are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        require(_deprecatedEtherfiWithdrawalQueueAmount == 0, "EtherFiARM: withdrawals pending");
+        if (_deprecatedEtherfiWithdrawalQueueAmount != 0) revert LegacyEtherFiWithdrawalsPending();
     }
 
     /// @notice This payable method is necessary for receiving ETH claimed from the EtherFi withdrawal queue.

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -14,6 +14,8 @@ import {AbstractARM} from "./AbstractARM.sol";
  * @author Origin Protocol Inc
  */
 contract LidoARM is Initializable, AbstractARM {
+    error LegacyLidoWithdrawalsPending();
+
     /// @dev Deprecated queue amount retained for storage layout compatibility.
     uint256 internal _deprecatedLidoWithdrawalQueueAmount;
 
@@ -54,7 +56,7 @@ contract LidoARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy Lido withdrawal requests are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        require(_deprecatedLidoWithdrawalQueueAmount == 0, "LidoARM: requests pending");
+        if (_deprecatedLidoWithdrawalQueueAmount != 0) revert LegacyLidoWithdrawalsPending();
     }
 
     /// @notice This payable method is necessary for receiving ETH claimed from the Lido withdrawal queue.

--- a/test/deploy/EthenaUpgradeGuards.t.sol
+++ b/test/deploy/EthenaUpgradeGuards.t.sol
@@ -36,11 +36,7 @@ contract EthenaUpgradeGuardsTest is Test {
     function test_UpgradeToAndCallMigratesWithClaimedLegacyWithdrawQueue() external {
         (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
-        vm.store(
-            address(proxy),
-            bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT),
-            bytes32(packedLegacyQueue)
-        );
+        vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
@@ -61,9 +57,7 @@ contract EthenaUpgradeGuardsTest is Test {
         (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
-        vm.store(
-            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue)
-        );
+        vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
 
         proxy.upgradeToAndCall(address(newImpl), data);
 

--- a/test/deploy/EthenaUpgradeGuards.t.sol
+++ b/test/deploy/EthenaUpgradeGuards.t.sol
@@ -33,17 +33,19 @@ contract EthenaUpgradeGuardsTest is Test {
         );
     }
 
-    function test_UpgradeToAndCallMigratesLegacyWithdrawQueue() external {
+    function test_UpgradeToAndCallMigratesWithClaimedLegacyWithdrawQueue() external {
         (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
+        uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
         vm.store(
             address(proxy),
             bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT),
-            bytes32(_packLegacyWithdrawQueue(1 ether, 1 ether))
+            bytes32(packedLegacyQueue)
         );
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
         assertEq(EthenaARM(address(proxy)).reservedWithdrawLiquidity(), 0);
+        assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
     function test_RevertWhen_UpgradeToAndCall_LegacyEthenaCooldownPending() external {
@@ -55,15 +57,18 @@ contract EthenaUpgradeGuardsTest is Test {
         proxy.upgradeToAndCall(address(newImpl), data);
     }
 
-    function test_RevertWhen_UpgradeToAndCall_LegacyWithdrawQueuePending() external {
+    function test_UpgradeToAndCallMigratesWithPendingLegacyWithdrawQueue() external {
         (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();
+        uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
         vm.store(
-            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(_packLegacyWithdrawQueue(1 ether, 0))
+            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue)
         );
 
-        vm.expectRevert();
         proxy.upgradeToAndCall(address(newImpl), data);
+
+        assertEq(EthenaARM(address(proxy)).reservedWithdrawLiquidity(), 0);
+        assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_CalledTwice() external {

--- a/test/deploy/EthenaUpgradeGuards.t.sol
+++ b/test/deploy/EthenaUpgradeGuards.t.sol
@@ -18,6 +18,7 @@ contract ExposedUpgradeEthenaARMScript is $028_UpgradeEthenaARMScript {
 
 contract EthenaUpgradeGuardsTest is Test {
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
+    uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
     uint256 internal constant ETHENA_LEGACY_COOLDOWN_AMOUNT_SLOT = 100;
 
     ExposedUpgradeEthenaARMScript internal script;
@@ -37,10 +38,12 @@ contract EthenaUpgradeGuardsTest is Test {
         (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
         vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
         assertEq(EthenaARM(address(proxy)).reservedWithdrawLiquidity(), 0);
+        assertEq(EthenaARM(address(proxy)).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
@@ -58,10 +61,12 @@ contract EthenaUpgradeGuardsTest is Test {
         bytes memory data = script.migrateLegacyWithdrawQueueData();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
         vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
 
         proxy.upgradeToAndCall(address(newImpl), data);
 
         assertEq(EthenaARM(address(proxy)).reservedWithdrawLiquidity(), 0);
+        assertEq(EthenaARM(address(proxy)).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 

--- a/test/deploy/EtherFiUpgradeGuards.t.sol
+++ b/test/deploy/EtherFiUpgradeGuards.t.sol
@@ -18,6 +18,7 @@ contract ExposedUpgradeEtherFiARMSwapFeeScript is $029_UpgradeEtherFiARMSwapFeeS
 
 contract EtherFiUpgradeGuardsTest is Test {
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
+    uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
     uint256 internal constant ETHERFI_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT = 100;
 
     ExposedUpgradeEtherFiARMSwapFeeScript internal script;
@@ -37,10 +38,12 @@ contract EtherFiUpgradeGuardsTest is Test {
         (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
         vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
         assertEq(EtherFiARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(EtherFiARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
@@ -58,10 +61,12 @@ contract EtherFiUpgradeGuardsTest is Test {
         bytes memory data = script.migrateLegacyWithdrawQueueData();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
         vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
 
         proxy.upgradeToAndCall(address(newImpl), data);
 
         assertEq(EtherFiARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(EtherFiARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 

--- a/test/deploy/EtherFiUpgradeGuards.t.sol
+++ b/test/deploy/EtherFiUpgradeGuards.t.sol
@@ -36,11 +36,7 @@ contract EtherFiUpgradeGuardsTest is Test {
     function test_UpgradeToAndCallMigratesWithClaimedLegacyWithdrawQueue() external {
         (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
-        vm.store(
-            address(proxy),
-            bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT),
-            bytes32(packedLegacyQueue)
-        );
+        vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
@@ -61,9 +57,7 @@ contract EtherFiUpgradeGuardsTest is Test {
         (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
-        vm.store(
-            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue)
-        );
+        vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
 
         proxy.upgradeToAndCall(address(newImpl), data);
 

--- a/test/deploy/EtherFiUpgradeGuards.t.sol
+++ b/test/deploy/EtherFiUpgradeGuards.t.sol
@@ -33,17 +33,19 @@ contract EtherFiUpgradeGuardsTest is Test {
         );
     }
 
-    function test_UpgradeToAndCallMigratesLegacyWithdrawQueue() external {
+    function test_UpgradeToAndCallMigratesWithClaimedLegacyWithdrawQueue() external {
         (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
+        uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
         vm.store(
             address(proxy),
             bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT),
-            bytes32(_packLegacyWithdrawQueue(1 ether, 1 ether))
+            bytes32(packedLegacyQueue)
         );
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
         assertEq(EtherFiARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
     function test_RevertWhen_UpgradeToAndCall_LegacyEtherFiWithdrawalsPending() external {
@@ -55,15 +57,18 @@ contract EtherFiUpgradeGuardsTest is Test {
         proxy.upgradeToAndCall(address(newImpl), data);
     }
 
-    function test_RevertWhen_UpgradeToAndCall_LegacyWithdrawQueuePending() external {
+    function test_UpgradeToAndCallMigratesWithPendingLegacyWithdrawQueue() external {
         (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();
+        uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
         vm.store(
-            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(_packLegacyWithdrawQueue(1 ether, 0))
+            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue)
         );
 
-        vm.expectRevert();
         proxy.upgradeToAndCall(address(newImpl), data);
+
+        assertEq(EtherFiARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_CalledTwice() external {

--- a/test/deploy/LidoUpgradeGuards.t.sol
+++ b/test/deploy/LidoUpgradeGuards.t.sol
@@ -18,6 +18,7 @@ contract ExposedUpgradeLidoARMSwapFeeScript is $030_UpgradeLidoARMSwapFeeScript 
 
 contract LidoUpgradeGuardsTest is Test {
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
+    uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
     uint256 internal constant LIDO_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT = 100;
 
     ExposedUpgradeLidoARMSwapFeeScript internal script;
@@ -37,10 +38,12 @@ contract LidoUpgradeGuardsTest is Test {
         (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
         vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
         assertEq(LidoARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(LidoARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
@@ -58,10 +61,12 @@ contract LidoUpgradeGuardsTest is Test {
         bytes memory data = script.migrateLegacyWithdrawQueueData();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
         vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
 
         proxy.upgradeToAndCall(address(newImpl), data);
 
         assertEq(LidoARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(LidoARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 

--- a/test/deploy/LidoUpgradeGuards.t.sol
+++ b/test/deploy/LidoUpgradeGuards.t.sol
@@ -36,11 +36,7 @@ contract LidoUpgradeGuardsTest is Test {
     function test_UpgradeToAndCallMigratesWithClaimedLegacyWithdrawQueue() external {
         (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
-        vm.store(
-            address(proxy),
-            bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT),
-            bytes32(packedLegacyQueue)
-        );
+        vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
@@ -61,9 +57,7 @@ contract LidoUpgradeGuardsTest is Test {
         (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();
         uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
-        vm.store(
-            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue)
-        );
+        vm.store(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
 
         proxy.upgradeToAndCall(address(newImpl), data);
 

--- a/test/deploy/LidoUpgradeGuards.t.sol
+++ b/test/deploy/LidoUpgradeGuards.t.sol
@@ -33,17 +33,19 @@ contract LidoUpgradeGuardsTest is Test {
         );
     }
 
-    function test_UpgradeToAndCallMigratesLegacyWithdrawQueue() external {
+    function test_UpgradeToAndCallMigratesWithClaimedLegacyWithdrawQueue() external {
         (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
+        uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 1 ether);
         vm.store(
             address(proxy),
             bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT),
-            bytes32(_packLegacyWithdrawQueue(1 ether, 1 ether))
+            bytes32(packedLegacyQueue)
         );
 
         proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
 
         assertEq(LidoARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
     function test_RevertWhen_UpgradeToAndCall_LegacyLidoWithdrawalRequestsPending() external {
@@ -55,15 +57,18 @@ contract LidoUpgradeGuardsTest is Test {
         proxy.upgradeToAndCall(address(newImpl), data);
     }
 
-    function test_RevertWhen_UpgradeToAndCall_LegacyWithdrawQueuePending() external {
+    function test_UpgradeToAndCallMigratesWithPendingLegacyWithdrawQueue() external {
         (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();
+        uint256 packedLegacyQueue = _packLegacyWithdrawQueue(1 ether, 0);
         vm.store(
-            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(_packLegacyWithdrawQueue(1 ether, 0))
+            address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue)
         );
 
-        vm.expectRevert();
         proxy.upgradeToAndCall(address(newImpl), data);
+
+        assertEq(LidoARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
+        assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
     }
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_CalledTwice() external {

--- a/test/fork/LidoARM/ClaimRedeem.t.sol
+++ b/test/fork/LidoARM/ClaimRedeem.t.sol
@@ -36,7 +36,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         requestRedeemFromLidoARM(address(this), DEFAULT_AMOUNT)
     {
         skip(delay - 1);
-        vm.expectRevert("Claim delay not met");
+        vm.expectRevert(bytes4(keccak256("ClaimDelayNotMet()")));
         lidoARM.claimRedeem(0);
     }
 
@@ -54,7 +54,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         skip(delay);
 
         // Expect revert
-        vm.expectRevert("Queue pending liquidity");
+        vm.expectRevert(bytes4(keccak256("QueuePendingLiquidity()")));
         lidoARM.claimRedeem(0);
     }
 
@@ -91,7 +91,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
 
         // Expect revert
         vm.startPrank(vm.randomAddress());
-        vm.expectRevert("Not requester or operator");
+        vm.expectRevert(bytes4(keccak256("NotRequesterOrOperator()")));
         lidoARM.claimRedeem(0);
     }
 
@@ -105,7 +105,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         claimRequestOnLidoARM(address(this), 0)
     {
         // Expect revert
-        vm.expectRevert("Already claimed");
+        vm.expectRevert(bytes4(keccak256("AlreadyClaimed()")));
         lidoARM.claimRedeem(0);
     }
 

--- a/test/fork/LidoARM/Deposit.t.sol
+++ b/test/fork/LidoARM/Deposit.t.sol
@@ -109,7 +109,7 @@ contract Fork_Concrete_LidoARM_Deposit_Test_ is Fork_Shared_Test_ {
 
         assertEq(lidoARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets should be floored at MIN_TOTAL_SUPPLY");
 
-        vm.expectRevert("ARM: insolvent");
+        vm.expectRevert(bytes4(keccak256("Insolvent()")));
         lidoARM.deposit(DEFAULT_AMOUNT);
     }
 

--- a/test/invariants/OriginARM/TargetFunction.sol
+++ b/test/invariants/OriginARM/TargetFunction.sol
@@ -103,7 +103,7 @@ abstract contract TargetFunction is Properties {
         vm.assume(user != address(0));
 
         // Bound shares to the balance of the user
-        shares = uint96(_bound(shares, 0, originARM.balanceOf(user)));
+        shares = uint96(_bound(shares, 1, originARM.balanceOf(user)));
 
         uint256 expectedId = originARM.nextWithdrawalIndex();
         uint256 expectedAmount = originARM.previewRedeem(shares);

--- a/test/smoke/AbstractSmokeTest.sol
+++ b/test/smoke/AbstractSmokeTest.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.23;
 
 // Foundry imports
-import {stdStorage, StdStorage, Test} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {DeployManager} from "script/deploy/DeployManager.s.sol";
 import {$028_UpgradeEthenaARMScript} from "script/deploy/mainnet/028_UpgradeEthenaARMScript.s.sol";
@@ -22,8 +22,6 @@ import {OriginAssetAdapter} from "contracts/adapters/OriginAssetAdapter.sol";
 import {WrappedOriginAssetAdapter} from "contracts/adapters/WrappedOriginAssetAdapter.sol";
 
 abstract contract AbstractSmokeTest is Test {
-    using stdStorage for StdStorage;
-
     /// @dev First derived-contract storage slot after AbstractARM's reserved gap.
     uint256 internal constant LEGACY_PENDING_AMOUNT_SLOT = 100;
     uint256 internal constant FEE_SCALE = 10000;
@@ -221,10 +219,9 @@ abstract contract AbstractSmokeTest is Test {
         vm.store(arm, bytes32(LEGACY_PENDING_AMOUNT_SLOT), bytes32(0));
     }
 
-    function _clearLegacyWithdrawQueueForSmoke(address arm) internal {
-        // The live fork can contain outstanding legacy LP withdrawals at the selected block.
-        // Smoke tests normalize that fork-only state so the strict production migration path can run.
-        stdstore.target(arm).sig("reservedWithdrawLiquidity()").checked_write(uint256(0));
+    function _clearLegacyWithdrawQueueForSmoke(address arm) internal pure {
+        (arm);
+        // Legacy LP withdrawals are now preserved for post-upgrade claims.
     }
 
     function _migrateLegacyWithdrawQueue(address arm) internal {

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -6,6 +6,7 @@ import {AbstractARM} from "contracts/AbstractARM.sol";
 
 contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
+    uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
     uint256 internal constant WITHDRAWAL_REQUESTS_SLOT = 55;
 
     function setUp() public virtual override {
@@ -65,45 +66,83 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
     }
 
     function test_ClaimRedeem_WhenLegacyRequestClaimedByWithdrawer() public timejump(CLAIM_DELAY) {
+        uint256 legacyRequestId = 1;
         uint128 legacyAssets = 0.4 ether;
+        uint128 legacyShares = 0.5 ether;
         uint128 legacyQueued = 1 ether;
         uint128 legacyClaimed = legacyQueued - legacyAssets;
         _writeLegacyWithdrawQueue(legacyQueued, legacyClaimed);
-        _writeLegacyWithdrawalRequest(0, alice, false, uint40(block.timestamp), legacyAssets, legacyQueued);
+        _writeLegacyWithdrawalRequest(
+            legacyRequestId, alice, false, uint40(block.timestamp), legacyAssets, legacyQueued, legacyShares
+        );
+        _migrateWithLegacyBoundary(3);
 
         uint256 aliceBalanceBefore = weth.balanceOf(alice);
+        uint256 armSharesBefore = originARM.balanceOf(address(originARM));
 
         vm.prank(alice);
         vm.expectEmit(address(originARM));
-        emit AbstractARM.RedeemClaimed(alice, 0, legacyAssets);
-        originARM.claimRedeem(0);
+        emit AbstractARM.RedeemClaimed(alice, legacyRequestId, legacyAssets);
+        originARM.claimRedeem(legacyRequestId);
 
-        (, bool claimed,,,, uint256 shares) = originARM.withdrawalRequests(0);
+        (, bool claimed,,,, uint256 shares) = originARM.withdrawalRequests(legacyRequestId);
         assertEq(claimed, true, "claimed");
-        assertEq(shares, 0, "legacy shares");
+        assertEq(shares, legacyShares, "legacy shares");
         assertEq(weth.balanceOf(alice), aliceBalanceBefore + legacyAssets, "alice WETH");
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
         assertEq(originARM.withdrawsClaimedShares(), 0, "claimed shares");
+        assertEq(originARM.balanceOf(address(originARM)), armSharesBefore, "escrowed shares");
         assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyQueued), "legacy claimed");
     }
 
     function test_ClaimRedeem_WhenLegacyRequestClaimedByOperator() public timejump(CLAIM_DELAY) {
+        uint256 legacyRequestId = 2;
         uint128 legacyAssets = 0.25 ether;
+        uint128 legacyShares = 0.3 ether;
         uint128 legacyQueued = 1 ether;
         uint128 legacyClaimed = legacyQueued - legacyAssets;
         _writeLegacyWithdrawQueue(legacyQueued, legacyClaimed);
-        _writeLegacyWithdrawalRequest(0, alice, false, uint40(block.timestamp), legacyAssets, legacyQueued);
+        _writeLegacyWithdrawalRequest(
+            legacyRequestId, alice, false, uint40(block.timestamp), legacyAssets, legacyQueued, legacyShares
+        );
+        _migrateWithLegacyBoundary(3);
 
         uint256 aliceBalanceBefore = weth.balanceOf(alice);
         uint256 operatorBalanceBefore = weth.balanceOf(operator);
+        uint256 armSharesBefore = originARM.balanceOf(address(originARM));
 
         vm.prank(operator);
-        originARM.claimRedeem(0);
+        originARM.claimRedeem(legacyRequestId);
 
         assertEq(weth.balanceOf(alice), aliceBalanceBefore + legacyAssets, "alice WETH");
         assertEq(weth.balanceOf(operator), operatorBalanceBefore, "operator WETH");
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.withdrawsClaimedShares(), 0, "claimed shares");
+        assertEq(originARM.balanceOf(address(originARM)), armSharesBefore, "escrowed shares");
         assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyQueued), "legacy claimed");
+    }
+
+    function test_ClaimRedeem_WhenRequestIdAtMigrationBoundaryUsesNewQueue()
+        public
+        timejump(CLAIM_DELAY)
+    {
+        _migrateWithLegacyBoundary(3);
+
+        vm.prank(alice);
+        (uint256 requestId,) = originARM.requestRedeem(DEFAULT_AMOUNT);
+        assertEq(requestId, 3, "new request id");
+
+        uint256 aliceBalanceBefore = weth.balanceOf(alice);
+        uint256 armSharesBefore = originARM.balanceOf(address(originARM));
+
+        vm.warp(block.timestamp + CLAIM_DELAY);
+        vm.prank(alice);
+        originARM.claimRedeem(requestId);
+
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "claimed shares");
+        assertEq(originARM.balanceOf(address(originARM)), armSharesBefore - DEFAULT_AMOUNT, "escrowed shares burned");
+        assertEq(weth.balanceOf(alice), aliceBalanceBefore + DEFAULT_AMOUNT, "alice WETH");
     }
 
     function test_RevertWhen_ClaimRedeem_Because_AlreadyClaimed() public requestRedeemAll(alice) timejump(CLAIM_DELAY) {
@@ -196,7 +235,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         bool claimed,
         uint40 claimTimestamp,
         uint128 assets,
-        uint128 queued
+        uint128 queued,
+        uint128 shares
     ) internal {
         bytes32 requestSlot = keccak256(abi.encode(requestId, WITHDRAWAL_REQUESTS_SLOT));
         uint256 slot0 =
@@ -206,7 +246,16 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         vm.store(
             address(originARM), bytes32(uint256(requestSlot) + 1), bytes32(uint256(assets) | (uint256(queued) << 128))
         );
-        vm.store(address(originARM), bytes32(uint256(requestSlot) + 2), bytes32(uint256(0)));
+        vm.store(address(originARM), bytes32(uint256(requestSlot) + 2), bytes32(uint256(shares)));
+    }
+
+    function _migrateWithLegacyBoundary(uint256 nextWithdrawalIndex) internal {
+        vm.store(address(originARM), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(nextWithdrawalIndex));
+
+        vm.prank(governor);
+        originARM.migrateLegacyWithdrawQueue();
+
+        assertEq(originARM.legacyWithdrawalRequestCount(), nextWithdrawalIndex, "legacy request count");
     }
 
     function _readLegacyWithdrawQueue() internal view returns (uint256) {

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -22,7 +22,7 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
     }
 
     function test_RevertWhen_ClaimRedeem_Because_DelayNotMet() public requestRedeemAll(alice) {
-        vm.expectRevert("Claim delay not met");
+        vm.expectRevert(bytes4(keccak256("ClaimDelayNotMet()")));
         originARM.claimRedeem(0);
     }
 
@@ -32,7 +32,7 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         requestRedeemAll(alice)
         timejump(CLAIM_DELAY)
     {
-        vm.expectRevert("Queue pending liquidity");
+        vm.expectRevert(bytes4(keccak256("QueuePendingLiquidity()")));
         originARM.claimRedeem(0);
     }
 
@@ -42,7 +42,7 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         timejump(CLAIM_DELAY)
         asNot(alice)
     {
-        vm.expectRevert("Not requester or operator");
+        vm.expectRevert(bytes4(keccak256("NotRequesterOrOperator()")));
         originARM.claimRedeem(0);
     }
 
@@ -113,7 +113,7 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
 
         // Attempt to claim again
         vm.prank(alice);
-        vm.expectRevert("Already claimed");
+        vm.expectRevert(bytes4(keccak256("AlreadyClaimed()")));
         originARM.claimRedeem(0);
     }
 
@@ -199,11 +199,13 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         uint128 queued
     ) internal {
         bytes32 requestSlot = keccak256(abi.encode(requestId, WITHDRAWAL_REQUESTS_SLOT));
-        uint256 slot0 = uint256(uint160(withdrawer)) | (claimed ? uint256(1) << 160 : 0)
-            | (uint256(claimTimestamp) << 168);
+        uint256 slot0 =
+            uint256(uint160(withdrawer)) | (claimed ? uint256(1) << 160 : 0) | (uint256(claimTimestamp) << 168);
 
         vm.store(address(originARM), requestSlot, bytes32(slot0));
-        vm.store(address(originARM), bytes32(uint256(requestSlot) + 1), bytes32(uint256(assets) | (uint256(queued) << 128)));
+        vm.store(
+            address(originARM), bytes32(uint256(requestSlot) + 1), bytes32(uint256(assets) | (uint256(queued) << 128))
+        );
         vm.store(address(originARM), bytes32(uint256(requestSlot) + 2), bytes32(uint256(0)));
     }
 

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -122,10 +122,7 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyQueued), "legacy claimed");
     }
 
-    function test_ClaimRedeem_WhenRequestIdAtMigrationBoundaryUsesNewQueue()
-        public
-        timejump(CLAIM_DELAY)
-    {
+    function test_ClaimRedeem_WhenRequestIdAtMigrationBoundaryUsesNewQueue() public timejump(CLAIM_DELAY) {
         _migrateWithLegacyBoundary(3);
 
         vm.prank(alice);

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -5,6 +5,9 @@ import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
 import {AbstractARM} from "contracts/AbstractARM.sol";
 
 contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
+    uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
+    uint256 internal constant WITHDRAWAL_REQUESTS_SLOT = 55;
+
     function setUp() public virtual override {
         super.setUp();
 
@@ -59,6 +62,48 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(weth.balanceOf(alice), aliceBalanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
         assertEq(weth.balanceOf(operator), operatorBalanceBefore, "Operator should not receive WETH");
         assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
+    }
+
+    function test_ClaimRedeem_WhenLegacyRequestClaimedByWithdrawer() public timejump(CLAIM_DELAY) {
+        uint128 legacyAssets = 0.4 ether;
+        uint128 legacyQueued = 1 ether;
+        uint128 legacyClaimed = legacyQueued - legacyAssets;
+        _writeLegacyWithdrawQueue(legacyQueued, legacyClaimed);
+        _writeLegacyWithdrawalRequest(0, alice, false, uint40(block.timestamp), legacyAssets, legacyQueued);
+
+        uint256 aliceBalanceBefore = weth.balanceOf(alice);
+
+        vm.prank(alice);
+        vm.expectEmit(address(originARM));
+        emit AbstractARM.RedeemClaimed(alice, 0, legacyAssets);
+        originARM.claimRedeem(0);
+
+        (, bool claimed,,,, uint256 shares) = originARM.withdrawalRequests(0);
+        assertEq(claimed, true, "claimed");
+        assertEq(shares, 0, "legacy shares");
+        assertEq(weth.balanceOf(alice), aliceBalanceBefore + legacyAssets, "alice WETH");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.withdrawsClaimedShares(), 0, "claimed shares");
+        assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyQueued), "legacy claimed");
+    }
+
+    function test_ClaimRedeem_WhenLegacyRequestClaimedByOperator() public timejump(CLAIM_DELAY) {
+        uint128 legacyAssets = 0.25 ether;
+        uint128 legacyQueued = 1 ether;
+        uint128 legacyClaimed = legacyQueued - legacyAssets;
+        _writeLegacyWithdrawQueue(legacyQueued, legacyClaimed);
+        _writeLegacyWithdrawalRequest(0, alice, false, uint40(block.timestamp), legacyAssets, legacyQueued);
+
+        uint256 aliceBalanceBefore = weth.balanceOf(alice);
+        uint256 operatorBalanceBefore = weth.balanceOf(operator);
+
+        vm.prank(operator);
+        originARM.claimRedeem(0);
+
+        assertEq(weth.balanceOf(alice), aliceBalanceBefore + legacyAssets, "alice WETH");
+        assertEq(weth.balanceOf(operator), operatorBalanceBefore, "operator WETH");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyQueued), "legacy claimed");
     }
 
     function test_RevertWhen_ClaimRedeem_Because_AlreadyClaimed() public requestRedeemAll(alice) timejump(CLAIM_DELAY) {
@@ -135,5 +180,38 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
         assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
+    }
+
+    function _writeLegacyWithdrawQueue(uint128 legacyQueued, uint128 legacyClaimed) internal {
+        vm.store(
+            address(originARM),
+            bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT),
+            bytes32(_packLegacyWithdrawQueue(legacyQueued, legacyClaimed))
+        );
+    }
+
+    function _writeLegacyWithdrawalRequest(
+        uint256 requestId,
+        address withdrawer,
+        bool claimed,
+        uint40 claimTimestamp,
+        uint128 assets,
+        uint128 queued
+    ) internal {
+        bytes32 requestSlot = keccak256(abi.encode(requestId, WITHDRAWAL_REQUESTS_SLOT));
+        uint256 slot0 = uint256(uint160(withdrawer)) | (claimed ? uint256(1) << 160 : 0)
+            | (uint256(claimTimestamp) << 168);
+
+        vm.store(address(originARM), requestSlot, bytes32(slot0));
+        vm.store(address(originARM), bytes32(uint256(requestSlot) + 1), bytes32(uint256(assets) | (uint256(queued) << 128)));
+        vm.store(address(originARM), bytes32(uint256(requestSlot) + 2), bytes32(uint256(0)));
+    }
+
+    function _readLegacyWithdrawQueue() internal view returns (uint256) {
+        return uint256(vm.load(address(originARM), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT)));
+    }
+
+    function _packLegacyWithdrawQueue(uint128 legacyQueued, uint128 legacyClaimed) internal pure returns (uint256) {
+        return uint256(legacyQueued) | (uint256(legacyClaimed) << 128);
     }
 }

--- a/test/unit/OriginARM/Deposit.sol
+++ b/test/unit/OriginARM/Deposit.sol
@@ -223,7 +223,7 @@ contract Unit_Concrete_OriginARM_Deposit_Test_ is Unit_Shared_Test {
         assertEq(originARM.totalAssets(), MIN_TOTAL_SUPPLY, "totalAssets should be floored at MIN_TOTAL_SUPPLY");
         assertGt(originARM.reservedWithdrawLiquidity(), 0, "should have outstanding requests");
 
-        vm.expectRevert("ARM: insolvent");
+        vm.expectRevert(bytes4(keccak256("Insolvent()")));
         vm.prank(alice);
         originARM.deposit(DEFAULT_AMOUNT);
     }

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import {stdStorage, StdStorage} from "forge-std/Test.sol";
 import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
 
 contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared_Test {
-    using stdStorage for StdStorage;
+    uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_NotGovernor() public asNotGovernor {
         vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
@@ -26,13 +25,16 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
         originARM.migrateLegacyWithdrawQueue();
 
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyClaimed), "legacy queue preserved");
     }
 
-    function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_LegacyWithdrawalsPending() public asGovernor {
+    function test_MigrateLegacyWithdrawQueue_When_LegacyWithdrawalsPending() public asGovernor {
         _writeLegacyWithdrawQueue(5 ether, 4 ether);
 
-        vm.expectRevert(bytes4(keccak256("LegacyWithdrawalsPending()")));
         originARM.migrateLegacyWithdrawQueue();
+
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(5 ether, 4 ether), "legacy queue preserved");
     }
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_NewQueueAlreadyUsed()
@@ -48,11 +50,18 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
     }
 
     function _writeLegacyWithdrawQueue(uint128 legacyQueued, uint128 legacyClaimed) internal {
-        uint256 packedLegacyQueue = uint256(legacyQueued) | (uint256(legacyClaimed) << 128);
+        uint256 packedLegacyQueue = _packLegacyWithdrawQueue(legacyQueued, legacyClaimed);
 
-        stdstore.target(address(originARM)).sig(originARM.reservedWithdrawLiquidity.selector)
-            .checked_write(packedLegacyQueue);
+        vm.store(address(originARM), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT), bytes32(packedLegacyQueue));
+        assertEq(_readLegacyWithdrawQueue(), packedLegacyQueue, "packed legacy queue");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+    }
 
-        assertEq(originARM.reservedWithdrawLiquidity(), packedLegacyQueue, "packed legacy queue");
+    function _readLegacyWithdrawQueue() internal view returns (uint256) {
+        return uint256(vm.load(address(originARM), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT)));
+    }
+
+    function _packLegacyWithdrawQueue(uint128 legacyQueued, uint128 legacyClaimed) internal pure returns (uint256) {
+        return uint256(legacyQueued) | (uint256(legacyClaimed) << 128);
     }
 }

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -5,6 +5,7 @@ import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
 
 contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared_Test {
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
+    uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_NotGovernor() public asNotGovernor {
         vm.expectRevert(bytes4(keccak256("OnlyOwner()")));
@@ -12,19 +13,24 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
     }
 
     function test_MigrateLegacyWithdrawQueue_When_LegacyQueueIsZero() public asGovernor {
+        _writeNextWithdrawalIndex(3);
+
         originARM.migrateLegacyWithdrawQueue();
 
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.legacyWithdrawalRequestCount(), 3, "legacy request count");
     }
 
     function test_MigrateLegacyWithdrawQueue_When_LegacyQueueIsFullyClaimed() public asGovernor {
         uint128 legacyQueued = 5 ether;
         uint128 legacyClaimed = legacyQueued;
         _writeLegacyWithdrawQueue(legacyQueued, legacyClaimed);
+        _writeNextWithdrawalIndex(3);
 
         originARM.migrateLegacyWithdrawQueue();
 
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.legacyWithdrawalRequestCount(), 3, "legacy request count");
         assertEq(
             _readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyClaimed), "legacy queue preserved"
         );
@@ -32,10 +38,12 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
 
     function test_MigrateLegacyWithdrawQueue_When_LegacyWithdrawalsPending() public asGovernor {
         _writeLegacyWithdrawQueue(5 ether, 4 ether);
+        _writeNextWithdrawalIndex(3);
 
         originARM.migrateLegacyWithdrawQueue();
 
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.legacyWithdrawalRequestCount(), 3, "legacy request count");
         assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(5 ether, 4 ether), "legacy queue preserved");
     }
 
@@ -61,6 +69,11 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
 
     function _readLegacyWithdrawQueue() internal view returns (uint256) {
         return uint256(vm.load(address(originARM), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT)));
+    }
+
+    function _writeNextWithdrawalIndex(uint256 nextWithdrawalIndex) internal {
+        vm.store(address(originARM), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(nextWithdrawalIndex));
+        assertEq(originARM.nextWithdrawalIndex(), nextWithdrawalIndex, "next withdrawal index");
     }
 
     function _packLegacyWithdrawQueue(uint128 legacyQueued, uint128 legacyClaimed) internal pure returns (uint256) {

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -25,7 +25,9 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
         originARM.migrateLegacyWithdrawQueue();
 
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
-        assertEq(_readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyClaimed), "legacy queue preserved");
+        assertEq(
+            _readLegacyWithdrawQueue(), _packLegacyWithdrawQueue(legacyQueued, legacyClaimed), "legacy queue preserved"
+        );
     }
 
     function test_MigrateLegacyWithdrawQueue_When_LegacyWithdrawalsPending() public asGovernor {

--- a/test/unit/OriginARM/RequestRedeem.sol
+++ b/test/unit/OriginARM/RequestRedeem.sol
@@ -53,4 +53,10 @@ contract Unit_Concrete_OriginARM_RequestRedeem_Test_ is Unit_Shared_Test {
         assertEq(queued_, queuedShares + expectedShares, "Queued should be updated");
         assertEq(shares, expectedShares, "Shares should be updated");
     }
+
+    function test_RevertWhen_RequestRedeem_Because_ZeroShares() public {
+        vm.prank(alice);
+        vm.expectRevert("ARM: Zero shares");
+        originARM.requestRedeem(0);
+    }
 }

--- a/test/unit/OriginARM/RequestRedeem.sol
+++ b/test/unit/OriginARM/RequestRedeem.sol
@@ -56,7 +56,7 @@ contract Unit_Concrete_OriginARM_RequestRedeem_Test_ is Unit_Shared_Test {
 
     function test_RevertWhen_RequestRedeem_Because_ZeroShares() public {
         vm.prank(alice);
-        vm.expectRevert("ARM: Zero shares");
+        vm.expectRevert(bytes4(keccak256("ZeroShares()")));
         originARM.requestRedeem(0);
     }
 }


### PR DESCRIPTION
## Summary

- Move `reservedWithdrawLiquidity` to a new storage slot and preserve the legacy packed withdrawal queue slot.
- Add one-step upgrade compatibility for legacy LP withdrawal requests with `shares == 0`.
- Convert LP-path revert strings to custom errors to keep ARM implementations under EIP-170.
- Update migration, unit, fork, and upgrade guard tests for pending legacy withdrawal queues.

## Details

Legacy asset-denominated LP withdrawal requests can now be claimed after the upgrade instead of requiring the old queue to be fully drained before `upgradeToAndCall`.

New share-escrowed requests continue to use the new share-based queue accounting, while legacy requests use the preserved `_deprecatedWithdrawsQueued/_deprecatedWithdrawsClaimed` counters.

Swap-facing revert strings are intentionally unchanged for compatibility.

## Testing

- `forge test --match-path 'test/unit/OriginARM/{Deposit,RequestRedeem,ClaimRedeem,MigrateLegacyWithdrawQueue}.sol' -vv`
- `forge test --match-path 'test/fork/LidoARM/{Deposit,ClaimRedeem}.t.sol' -vv`
- `forge test --match-path 'test/deploy/*UpgradeGuards.t.sol' -vv`
- `forge build --sizes | rg '(^|\| )(LidoARM|OriginARM|EthenaARM|EtherFiARM|ReentrantGuardHarnessARM) '`
- `git diff --check`

## Contract Sizes

```text
EthenaARM   23,699 B   margin +877 B
EtherFiARM  24,469 B   margin +107 B
LidoARM     24,430 B   margin +146 B
OriginARM   23,680 B   margin +896 B
```