### PR TITLE
Fix token approval in adapters

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -767,7 +767,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @param shares LP shares to burn.
     /// @return requestId The LP withdrawal request id.
     /// @return assets The maximum liquidity assets claimable by the redeemer.
-    function requestRedeem(uint256 shares) external whenNotPaused nonReentrant returns (uint256 requestId, uint256 assets) {
+    function requestRedeem(uint256 shares)
+        external
+        whenNotPaused
+        nonReentrant
+        returns (uint256 requestId, uint256 assets)
+    {
         assets = convertToAssets(shares);
         requestId = nextWithdrawalIndex;
         // Store the next withdrawal request id.

--- a/src/contracts/adapters/AbstractLidoAssetAdapter.sol
+++ b/src/contracts/adapters/AbstractLidoAssetAdapter.sol
@@ -24,8 +24,6 @@ abstract contract AbstractLidoAssetAdapter is Initializable, IAssetAdapter {
         weth = IWETH(_weth);
         steth = ISTETH(_steth);
         lidoWithdrawalQueue = IStETHWithdrawal(_lidoWithdrawalQueue);
-
-        IERC20(_steth).approve(_lidoWithdrawalQueue, type(uint256).max);
     }
 
     function initialize() external initializer {

--- a/src/contracts/adapters/EtherFiAssetAdapter.sol
+++ b/src/contracts/adapters/EtherFiAssetAdapter.sol
@@ -29,8 +29,6 @@ contract EtherFiAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
         weth = IWETH(_weth);
         etherfiWithdrawalQueue = IEETHWithdrawal(_etherfiWithdrawalQueue);
         etherfiWithdrawalNFT = IEETHWithdrawalNFT(_etherfiWithdrawalNFT);
-
-        eeth.approve(_etherfiWithdrawalQueue, type(uint256).max);
     }
 
     function initialize() external initializer {

--- a/src/contracts/adapters/OriginAssetAdapter.sol
+++ b/src/contracts/adapters/OriginAssetAdapter.sol
@@ -20,7 +20,6 @@ contract OriginAssetAdapter is Initializable, IAssetAdapter {
         otoken = IERC20(_otoken);
         liquidityAsset = IERC20(_liquidityAsset);
         vault = IOriginVault(_vault);
-        otoken.approve(_vault, type(uint256).max);
     }
 
     function initialize() external initializer {

--- a/src/contracts/adapters/WeETHAssetAdapter.sol
+++ b/src/contracts/adapters/WeETHAssetAdapter.sol
@@ -33,8 +33,6 @@ contract WeETHAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
         weth = IWETH(_weth);
         etherfiWithdrawalQueue = IEETHWithdrawal(_etherfiWithdrawalQueue);
         etherfiWithdrawalNFT = IEETHWithdrawalNFT(_etherfiWithdrawalNFT);
-
-        eeth.approve(_etherfiWithdrawalQueue, type(uint256).max);
     }
 
     function initialize() external initializer {

--- a/src/contracts/adapters/WrappedOriginAssetAdapter.sol
+++ b/src/contracts/adapters/WrappedOriginAssetAdapter.sol
@@ -24,7 +24,6 @@ contract WrappedOriginAssetAdapter is Initializable, IAssetAdapter {
         otoken = IERC20(_otoken);
         liquidityAsset = IERC20(_liquidityAsset);
         vault = IOriginVault(_vault);
-        otoken.approve(_vault, type(uint256).max);
     }
 
     function initialize() external initializer {

--- a/test/fork/EtherFiARM/shared/Shared.sol
+++ b/test/fork/EtherFiARM/shared/Shared.sol
@@ -108,6 +108,7 @@ abstract contract Fork_Shared_Test is Base_Test_ {
             Mainnet.ETHERFI_WITHDRAWAL,
             Mainnet.ETHERFI_WITHDRAWAL_NFT
         );
+        etherfiAssetAdapter.initialize();
         etherfiARM.addBaseAsset(
             address(eeth),
             address(etherfiAssetAdapter),
@@ -127,6 +128,7 @@ abstract contract Fork_Shared_Test is Base_Test_ {
             Mainnet.ETHERFI_WITHDRAWAL,
             Mainnet.ETHERFI_WITHDRAWAL_NFT
         );
+        weethAssetAdapter.initialize();
         etherfiARM.addBaseAsset(
             address(weeth),
             address(weethAssetAdapter),

--- a/test/fork/LidoARM/SwapGasClean.t.sol
+++ b/test/fork/LidoARM/SwapGasClean.t.sol
@@ -67,6 +67,8 @@ contract Fork_Concrete_LidoARM_SwapGasClean_Test is Test {
                 address(lidoProxy), address(weth), address(steth), Mainnet.WSTETH, Mainnet.LIDO_WITHDRAWAL
             )
         );
+        StETHAssetAdapter(payable(stethAdapter)).initialize();
+        WstETHAssetAdapter(payable(wstethAdapter)).initialize();
         lidoARM.addBaseAsset(
             address(steth),
             stethAdapter,

--- a/test/fork/LidoARM/SwapGasComparison.t.sol
+++ b/test/fork/LidoARM/SwapGasComparison.t.sol
@@ -147,6 +147,8 @@ contract Fork_Concrete_LidoARM_SwapGasUpgraded_Test is Fork_LidoARM_SwapGasCompa
                 address(lidoProxy), address(weth), address(steth), Mainnet.WSTETH, Mainnet.LIDO_WITHDRAWAL
             )
         );
+        StETHAssetAdapter(payable(stethAdapter)).initialize();
+        WstETHAssetAdapter(payable(wstethAdapter)).initialize();
 
         vm.prank(lidoProxy.owner());
         lidoARM.addBaseAsset(

--- a/test/fork/OriginARM/shared/Shared.sol
+++ b/test/fork/OriginARM/shared/Shared.sol
@@ -120,6 +120,7 @@ abstract contract Fork_Shared_Test is Base_Test_, Modifiers {
         // --- Set the proxy as the OriginARM
         originARM = OriginARM(address(originARMProxy));
         originAssetAdapter = new OriginAssetAdapter(address(originARM), address(os), address(ws), address(vault));
+        originAssetAdapter.initialize();
 
         // --- Set the SiloMarket as the market
         siloMarket = SiloMarket(address(marketAdapterProxy));

--- a/test/fork/shared/Shared.sol
+++ b/test/fork/shared/Shared.sol
@@ -148,6 +148,8 @@ abstract contract Fork_Shared_Test_ is Modifiers {
                 address(lidoProxy), address(weth), address(steth), address(wsteth), Mainnet.LIDO_WITHDRAWAL
             )
         );
+        StETHAssetAdapter(payable(stethAdapter)).initialize();
+        WstETHAssetAdapter(payable(wstethAdapter)).initialize();
 
         lidoARM.addBaseAsset(
             address(steth), stethAdapter, 992 * 1e33, 1001 * 1e33, type(uint128).max, type(uint128).max, 1e36, true

--- a/test/invariants/LidoARM/Setup.sol
+++ b/test/invariants/LidoARM/Setup.sol
@@ -159,6 +159,7 @@ abstract contract Setup is Base_Test_ {
         lidoARM = LidoARM(payable(address(lidoProxy)));
 
         stethAdapter = address(new StETHAssetAdapter(address(lidoProxy), address(weth), address(steth), lidoWithdraw));
+        StETHAssetAdapter(payable(stethAdapter)).initialize();
     }
 
     function min(uint256 a, uint256 b) public pure returns (uint256) {

--- a/test/invariants/OriginARM/Setup.sol
+++ b/test/invariants/OriginARM/Setup.sol
@@ -182,6 +182,7 @@ abstract contract Setup is Base_Test_ {
         // --- 4. Set the proxy as the OriginARM ---
         originARM = OriginARM(address(originARMProxy));
         originAssetAdapter = new OriginAssetAdapter(address(originARM), address(os), address(ws), address(vault));
+        originAssetAdapter.initialize();
         siloMarket = SiloMarket(address(siloMarketProxy));
 
         // ---

--- a/test/unit/OriginARM/Reentrancy.sol
+++ b/test/unit/OriginARM/Reentrancy.sol
@@ -33,6 +33,7 @@ contract Unit_Concrete_OriginARM_Reentrancy_Test_ is Unit_Shared_Test {
             address(weth),
             address(new MockVault(IERC20(address(reentrantBase)), weth))
         );
+        adapter.initialize();
 
         vm.prank(governor);
         originARM.addBaseAsset(

--- a/test/unit/shared/Shared.sol
+++ b/test/unit/shared/Shared.sol
@@ -114,6 +114,8 @@ abstract contract Unit_Shared_Test is Base_Test_, Modifiers {
         wrappedOriginAssetAdapter = new WrappedOriginAssetAdapter(
             address(originARM), address(woeth), address(oeth), address(weth), address(vault)
         );
+        originAssetAdapter.initialize();
+        wrappedOriginAssetAdapter.initialize();
         capManager = CapManager(address(capManagerProxy));
         siloMarket = SiloMarket(address(siloMarketProxy));
 


### PR DESCRIPTION
**Summary**

Remove constructor-time token approvals from proxied asset adapters. Approvals now happen only during `initialize()`, so they are set on the proxy address rather than the implementation.

Updated direct test harness deployments to call adapter `initialize()` explicitly, matching the proxied deployment flow.
