### PR TITLE
Adds legacy withdrawal queue safety checks and selector documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,6 @@ This file provides guidance to Codex when working with code in this repository.
 
 - When writing NatSpec for scaled or non-obvious numeric parameters, include concrete examples.
   For example: `10,000 = 100% fee`, `500 = 5% fee`, `1e18 = 100% buffer`, `0.1e18 = 10% buffer`.
-
+- When adding custom errors under `src/contracts`, include the 4-byte selector in an inline comment next to
+  the declaration, for example `error SomeError(); // 0x12345678`. Compute selectors from canonical ABI
+  signatures, using the ABI type for enums (for example, `uint8`).

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -168,12 +168,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     error AlreadyMigrated(); // 0xca1c3cbc
     error LegacyWithdrawalsPending(); // 0x6df56289
     error ContractPaused(); // 0xab35696f
-    error Insolvent();
-    error ZeroShares();
-    error ClaimDelayNotMet();
-    error QueuePendingLiquidity();
-    error NotRequesterOrOperator();
-    error AlreadyClaimed();
+    error Insolvent(); // 0xfc220038
+    error ZeroShares(); // 0x9811e0c7
+    error ClaimDelayNotMet(); // 0x4a1eec28
+    error QueuePendingLiquidity(); // 0xa5e8d7ac
+    error NotRequesterOrOperator(); // 0x40e6afe4
+    error AlreadyClaimed(); // 0x646cf558
 
     ////////////////////////////////////////////////////
     ///                 Events

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -142,28 +142,28 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     ///                 Errors
     ////////////////////////////////////////////////////
 
-    error UnsupportedAsset();
-    error InvalidAsset();
-    error InvalidAdapter();
-    error AssetAlreadySupported();
-    error InvalidAssetDecimals();
-    error InvalidAdapterAsset();
-    error InvalidBuyPrice();
-    error SellPriceTooLow();
-    error CrossPriceTooLow();
-    error CrossPriceTooHigh();
-    error TooManyBaseAssets();
-    error FeeTooHigh();
-    error InvalidFeeCollector();
-    error InvalidMarket();
-    error InvalidMarketAsset();
-    error MarketAlreadySupported();
-    error MarketNotSupported();
-    error MarketActive();
-    error InvalidARMBuffer();
-    error AlreadyMigrated();
-    error LegacyWithdrawalsPending();
-    error ContractPaused();
+    error UnsupportedAsset(); // 0x24a01144
+    error InvalidAsset(); // 0xc891add2
+    error InvalidAdapter(); // 0xfbf66df1
+    error AssetAlreadySupported(); // 0xb1093e5b
+    error InvalidAssetDecimals(); // 0xe2364765
+    error InvalidAdapterAsset(); // 0x030f0830
+    error InvalidBuyPrice(); // 0x36c64b27
+    error SellPriceTooLow(); // 0x2394065c
+    error CrossPriceTooLow(); // 0xea59e662
+    error CrossPriceTooHigh(); // 0x682101d7
+    error TooManyBaseAssets(); // 0x94049173
+    error FeeTooHigh(); // 0xcd4e6167
+    error InvalidFeeCollector(); // 0xbb0bac99
+    error InvalidMarket(); // 0x9db8d5b1
+    error InvalidMarketAsset(); // 0xb9ced245
+    error MarketAlreadySupported(); // 0xf8d9e05f
+    error MarketNotSupported(); // 0x7f972548
+    error MarketActive(); // 0xaeb31949
+    error InvalidARMBuffer(); // 0x06f77af9
+    error AlreadyMigrated(); // 0xca1c3cbc
+    error LegacyWithdrawalsPending(); // 0x6df56289
+    error ContractPaused(); // 0xab35696f
 
     ////////////////////////////////////////////////////
     ///                 Events

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -767,7 +767,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @param shares LP shares to burn.
     /// @return requestId The LP withdrawal request id.
     /// @return assets The maximum liquidity assets claimable by the redeemer.
