### PR TITLE
Added rescueWithdrawalNFT functions to Lido and EtherFi Adapters

### DIFF
--- a/src/contracts/Interfaces.sol
+++ b/src/contracts/Interfaces.sol
@@ -267,6 +267,10 @@ interface IEETHWithdrawalNFT {
     function batchClaimWithdraw(uint256[] calldata requestIds) external;
 }
 
+interface IOwnable {
+    function owner() external view returns (address);
+}
+
 interface IEETHRedemptionManager {
     function redeemEEth(uint256 amount, address receiver) external;
     function redeemWeEth(uint256 amount, address receiver) external;

--- a/src/contracts/adapters/AbstractLidoAssetAdapter.sol
+++ b/src/contracts/adapters/AbstractLidoAssetAdapter.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.23;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-import {IAssetAdapter, IERC20, IStETHWithdrawal, ISTETH, IWETH} from "../Interfaces.sol";
+import {IAssetAdapter, IERC20, IOwnable, IStETHWithdrawal, ISTETH, IWETH} from "../Interfaces.sol";
 
 /**
  * @title Shared Lido withdrawal queue asset adapter
@@ -12,6 +13,12 @@ import {IAssetAdapter, IERC20, IStETHWithdrawal, ISTETH, IWETH} from "../Interfa
  * @author Origin Protocol Inc
  */
 abstract contract AbstractLidoAssetAdapter is Initializable, IAssetAdapter {
+    /// @notice Thrown when attempting to rescue an active adapter-managed withdrawal NFT.
+    /// @param requestId Lido withdrawal NFT token id.
+    error ActiveWithdrawalNFT(uint256 requestId);
+    /// @notice Thrown when a caller other than the ARM owner attempts an owner-only action.
+    error OnlyARMOwner();
+
     /// @notice Maximum stETH amount accepted by Lido for a single withdrawal request.
     uint256 internal constant MAX_WITHDRAWAL_AMOUNT = 1000 ether;
 
@@ -32,8 +39,15 @@ abstract contract AbstractLidoAssetAdapter is Initializable, IAssetAdapter {
     uint256[] internal pendingRequestIds;
     uint256 internal nextPendingIndex;
 
+    event WithdrawalNFTRescued(uint256 indexed requestId, address indexed to);
+
     modifier onlyARM() {
         require(msg.sender == arm, "Adapter: only ARM");
+        _;
+    }
+
+    modifier onlyARMOwner() {
+        if (msg.sender != IOwnable(arm).owner()) revert OnlyARMOwner();
         _;
     }
 
@@ -184,6 +198,18 @@ abstract contract AbstractLidoAssetAdapter is Initializable, IAssetAdapter {
     /// @param index Index in the pending request id array.
     function pendingRequestId(uint256 index) external view returns (uint256) {
         return pendingRequestIds[index];
+    }
+
+    /// @notice Rescue a Lido withdrawal NFT that was sent here by mistake.
+    /// @dev Reverts for active adapter-managed withdrawal NFTs so legitimate requests cannot be rescued.
+    /// @param requestId Lido withdrawal NFT token id.
+    /// @param to Recipient of the rescued withdrawal NFT.
+    function rescueWithdrawalNFT(uint256 requestId, address to) external onlyARMOwner {
+        if (requestShares[requestId] != 0 || requestAssets[requestId] != 0) revert ActiveWithdrawalNFT(requestId);
+
+        IERC721(address(lidoWithdrawalQueue)).safeTransferFrom(address(this), to, requestId);
+
+        emit WithdrawalNFTRescued(requestId, to);
     }
 
     /// @notice Splits an amount into chunks accepted by the Lido withdrawal queue.

--- a/src/contracts/adapters/EtherFiAssetAdapter.sol
+++ b/src/contracts/adapters/EtherFiAssetAdapter.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.23;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import {IAssetAdapter, IERC20, IEETHWithdrawal, IEETHWithdrawalNFT, IWETH} from "../Interfaces.sol";
+import {IAssetAdapter, IERC20, IEETHWithdrawal, IEETHWithdrawalNFT, IOwnable, IWETH} from "../Interfaces.sol";
 
 /**
  * @title Ether.fi eETH asset adapter
@@ -13,6 +14,12 @@ import {IAssetAdapter, IERC20, IEETHWithdrawal, IEETHWithdrawalNFT, IWETH} from 
  * @author Origin Protocol Inc
  */
 contract EtherFiAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
+    /// @notice Thrown when attempting to rescue an active adapter-managed withdrawal NFT.
+    /// @param requestId Ether.fi withdrawal NFT token id.
+    error ActiveWithdrawalNFT(uint256 requestId);
+    /// @notice Thrown when a caller other than the ARM owner attempts an owner-only action.
+    error OnlyARMOwner();
+
     /// @notice ARM contract authorized to request and claim redemptions.
     address public immutable arm;
     /// @notice eETH token submitted to Ether.fi withdrawals.
@@ -29,8 +36,15 @@ contract EtherFiAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
     uint256[] internal pendingRequestIds;
     uint256 internal nextPendingIndex;
 
+    event WithdrawalNFTRescued(uint256 indexed requestId, address indexed to);
+
     modifier onlyARM() {
         require(msg.sender == arm, "Adapter: only ARM");
+        _;
+    }
+
+    modifier onlyARMOwner() {
+        if (msg.sender != IOwnable(arm).owner()) revert OnlyARMOwner();
         _;
     }
 
@@ -156,6 +170,18 @@ contract EtherFiAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
     /// @param index Index in the pending request id array.
     function pendingRequestId(uint256 index) external view returns (uint256) {
         return pendingRequestIds[index];
+    }
+
+    /// @notice Rescue an Ether.fi withdrawal NFT that was sent here by mistake.
+    /// @dev Reverts for active adapter-managed withdrawal NFTs so legitimate requests cannot be rescued.
+    /// @param requestId Ether.fi withdrawal NFT token id.
+    /// @param to Recipient of the rescued withdrawal NFT.
+    function rescueWithdrawalNFT(uint256 requestId, address to) external onlyARMOwner {
+        if (requestShares[requestId] != 0) revert ActiveWithdrawalNFT(requestId);
+
+        IERC721(address(etherfiWithdrawalNFT)).safeTransferFrom(address(this), to, requestId);
+
+        emit WithdrawalNFTRescued(requestId, to);
     }
 
     receive() external payable {}

--- a/src/contracts/adapters/WeETHAssetAdapter.sol
+++ b/src/contracts/adapters/WeETHAssetAdapter.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.23;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import {IAssetAdapter, IERC20, IEETHWithdrawal, IEETHWithdrawalNFT, IWeETH, IWETH} from "../Interfaces.sol";
+import {IAssetAdapter, IERC20, IEETHWithdrawal, IEETHWithdrawalNFT, IOwnable, IWeETH, IWETH} from "../Interfaces.sol";
 
 /**
  * @title Ether.fi weETH asset adapter
@@ -13,6 +14,12 @@ import {IAssetAdapter, IERC20, IEETHWithdrawal, IEETHWithdrawalNFT, IWeETH, IWET
  * @author Origin Protocol Inc
  */
 contract WeETHAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
+    /// @notice Thrown when attempting to rescue an active adapter-managed withdrawal NFT.
+    /// @param requestId Ether.fi withdrawal NFT token id.
+    error ActiveWithdrawalNFT(uint256 requestId);
+    /// @notice Thrown when a caller other than the ARM owner attempts an owner-only action.
+    error OnlyARMOwner();
+
     /// @notice ARM contract authorized to request and claim redemptions.
     address public immutable arm;
     /// @notice weETH token supplied by the ARM.
@@ -33,8 +40,15 @@ contract WeETHAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
     uint256[] internal pendingRequestIds;
     uint256 internal nextPendingIndex;
 
+    event WithdrawalNFTRescued(uint256 indexed requestId, address indexed to);
+
     modifier onlyARM() {
         require(msg.sender == arm, "Adapter: only ARM");
+        _;
+    }
+
+    modifier onlyARMOwner() {
+        if (msg.sender != IOwnable(arm).owner()) revert OnlyARMOwner();
         _;
     }
 
@@ -166,6 +180,18 @@ contract WeETHAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
     /// @param index Index in the pending request id array.
     function pendingRequestId(uint256 index) external view returns (uint256) {
         return pendingRequestIds[index];
+    }
+
+    /// @notice Rescue an Ether.fi withdrawal NFT that was sent here by mistake.
+    /// @dev Reverts for active adapter-managed withdrawal NFTs so legitimate requests cannot be rescued.
+    /// @param requestId Ether.fi withdrawal NFT token id.
+    /// @param to Recipient of the rescued withdrawal NFT.
+    function rescueWithdrawalNFT(uint256 requestId, address to) external onlyARMOwner {
+        if (requestShares[requestId] != 0) revert ActiveWithdrawalNFT(requestId);
+
+        IERC721(address(etherfiWithdrawalNFT)).safeTransferFrom(address(this), to, requestId);
+
+        emit WithdrawalNFTRescued(requestId, to);
     }
 
     receive() external payable {}

--- a/test/fork/EtherFiARM/RequestWithdraw.t.sol
+++ b/test/fork/EtherFiARM/RequestWithdraw.t.sol
@@ -3,11 +3,21 @@ pragma solidity 0.8.23;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/EtherFiARM/shared/Shared.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
+
+// Contracts
+import {EtherFiAssetAdapter} from "contracts/adapters/EtherFiAssetAdapter.sol";
+import {WeETHAssetAdapter} from "contracts/adapters/WeETHAssetAdapter.sol";
 
 // Interfaces
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IWeETH} from "contracts/Interfaces.sol";
 
 contract Fork_Concrete_EtherFiARM_RequestWithdraw_Test_ is Fork_Shared_Test {
+    using stdStorage for StdStorage;
+
+    event WithdrawalNFTRescued(uint256 indexed requestId, address indexed to);
+
     function test_DelayWithdraw() public {
         // Fund the ARM with eETH from weETH
         vm.prank(address(weeth));
@@ -78,5 +88,98 @@ contract Fork_Concrete_EtherFiARM_RequestWithdraw_Test_ is Fork_Shared_Test {
 
         (,,,,, pendingRedeemAssets,,) = etherfiARM.baseAssetConfigs(address(weeth));
         assertEq(pendingRedeemAssets, 0, "pending redeem assets after claim");
+    }
+
+    function test_EETH_CannotRescueActiveWithdrawalNFT() public {
+        vm.prank(address(weeth));
+        eeth.transfer(address(etherfiARM), 1 ether);
+
+        vm.prank(operator);
+        etherfiARM.requestBaseAssetRedeem(address(eeth), 1 ether);
+        uint256 requestId = etherfiAssetAdapter.pendingRequestId(0);
+
+        vm.expectRevert(abi.encodeWithSelector(EtherFiAssetAdapter.ActiveWithdrawalNFT.selector, requestId));
+        etherfiAssetAdapter.rescueWithdrawalNFT(requestId, bob);
+    }
+
+    function test_EETH_RescueAccidentalWithdrawalNFT() public {
+        address recipient = address(0xBEEF);
+        uint256 requestId = _requestAdapterEETHWithdrawal();
+        _clearEETHAdapterRequest(requestId);
+
+        vm.expectEmit(true, true, false, true);
+        emit WithdrawalNFTRescued(requestId, recipient);
+        etherfiAssetAdapter.rescueWithdrawalNFT(requestId, recipient);
+
+        assertEq(IERC721(address(etherfiWithdrawalNFT)).ownerOf(requestId), recipient, "rescued NFT owner");
+    }
+
+    function test_WeETH_CannotRescueActiveWithdrawalNFT() public {
+        uint256 weethAmount = 1 ether;
+        deal(address(weeth), address(etherfiARM), weethAmount);
+
+        vm.prank(operator);
+        etherfiARM.requestBaseAssetRedeem(address(weeth), weethAmount);
+        uint256 requestId = weethAssetAdapter.pendingRequestId(0);
+
+        vm.expectRevert(abi.encodeWithSelector(WeETHAssetAdapter.ActiveWithdrawalNFT.selector, requestId));
+        weethAssetAdapter.rescueWithdrawalNFT(requestId, bob);
+    }
+
+    function test_WeETH_RescueAccidentalWithdrawalNFT() public {
+        address recipient = address(0xBEEF);
+        uint256 requestId = _requestAdapterWeETHWithdrawal(1 ether);
+        _clearWeETHAdapterRequest(requestId);
+
+        vm.expectEmit(true, true, false, true);
+        emit WithdrawalNFTRescued(requestId, recipient);
+        weethAssetAdapter.rescueWithdrawalNFT(requestId, recipient);
+
+        assertEq(IERC721(address(etherfiWithdrawalNFT)).ownerOf(requestId), recipient, "rescued NFT owner");
+    }
+
+    function test_EETH_OnlyARMOwnerCanRescueWithdrawalNFT() public {
+        uint256 requestId = _requestAdapterEETHWithdrawal();
+        _clearEETHAdapterRequest(requestId);
+
+        vm.prank(alice);
+        vm.expectRevert(EtherFiAssetAdapter.OnlyARMOwner.selector);
+        etherfiAssetAdapter.rescueWithdrawalNFT(requestId, bob);
+    }
+
+    function _requestAdapterEETHWithdrawal() internal returns (uint256 requestId) {
+        vm.prank(address(weeth));
+        eeth.transfer(address(etherfiARM), 1 ether);
+
+        vm.prank(operator);
+        etherfiARM.requestBaseAssetRedeem(address(eeth), 1 ether);
+
+        requestId = etherfiAssetAdapter.pendingRequestId(0);
+        assertEq(IERC721(address(etherfiWithdrawalNFT)).ownerOf(requestId), address(etherfiAssetAdapter), "NFT owner");
+    }
+
+    function _requestAdapterWeETHWithdrawal(uint256 weethAmount) internal returns (uint256 requestId) {
+        deal(address(weeth), address(etherfiARM), weethAmount);
+
+        vm.prank(operator);
+        etherfiARM.requestBaseAssetRedeem(address(weeth), weethAmount);
+
+        requestId = weethAssetAdapter.pendingRequestId(0);
+        assertEq(IERC721(address(etherfiWithdrawalNFT)).ownerOf(requestId), address(weethAssetAdapter), "NFT owner");
+    }
+
+    function _clearEETHAdapterRequest(uint256 requestId) internal {
+        stdstore.target(address(etherfiAssetAdapter)).sig("requestShares(uint256)").with_key(requestId)
+            .checked_write(uint256(0));
+        assertEq(etherfiAssetAdapter.requestShares(requestId), 0, "request shares cleared");
+    }
+
+    function _clearWeETHAdapterRequest(uint256 requestId) internal {
+        stdstore.target(address(weethAssetAdapter)).sig("requestShares(uint256)").with_key(requestId)
+            .checked_write(uint256(0));
+        stdstore.target(address(weethAssetAdapter)).sig("requestAssets(uint256)").with_key(requestId)
+            .checked_write(uint256(0));
+        assertEq(weethAssetAdapter.requestShares(requestId), 0, "request shares cleared");
+        assertEq(weethAssetAdapter.requestAssets(requestId), 0, "request assets cleared");
     }
 }

--- a/test/fork/LidoARM/RequestStETHWithdrawalForETH.t.sol
+++ b/test/fork/LidoARM/RequestStETHWithdrawalForETH.t.sol
@@ -3,13 +3,20 @@ pragma solidity 0.8.23;
 
 // Test imports
 import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
 // Contracts
+import {AbstractLidoAssetAdapter} from "contracts/adapters/AbstractLidoAssetAdapter.sol";
 import {IERC20, IStETHWithdrawal} from "contracts/Interfaces.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
 import {Mainnet} from "contracts/utils/Addresses.sol";
 
 contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_ {
+    using stdStorage for StdStorage;
+
+    event WithdrawalNFTRescued(uint256 indexed requestId, address indexed to);
+
     //////////////////////////////////////////////////////
     /// --- SETUP
     //////////////////////////////////////////////////////
@@ -39,6 +46,25 @@ contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_
 
         vm.expectRevert();
         lidoARM.requestBaseAssetRedeem(address(steth), amounts[0]);
+    }
+
+    function test_RevertWhen_RescueActiveWithdrawalNFT() public {
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = DEFAULT_AMOUNT;
+        uint256[] memory requestIds = _requestLidoWithdrawals(amounts);
+        uint256 requestId = requestIds[0];
+
+        vm.expectRevert(abi.encodeWithSelector(AbstractLidoAssetAdapter.ActiveWithdrawalNFT.selector, requestId));
+        AbstractLidoAssetAdapter(payable(stethAdapter)).rescueWithdrawalNFT(requestId, alice);
+    }
+
+    function test_RevertWhen_RescueWithdrawalNFT_NotARMOwner() public {
+        uint256 requestId = _requestAdapterLidoWithdrawal();
+        _clearLidoAdapterRequest(requestId);
+
+        vm.prank(alice);
+        vm.expectRevert(AbstractLidoAssetAdapter.OnlyARMOwner.selector);
+        AbstractLidoAssetAdapter(payable(stethAdapter)).rescueWithdrawalNFT(requestId, alice);
     }
 
     //////////////////////////////////////////////////////
@@ -97,5 +123,35 @@ contract Fork_Concrete_LidoARM_RequestLidoWithdrawals_Test_ is Fork_Shared_Test_
         uint256[] memory requestIds = _requestLidoWithdrawals(amounts);
 
         assertEq(requestIds, expectedLidoRequestIds);
+    }
+
+    function test_RescueAccidentalWithdrawalNFT() public {
+        address recipient = address(0xBEEF);
+        uint256 requestId = _requestAdapterLidoWithdrawal();
+        _clearLidoAdapterRequest(requestId);
+
+        vm.expectEmit(true, true, false, true);
+        emit WithdrawalNFTRescued(requestId, recipient);
+        AbstractLidoAssetAdapter(payable(stethAdapter)).rescueWithdrawalNFT(requestId, recipient);
+
+        assertEq(IERC721(address(Mainnet.LIDO_WITHDRAWAL)).ownerOf(requestId), recipient, "rescued NFT owner");
+    }
+
+    function _requestAdapterLidoWithdrawal() internal returns (uint256 requestId) {
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = DEFAULT_AMOUNT;
+        uint256[] memory requestIds = _requestLidoWithdrawals(amounts);
+        requestId = requestIds[0];
+
+        assertEq(IERC721(address(Mainnet.LIDO_WITHDRAWAL)).ownerOf(requestId), stethAdapter, "NFT owner");
+    }
+
+    function _clearLidoAdapterRequest(uint256 requestId) internal {
+        AbstractLidoAssetAdapter adapter = AbstractLidoAssetAdapter(payable(stethAdapter));
+
+        stdstore.target(address(adapter)).sig("requestShares(uint256)").with_key(requestId).checked_write(uint256(0));
+        stdstore.target(address(adapter)).sig("requestAssets(uint256)").with_key(requestId).checked_write(uint256(0));
+        assertEq(adapter.requestShares(requestId), 0, "request shares cleared");
+        assertEq(adapter.requestAssets(requestId), 0, "request assets cleared");
     }
 }


### PR DESCRIPTION
## Changes

- Added `rescueWithdrawalNFT(requestId, to)` to:
  - `AbstractLidoAssetAdapter`
  - `EtherFiAssetAdapter`
  - `WeETHAssetAdapter`
- Rescue is restricted to the ARM owner.
- Rescue reverts for active adapter-managed withdrawal NFTs:
  - Lido checks `requestShares[requestId]` and `requestAssets[requestId]`
  - EtherFi checks `requestShares[requestId]`
- Added custom errors:
  - `ActiveWithdrawalNFT(uint256 requestId)`
  - `OnlyARMOwner()`
- Added `IOwnable` interface for adapter-side ARM owner checks.
- Added fork test coverage for:
  - rescuing untracked withdrawal NFTs
  - preventing rescue of active adapter-managed NFTs
  - rejecting non-owner rescue attempts
