### PR TITLE
test: cover ARM claim accounting after market recovery

### DIFF
--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -115,4 +115,61 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
         assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }
+
+    function test_ClaimRedeem_AfterMarketLoss_NewDepositorRecoveryAccounting()
+        public
+        setFee(0)
+        addMarket(address(market))
+        setActiveMarket(address(market))
+        setARMBuffer(0)
+    {
+        // Alice and Bob are independent LPs. All liquid WETH is allocated to the market.
+        deal(address(weth), alice, 2 * DEFAULT_AMOUNT);
+        vm.startPrank(alice);
+        weth.approve(address(originARM), type(uint256).max);
+        originARM.deposit(2 * DEFAULT_AMOUNT);
+        vm.stopPrank();
+        originARM.allocate();
+
+        uint256 aliceShares = originARM.balanceOf(alice);
+        uint256 expectedRequestedAssets = originARM.convertToAssets(aliceShares / 2);
+        vm.prank(alice);
+        (uint256 requestId, uint256 requestedAssets) = originARM.requestRedeem(aliceShares / 2);
+        assertEq(requestedAssets, expectedRequestedAssets, "sanity: queued amount matches preview");
+
+        // Simulate a 10% market loss after the request. Alice's claim should be haircut at claim time.
+        uint256 marketWethBeforeLoss = weth.balanceOf(address(market));
+        vm.prank(address(market));
+        weth.transfer(address(0x1), marketWethBeforeLoss / 10);
+
+        vm.warp(block.timestamp + CLAIM_DELAY);
+        uint256 aliceBalanceBefore = weth.balanceOf(alice);
+        vm.prank(alice);
+        uint256 claimedAssets = originARM.claimRedeem(requestId);
+        assertLt(claimedAssets, requestedAssets, "claim should be haircut after market loss");
+        assertEq(weth.balanceOf(alice), aliceBalanceBefore + claimedAssets, "Alice receives claimed assets");
+        assertEq(originARM.withdrawsClaimed(), requestedAssets, "queue is advanced by request amount");
+        assertEq(originARM.withdrawsQueued(), requestedAssets, "queue total is request amount");
+
+        uint256 totalAssetsBeforeBob = originARM.totalAssets();
+        uint256 bobExpectedShares = originARM.convertToShares(DEFAULT_AMOUNT);
+
+        deal(address(weth), bob, DEFAULT_AMOUNT);
+        vm.startPrank(bob);
+        weth.approve(address(originARM), DEFAULT_AMOUNT);
+        originARM.deposit(DEFAULT_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(originARM.balanceOf(bob), bobExpectedShares, "Bob shares use post-loss PPS");
+        assertEq(originARM.totalAssets(), totalAssetsBeforeBob + DEFAULT_AMOUNT, "Bob deposit increases assets 1:1");
+
+        // Simulate market recovery/donation after Bob enters. With fee disabled, recovery should accrue to LPs
+        // through totalAssets without making Alice's already-claimed request claimable again.
+        deal(address(weth), address(market), weth.balanceOf(address(market)) + marketWethBeforeLoss / 10);
+        (, bool claimed,,,,) = originARM.withdrawalRequests(requestId);
+        assertTrue(claimed, "Alice request remains claimed after recovery");
+        assertEq(originARM.withdrawsClaimed(), requestedAssets, "recovery does not reopen queue accounting");
+        assertGt(originARM.totalAssets(), totalAssetsBeforeBob + DEFAULT_AMOUNT, "recovery increases remaining LP assets");
+    }
+
 }


### PR DESCRIPTION
## Summary

This PR adds regression coverage for an ARM withdrawal-queue accounting edge case around market loss, haircut claims, new deposits, and later market recovery.

## Changes

- Adds a unit test for `requestRedeem -> market loss -> haircut claim -> new depositor -> market recovery`.
- Verifies the old request stays claimed and queue accounting is not reopened after recovery.
- Verifies the new depositor receives shares at post-loss PPS and their deposit increases assets 1:1.

## Testing

- `forge test --match-path test/unit/OriginARM/ClaimRedeem.sol --match-test test_ClaimRedeem_AfterMarketLoss_NewDepositorRecoveryAccounting -vv`
- `forge test --match-path 'test/unit/OriginARM/*.sol' -vv`

## Notes

Defensive regression coverage only; no sensitive vulnerability details are included.
