### PR TITLE
Fix Lido withdrawal claim access control

### DIFF
--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -141,7 +141,12 @@ contract LidoARM is Initializable, AbstractARM {
      * @param hintIds The hint IDs of the withdrawal requests.
      * Call `findCheckpointHints` on the Lido withdrawal queue contract to get the hint IDs.
      */
-    function claimLidoWithdrawals(uint256[] calldata requestIds, uint256[] calldata hintIds) external {
+    function claimLidoWithdrawals(uint256[] calldata requestIds, uint256[] calldata hintIds)
+        external
+        onlyOperatorOrOwner
+    {
+        uint256 ethBalanceBefore = address(this).balance;
+
         // Claim the NFTs for ETH.
         lidoWithdrawalQueue.claimWithdrawals(requestIds, hintIds);
 
@@ -165,8 +170,9 @@ contract LidoARM is Initializable, AbstractARM {
         // this subtraction should never underflow.
         lidoWithdrawalQueueAmount -= totalAmountRequested;
 
-        // Wrap all the received ETH to WETH. This can be less than the requested amount in the event of slashing.
-        weth.deposit{value: address(this).balance}();
+        // Wrap only the ETH received from this claim. This can be less than the requested amount in the event of slashing.
+        uint256 ethReceived = address(this).balance - ethBalanceBefore;
+        if (ethReceived > 0) weth.deposit{value: ethReceived}();
 
         emit ClaimLidoWithdrawals(requestIds);
     }

--- a/test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol
+++ b/test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol
@@ -35,6 +35,16 @@ contract Fork_Concrete_LidoARM_ClaimLidoWithdrawals_Test_ is Fork_Shared_Test_ {
     }
 
     //////////////////////////////////////////////////////
+    /// --- REVERTING TESTS
+    //////////////////////////////////////////////////////
+    function test_RevertWhen_ClaimLidoWithdrawals_NotOperatorOrOwner() public asRandomAddress {
+        uint256[] memory emptyList = new uint256[](0);
+
+        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        lidoARM.claimLidoWithdrawals(emptyList, emptyList);
+    }
+
+    //////////////////////////////////////////////////////
     /// --- PASSING TESTS
     //////////////////////////////////////////////////////
     function test_ClaimLidoWithdrawals_EmptyList() public asOperator requestLidoWithdrawalsOnLidoARM(new uint256[](0)) {
@@ -79,6 +89,33 @@ contract Fork_Concrete_LidoARM_ClaimLidoWithdrawals_Test_ is Fork_Shared_Test_ {
         lidoARM.claimLidoWithdrawals(requests, hintIds);
 
         // Assertions after
+        assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
+        assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + DEFAULT_AMOUNT);
+    }
+
+    function test_ClaimLidoWithdrawals_OnlyWrapsClaimedETH()
+        public
+        asOperator
+        requestLidoWithdrawalsOnLidoARM(amounts1)
+        mockFunctionClaimWithdrawOnLidoARM(DEFAULT_AMOUNT)
+    {
+        uint256 donatedETH = 0.5 ether;
+        vm.deal(address(lidoARM), donatedETH);
+
+        uint256 balanceBefore = weth.balanceOf(address(lidoARM));
+        assertEq(address(lidoARM).balance, donatedETH);
+        assertEq(lidoARM.lidoWithdrawalQueueAmount(), DEFAULT_AMOUNT);
+
+        stETHWithdrawal.getLastRequestId();
+        uint256[] memory requests = new uint256[](1);
+        requests[0] = stETHWithdrawal.getLastRequestId();
+
+        uint256 lastIndex = stETHWithdrawal.getLastCheckpointIndex();
+        uint256[] memory hintIds = stETHWithdrawal.findCheckpointHints(requests, 1, lastIndex);
+
+        lidoARM.claimLidoWithdrawals(requests, hintIds);
+
+        assertEq(address(lidoARM).balance, donatedETH);
         assertEq(lidoARM.lidoWithdrawalQueueAmount(), 0);
         assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + DEFAULT_AMOUNT);
     }

--- a/test/fork/utils/MockCall.sol
+++ b/test/fork/utils/MockCall.sol
@@ -71,6 +71,6 @@ contract ETHSender {
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     function sendETH(address target) external {
-        vm.deal(target, address(this).balance);
+        vm.deal(target, target.balance + address(this).balance);
     }
 }


### PR DESCRIPTION
## Summary
- restrict `claimLidoWithdrawals` to the configured operator or owner
- wrap only ETH received by the current Lido claim instead of the full contract ETH balance
- cover unauthorized callers and pre-existing ETH balances in the fork tests

Fixes #241

## Verification
- `forge build --skip test script --force`
- `forge test --match-path test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol --fork-url https://ethereum.publicnode.com -vv`
- `node_modules/.bin/hardhat.CMD compile`