-    function requestRedeem(uint256 shares) external whenNotPaused nonReentrant returns (uint256 requestId, uint256 assets) {
+    function requestRedeem(uint256 shares)
+        external
+        whenNotPaused
+        nonReentrant
+        returns (uint256 requestId, uint256 assets)
+    {
         assets = convertToAssets(shares);
         requestId = nextWithdrawalIndex;
         // Store the next withdrawal request id.

--- a/src/contracts/CapManager.sol
+++ b/src/contracts/CapManager.sol
@@ -12,7 +12,7 @@ import {ILiquidityProviderARM} from "./Interfaces.sol";
  * @author Origin Protocol Inc
  */
 contract CapManager is Initializable, OwnableOperable {
-    error AccountCapAlreadySet();
+    error AccountCapAlreadySet(); // 0xbd6b5eba
 
     /// @notice The address of the linked Automated Redemption Manager (ARM).
     address public immutable arm;

--- a/src/contracts/EthenaARM.sol
+++ b/src/contracts/EthenaARM.sol
@@ -19,8 +19,6 @@ contract EthenaARM is Initializable, AbstractARM {
     /// @dev Deprecated request timestamp retained for storage layout compatibility.
     uint32 internal _deprecatedLastRequestTimestamp;
 
-    error LegacyEthenaCooldownPending(); // 0x0b5abdf2
-
     /// @param _usde The address of Ethena's synthetic dollar token (USDe)
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
     /// @param _minSharesToRedeem The minimum amount of shares to redeem from the active lending market
@@ -55,6 +53,6 @@ contract EthenaARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy Ethena cooldowns are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        if (_deprecatedLiquidityAmountInCooldown != 0) revert LegacyEthenaCooldownPending();
+        if (_deprecatedLiquidityAmountInCooldown != 0) revert LegacyWithdrawalsPending();
     }
 }

--- a/src/contracts/EthenaARM.sol
+++ b/src/contracts/EthenaARM.sol
@@ -19,7 +19,7 @@ contract EthenaARM is Initializable, AbstractARM {
     /// @dev Deprecated request timestamp retained for storage layout compatibility.
     uint32 internal _deprecatedLastRequestTimestamp;
 
-    error LegacyEthenaCooldownPending();
+    error LegacyEthenaCooldownPending(); // 0x0b5abdf2
 
     /// @param _usde The address of Ethena's synthetic dollar token (USDe)
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request

--- a/src/contracts/EthenaARM.sol
+++ b/src/contracts/EthenaARM.sol
@@ -19,6 +19,8 @@ contract EthenaARM is Initializable, AbstractARM {
     /// @dev Deprecated request timestamp retained for storage layout compatibility.
     uint32 internal _deprecatedLastRequestTimestamp;
 
+    error LegacyEthenaCooldownPending();
+
     /// @param _usde The address of Ethena's synthetic dollar token (USDe)
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
     /// @param _minSharesToRedeem The minimum amount of shares to redeem from the active lending market
@@ -53,6 +55,6 @@ contract EthenaARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy Ethena cooldowns are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        require(_deprecatedLiquidityAmountInCooldown == 0, "EthenaARM: cooldown pending");
+        if (_deprecatedLiquidityAmountInCooldown != 0) revert LegacyEthenaCooldownPending();
     }
 }

--- a/src/contracts/EtherFiARM.sol
+++ b/src/contracts/EtherFiARM.sol
@@ -20,7 +20,7 @@ contract EtherFiARM is Initializable, AbstractARM {
     /// @dev Deprecated withdrawal request mapping retained for storage layout compatibility.
     uint256 internal _deprecatedEtherfiWithdrawalRequests;
 
-    error LegacyEtherFiWithdrawalsPending();
+    error LegacyEtherFiWithdrawalsPending(); // 0x991777b5
 
     /// @param _weth The address of the WETH token
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request

--- a/src/contracts/EtherFiARM.sol
+++ b/src/contracts/EtherFiARM.sol
@@ -20,6 +20,8 @@ contract EtherFiARM is Initializable, AbstractARM {
     /// @dev Deprecated withdrawal request mapping retained for storage layout compatibility.
     uint256 internal _deprecatedEtherfiWithdrawalRequests;
 
+    error LegacyEtherFiWithdrawalsPending();
+
     /// @param _weth The address of the WETH token
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
     /// @param _minSharesToRedeem The minimum amount of shares to redeem from the active lending market
@@ -61,7 +63,7 @@ contract EtherFiARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy EtherFi withdrawal requests are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        require(_deprecatedEtherfiWithdrawalQueueAmount == 0, "EtherFiARM: withdrawals pending");
+        if (_deprecatedEtherfiWithdrawalQueueAmount != 0) revert LegacyEtherFiWithdrawalsPending();
     }
 
     /// @notice This payable method is necessary for receiving ETH claimed from the EtherFi withdrawal queue.

--- a/src/contracts/Interfaces.sol
+++ b/src/contracts/Interfaces.sol
@@ -273,9 +273,9 @@ struct UserCooldown {
 interface IStakedUSDe is IERC4626 {
     // Errors //
     /// @notice Error emitted when the shares amount to redeem is greater than the shares balance of the owner
-    error ExcessiveRedeemAmount();
+    error ExcessiveRedeemAmount(); // 0x63345388
     /// @notice Error emitted when the shares amount to withdraw is greater than the shares balance of the owner
-    error ExcessiveWithdrawAmount();
+    error ExcessiveWithdrawAmount(); // 0xdf53dde2
 
     function cooldownAssets(uint256 assets) external returns (uint256 shares);
 

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -20,7 +20,7 @@ contract LidoARM is Initializable, AbstractARM {
     /// @dev Deprecated withdrawal request mapping retained for storage layout compatibility.
     uint256 internal _deprecatedLidoWithdrawalRequests;
 
-    error LegacyLidoWithdrawalsPending();
+    error LegacyLidoWithdrawalsPending(); // 0xd5605722
 
     /// @param _weth The address of the WETH token
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -20,6 +20,8 @@ contract LidoARM is Initializable, AbstractARM {
     /// @dev Deprecated withdrawal request mapping retained for storage layout compatibility.
     uint256 internal _deprecatedLidoWithdrawalRequests;
 
+    error LegacyLidoWithdrawalsPending();
+
     /// @param _weth The address of the WETH token
     /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
     /// @param _minSharesToRedeem The minimum amount of shares to redeem from the active lending market
@@ -54,7 +56,7 @@ contract LidoARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy Lido withdrawal requests are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        require(_deprecatedLidoWithdrawalQueueAmount == 0, "LidoARM: requests pending");
+        if (_deprecatedLidoWithdrawalQueueAmount != 0) revert LegacyLidoWithdrawalsPending();
     }
 
     /// @notice This payable method is necessary for receiving ETH claimed from the Lido withdrawal queue.

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -23,6 +23,8 @@ contract OriginARM is Initializable, AbstractARM {
     event RequestOriginWithdrawal(uint256 amount, uint256 requestId);
     event ClaimOriginWithdrawals(uint256[] requestIds, uint256 amountClaimed);
 
+    error LegacyOriginWithdrawalsPending();
+
     /// @param _otoken The address of the Origin token. eg OETH or OS
     /// @param _liquidityAsset The address of the liquidity asset. eg WETH or wS
     /// @param _vault The address of the Origin Vault
@@ -75,6 +77,6 @@ contract OriginARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy Origin vault withdrawal requests are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        require(_deprecatedVaultWithdrawalAmount == 0, "OriginARM: withdrawals pending");
+        if (_deprecatedVaultWithdrawalAmount != 0) revert LegacyOriginWithdrawalsPending();
     }
 }

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -72,4 +72,9 @@ contract OriginARM is Initializable, AbstractARM {
     function vaultWithdrawalAmount() external view returns (uint256) {
         return _deprecatedVaultWithdrawalAmount;
     }
+
+    /// @dev Revert if legacy Origin vault withdrawal requests are still outstanding.
+    function _checkNoLegacyWithdrawQueue() internal view override {
+        require(_deprecatedVaultWithdrawalAmount == 0, "OriginARM: withdrawals pending");
+    }
 }

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -23,8 +23,6 @@ contract OriginARM is Initializable, AbstractARM {
     event RequestOriginWithdrawal(uint256 amount, uint256 requestId);
     event ClaimOriginWithdrawals(uint256[] requestIds, uint256 amountClaimed);
 
-    error LegacyOriginWithdrawalsPending(); // 0xfa449524
-
     /// @param _otoken The address of the Origin token. eg OETH or OS
     /// @param _liquidityAsset The address of the liquidity asset. eg WETH or wS
     /// @param _vault The address of the Origin Vault
@@ -77,6 +75,6 @@ contract OriginARM is Initializable, AbstractARM {
 
     /// @dev Revert if legacy Origin vault withdrawal requests are still outstanding.
     function _checkNoLegacyWithdrawQueue() internal view override {
-        if (_deprecatedVaultWithdrawalAmount != 0) revert LegacyOriginWithdrawalsPending();
+        if (_deprecatedVaultWithdrawalAmount != 0) revert LegacyWithdrawalsPending();
     }
 }

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -23,7 +23,7 @@ contract OriginARM is Initializable, AbstractARM {
     event RequestOriginWithdrawal(uint256 amount, uint256 requestId);
     event ClaimOriginWithdrawals(uint256[] requestIds, uint256 amountClaimed);
 
-    error LegacyOriginWithdrawalsPending();
+    error LegacyOriginWithdrawalsPending(); // 0xfa449524
 
     /// @param _otoken The address of the Origin token. eg OETH or OS
     /// @param _liquidityAsset The address of the liquidity asset. eg WETH or wS

--- a/src/contracts/Ownable.sol
+++ b/src/contracts/Ownable.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.23;
  * @author Origin Protocol Inc
  */
 contract Ownable {
-    error OnlyOwner();
+    error OnlyOwner(); // 0x5fc483c5
 
     /// @notice The slot used to store the owner of the contract.
     /// This is also used as the proxy admin.

--- a/src/contracts/OwnableOperable.sol
+++ b/src/contracts/OwnableOperable.sol
@@ -8,7 +8,7 @@ import {Ownable} from "./Ownable.sol";
  * @author Origin Protocol Inc
  */
 contract OwnableOperable is Ownable {
-    error OnlyOperatorOrOwner();
+    error OnlyOperatorOrOwner(); // 0x3fbed347
 
     /// @notice The account that can request and claim withdrawals.
     address public operator;

--- a/test/deploy/EthenaUpgradeGuards.t.sol
+++ b/test/deploy/EthenaUpgradeGuards.t.sol
@@ -55,6 +55,15 @@ contract EthenaUpgradeGuardsTest is Test {
         proxy.upgradeToAndCall(address(newImpl), data);
     }
 
+    function test_RevertWhen_MigrateLegacyWithdrawQueue_LegacyEthenaCooldownPending() external {
+        (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
+        proxy.upgradeTo(address(newImpl));
+        vm.store(address(proxy), bytes32(ETHENA_LEGACY_COOLDOWN_AMOUNT_SLOT), bytes32(uint256(1 ether)));
+
+        vm.expectRevert(EthenaARM.LegacyEthenaCooldownPending.selector);
+        EthenaARM(address(proxy)).migrateLegacyWithdrawQueue();
+    }
+
     function test_RevertWhen_UpgradeToAndCall_LegacyWithdrawQueuePending() external {
         (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();

--- a/test/deploy/EthenaUpgradeGuards.t.sol
+++ b/test/deploy/EthenaUpgradeGuards.t.sol
@@ -61,7 +61,7 @@ contract EthenaUpgradeGuardsTest is Test {
         proxy.upgradeTo(address(newImpl));
         vm.store(address(proxy), bytes32(ETHENA_LEGACY_COOLDOWN_AMOUNT_SLOT), bytes32(uint256(1 ether)));
 
-        vm.expectRevert(EthenaARM.LegacyEthenaCooldownPending.selector);
+        vm.expectRevert(AbstractARM.LegacyWithdrawalsPending.selector);
         EthenaARM(address(proxy)).migrateLegacyWithdrawQueue();
     }
 

--- a/test/deploy/EtherFiUpgradeGuards.t.sol
+++ b/test/deploy/EtherFiUpgradeGuards.t.sol
@@ -55,6 +55,15 @@ contract EtherFiUpgradeGuardsTest is Test {
         proxy.upgradeToAndCall(address(newImpl), data);
     }
 
+    function test_RevertWhen_MigrateLegacyWithdrawQueue_LegacyEtherFiWithdrawalsPending() external {
+        (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
+        proxy.upgradeTo(address(newImpl));
+        vm.store(address(proxy), bytes32(ETHERFI_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT), bytes32(uint256(1 ether)));
+
+        vm.expectRevert(EtherFiARM.LegacyEtherFiWithdrawalsPending.selector);
+        EtherFiARM(payable(address(proxy))).migrateLegacyWithdrawQueue();
+    }
+
     function test_RevertWhen_UpgradeToAndCall_LegacyWithdrawQueuePending() external {
         (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();

--- a/test/deploy/LidoUpgradeGuards.t.sol
+++ b/test/deploy/LidoUpgradeGuards.t.sol
@@ -55,6 +55,15 @@ contract LidoUpgradeGuardsTest is Test {
         proxy.upgradeToAndCall(address(newImpl), data);
     }
 
+    function test_RevertWhen_MigrateLegacyWithdrawQueue_LegacyLidoWithdrawalRequestsPending() external {
+        (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
+        proxy.upgradeTo(address(newImpl));
+        vm.store(address(proxy), bytes32(LIDO_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT), bytes32(uint256(1 ether)));
+
+        vm.expectRevert(LidoARM.LegacyLidoWithdrawalsPending.selector);
+        LidoARM(payable(address(proxy))).migrateLegacyWithdrawQueue();
+    }
+
     function test_RevertWhen_UpgradeToAndCall_LegacyWithdrawQueuePending() external {
         (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
         bytes memory data = script.migrateLegacyWithdrawQueueData();

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -35,6 +35,13 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
         originARM.migrateLegacyWithdrawQueue();
     }
 
+    function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_LegacyOriginWithdrawalsPending() public asGovernor {
+        stdstore.target(address(originARM)).sig(originARM.vaultWithdrawalAmount.selector).checked_write(uint256(1 ether));
+
+        vm.expectRevert("OriginARM: withdrawals pending");
+        originARM.migrateLegacyWithdrawQueue();
+    }
+
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_NewQueueAlreadyUsed()
         public
         deposit(alice, DEFAULT_AMOUNT)

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -37,7 +37,8 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
     }
 
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_LegacyOriginWithdrawalsPending() public asGovernor {
-        stdstore.target(address(originARM)).sig(originARM.vaultWithdrawalAmount.selector).checked_write(uint256(1 ether));
+        stdstore.target(address(originARM)).sig(originARM.vaultWithdrawalAmount.selector)
+            .checked_write(uint256(1 ether));
 
         vm.expectRevert(OriginARM.LegacyOriginWithdrawalsPending.selector);
         originARM.migrateLegacyWithdrawQueue();

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.23;
 
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
+import {OriginARM} from "contracts/OriginARM.sol";
 import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
 
 contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared_Test {
@@ -38,7 +39,7 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
     function test_RevertWhen_MigrateLegacyWithdrawQueue_Because_LegacyOriginWithdrawalsPending() public asGovernor {
         stdstore.target(address(originARM)).sig(originARM.vaultWithdrawalAmount.selector).checked_write(uint256(1 ether));
 
-        vm.expectRevert("OriginARM: withdrawals pending");
+        vm.expectRevert(OriginARM.LegacyOriginWithdrawalsPending.selector);
         originARM.migrateLegacyWithdrawQueue();
     }
 

--- a/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
+++ b/test/unit/OriginARM/MigrateLegacyWithdrawQueue.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.23;
 
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
+import {AbstractARM} from "contracts/AbstractARM.sol";
 import {OriginARM} from "contracts/OriginARM.sol";
 import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
 
@@ -55,7 +56,7 @@ contract Unit_Concrete_OriginARM_MigrateLegacyWithdrawQueue_Test_ is Unit_Shared
         stdstore.target(address(originARM)).sig(originARM.vaultWithdrawalAmount.selector)
             .checked_write(uint256(1 ether));
 
-        vm.expectRevert(OriginARM.LegacyOriginWithdrawalsPending.selector);
+        vm.expectRevert(AbstractARM.LegacyWithdrawalsPending.selector);
         originARM.migrateLegacyWithdrawQueue();
     }
 


### PR DESCRIPTION
## Summary ##

- Enforces OriginARM legacy vault withdrawal queue must be empty before `migrateLegacyWithdrawQueue()`.
- Converts protocol-specific legacy queue reverts across ARM implementations to custom errors.
- Adds selector comments for custom errors in `src/contracts`.
- Documents the selector-comment convention in `AGENTS.md`.

## Contract Sizes ##

Current ARM implementation sizes from `forge build --sizes` / artifacts:

| Contract | Runtime size | Runtime margin vs 24,576 | Initcode size | Deployable? |
|---|---:|---:|---:|---|
| `EthenaARM` | 23,668 B | 908 B | 24,770 B | Yes |
| `OriginARM` | 23,737 B | 839 B | 24,912 B | Yes |
| `LidoARM` | 24,458 B | 118 B | 25,560 B | Yes, tight |
| `EtherFiARM` | 24,497 B | 79 B | 25,634 B | Yes, very tight |

So the ARM implementations are deployable under the EIP-170 runtime limit of 24,576 bytes.