### PR TITLE
Harden Lido withdrawal claims

### DIFF
--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -141,7 +141,12 @@ contract LidoARM is Initializable, AbstractARM {
      * @param hintIds The hint IDs of the withdrawal requests.
      * Call `findCheckpointHints` on the Lido withdrawal queue contract to get the hint IDs.
      */
-    function claimLidoWithdrawals(uint256[] calldata requestIds, uint256[] calldata hintIds) external {
+    function claimLidoWithdrawals(uint256[] calldata requestIds, uint256[] calldata hintIds)
+        external
+        onlyOperatorOrOwner
+    {
+        uint256 ethBalanceBefore = address(this).balance;
+
         // Claim the NFTs for ETH.
         lidoWithdrawalQueue.claimWithdrawals(requestIds, hintIds);
 
@@ -165,8 +170,9 @@ contract LidoARM is Initializable, AbstractARM {
         // this subtraction should never underflow.
         lidoWithdrawalQueueAmount -= totalAmountRequested;
 
-        // Wrap all the received ETH to WETH. This can be less than the requested amount in the event of slashing.
-        weth.deposit{value: address(this).balance}();
+        // Wrap the ETH balance increase from this claim. This can be less than the requested amount
+        // in the event of slashing, and ignores ETH donated before the claim starts.
+        weth.deposit{value: address(this).balance - ethBalanceBefore}();
 
         emit ClaimLidoWithdrawals(requestIds);
     }

--- a/test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol
+++ b/test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol
@@ -83,6 +83,44 @@ contract Fork_Concrete_LidoARM_ClaimLidoWithdrawals_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + DEFAULT_AMOUNT);
     }
 
+    function test_ClaimLidoWithdrawals_RevertsWhenNotOperatorOrOwner()
+        public
+        requestLidoWithdrawalsOnLidoARM(amounts1)
+        mockFunctionClaimWithdrawOnLidoARM(DEFAULT_AMOUNT)
+    {
+        uint256[] memory requests = new uint256[](1);
+        requests[0] = stETHWithdrawal.getLastRequestId();
+
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
+
+        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        vm.prank(alice);
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
+    }
+
+    function test_ClaimLidoWithdrawals_DoesNotWrapPreexistingEth()
+        public
+        asOperator
+        requestLidoWithdrawalsOnLidoARM(amounts1)
+        mockFunctionClaimWithdrawOnLidoARM(DEFAULT_AMOUNT)
+    {
+        uint256 donation = 1 ether;
+        deal(address(lidoARM), donation);
+        uint256 balanceBefore = weth.balanceOf(address(lidoARM));
+
+        uint256[] memory requests = new uint256[](1);
+        requests[0] = stETHWithdrawal.getLastRequestId();
+
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
+
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
+
+        assertEq(address(lidoARM).balance, donation);
+        assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + DEFAULT_AMOUNT);
+    }
+
     function test_ClaimLidoWithdrawals_MultiRequest()
         public
         asOperator

--- a/test/fork/utils/MockCall.sol
+++ b/test/fork/utils/MockCall.sol
@@ -71,6 +71,8 @@ contract ETHSender {
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     function sendETH(address target) external {
-        vm.deal(target, address(this).balance);
+        uint256 amount = address(this).balance;
+        vm.deal(target, target.balance + amount);
+        vm.deal(address(this), 0);
     }
 }


### PR DESCRIPTION
## Summary
- Add `onlyOperatorOrOwner` to `LidoARM.claimLidoWithdrawals()` so claim timing stays under the same operator/owner control as `requestLidoWithdrawals()`.
- Wrap only the ETH received during the current Lido claim instead of `address(this).balance`, so pre-existing donated ETH is not swept into WETH during a claim.
- Add regression coverage for unauthorized callers and pre-existing ETH, and make the Lido claim test helper model ETH sends without overwriting or retaining the sender balance.

Fixes #241.

## Validation
- `MAINNET_URL=https://ethereum-rpc.publicnode.com C:\Users\tupm96\.foundry\bin\forge.exe test --match-path test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol --summary -vvv` -> 5 passed
- `C:\Users\tupm96\.foundry\bin\forge.exe build --skip test script --force` -> success, existing warnings only
- `C:\Users\tupm96\.foundry\bin\forge.exe fmt --check src/contracts/LidoARM.sol test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol test/fork/utils/MockCall.sol` -> success
- `git diff --check` -> clean

No private keys, wallet secrets, payout details, private vulnerability details, or mainnet transactions are included.