### PR TITLE
Sweep donated ETH and WETH from claim adapters

### DIFF
--- a/src/contracts/adapters/AbstractLidoAssetAdapter.sol
+++ b/src/contracts/adapters/AbstractLidoAssetAdapter.sol
@@ -88,12 +88,13 @@ abstract contract AbstractLidoAssetAdapter is Initializable, IAssetAdapter {
         sharesRequested = shares;
     }
 
-    /// @notice Claims finalized Lido withdrawal requests and transfers WETH to the ARM.
-    /// @dev Claims finalized pending requests in FIFO order and wraps any received ETH into WETH.
+    /// @notice Claims finalized Lido withdrawal requests and sweeps WETH to the ARM.
+    /// @dev Claims finalized pending requests in FIFO order, wraps the full ETH balance into WETH, and transfers
+    /// all adapter-held WETH to the ARM. `assetsReceived` may include previously donated ETH or WETH.
     /// @param shares Exact amount of shares represented by finalized pending requests to claim.
     /// @return sharesClaimed Amount of shares represented by claimed requests.
     /// @return assetsExpected Expected WETH amount recorded when requests were opened.
-    /// @return assetsReceived Actual WETH amount received and transferred to the ARM.
+    /// @return assetsReceived Total WETH amount swept to the ARM.
     function redeem(uint256 shares)
         external
         onlyARM
@@ -139,7 +140,6 @@ abstract contract AbstractLidoAssetAdapter is Initializable, IAssetAdapter {
         uint256 lastCheckpointIndex = lidoWithdrawalQueue.getLastCheckpointIndex();
         uint256[] memory hintIds = lidoWithdrawalQueue.findCheckpointHints(requestIds, 1, lastCheckpointIndex);
 
-        uint256 wethBefore = weth.balanceOf(address(this));
         lidoWithdrawalQueue.claimWithdrawals(requestIds, hintIds);
 
         uint256 ethBalance = address(this).balance;
@@ -147,7 +147,7 @@ abstract contract AbstractLidoAssetAdapter is Initializable, IAssetAdapter {
             weth.deposit{value: ethBalance}();
         }
 
-        assetsReceived = weth.balanceOf(address(this)) - wethBefore;
+        assetsReceived = weth.balanceOf(address(this));
         IERC20(address(weth)).transfer(arm, assetsReceived);
     }
 

--- a/src/contracts/adapters/EtherFiAssetAdapter.sol
+++ b/src/contracts/adapters/EtherFiAssetAdapter.sol
@@ -101,12 +101,13 @@ contract EtherFiAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
         assetsExpected = shares;
     }
 
-    /// @notice Claims queued Ether.fi withdrawal requests and transfers received WETH to the ARM.
-    /// @dev Claims pending requests in FIFO order and wraps any received ETH into WETH.
+    /// @notice Claims queued Ether.fi withdrawal requests and sweeps WETH to the ARM.
+    /// @dev Claims pending requests in FIFO order, wraps the full ETH balance into WETH, and transfers
+    /// all adapter-held WETH to the ARM. `assetsReceived` may include previously donated ETH or WETH.
     /// @param shares Exact amount of eETH represented by pending requests to claim.
     /// @return sharesClaimed Amount of eETH represented by claimed requests.
     /// @return assetsExpected Expected WETH amount from the claimed requests.
-    /// @return assetsReceived Actual WETH amount received and transferred to the ARM.
+    /// @return assetsReceived Total WETH amount swept to the ARM.
     function redeem(uint256 shares)
         external
         onlyARM
@@ -137,13 +138,12 @@ contract EtherFiAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
         }
         nextPendingIndex = cursor + claimCount;
 
-        uint256 wethBefore = weth.balanceOf(address(this));
         etherfiWithdrawalNFT.batchClaimWithdraw(requestIds);
 
         uint256 ethBalance = address(this).balance;
         if (ethBalance > 0) weth.deposit{value: ethBalance}();
 
-        assetsReceived = weth.balanceOf(address(this)) - wethBefore;
+        assetsReceived = weth.balanceOf(address(this));
         IERC20(address(weth)).transfer(arm, assetsReceived);
     }
 

--- a/src/contracts/adapters/WeETHAssetAdapter.sol
+++ b/src/contracts/adapters/WeETHAssetAdapter.sol
@@ -110,12 +110,13 @@ contract WeETHAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
         sharesRequested = shares;
     }
 
-    /// @notice Claims queued Ether.fi withdrawal requests and transfers received WETH to the ARM.
-    /// @dev Claims pending requests in FIFO order and wraps any received ETH into WETH.
+    /// @notice Claims queued Ether.fi withdrawal requests and sweeps WETH to the ARM.
+    /// @dev Claims pending requests in FIFO order, wraps the full ETH balance into WETH, and transfers
+    /// all adapter-held WETH to the ARM. `assetsReceived` may include previously donated ETH or WETH.
     /// @param shares Exact amount of weETH represented by pending requests to claim.
     /// @return sharesClaimed Amount of weETH represented by claimed requests.
     /// @return assetsExpected Expected WETH amount recorded when requests were opened.
-    /// @return assetsReceived Actual WETH amount received and transferred to the ARM.
+    /// @return assetsReceived Total WETH amount swept to the ARM.
     function redeem(uint256 shares)
         external
         onlyARM
@@ -147,13 +148,12 @@ contract WeETHAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
         }
         nextPendingIndex = cursor + claimCount;
 
-        uint256 wethBefore = weth.balanceOf(address(this));
         etherfiWithdrawalNFT.batchClaimWithdraw(requestIds);
 
         uint256 ethBalance = address(this).balance;
         if (ethBalance > 0) weth.deposit{value: ethBalance}();
 
-        assetsReceived = weth.balanceOf(address(this)) - wethBefore;
+        assetsReceived = weth.balanceOf(address(this));
         IERC20(address(weth)).transfer(arm, assetsReceived);
     }
 

--- a/test/fork/EtherFiARM/RequestWithdraw.t.sol
+++ b/test/fork/EtherFiARM/RequestWithdraw.t.sol
@@ -24,9 +24,22 @@ contract Fork_Concrete_EtherFiARM_RequestWithdraw_Test_ is Fork_Shared_Test {
         vm.prank(0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705);
         etherfiWithdrawalNFT.finalizeRequests(requestId);
 
+        uint256 donatedETH = 0.2 ether;
+        uint256 donatedWETH = 0.3 ether;
+
+        vm.deal(address(etherfiAssetAdapter), donatedETH);
+        deal(address(weth), address(etherfiAssetAdapter), donatedWETH);
+
+        uint256 wethBefore = weth.balanceOf(address(etherfiARM));
+
         // Claim the withdrawal
         vm.prank(operator);
-        etherfiARM.claimBaseAssetRedeem(address(eeth), 1 ether);
+        (,, uint256 assetsReceived) = etherfiARM.claimBaseAssetRedeem(address(eeth), 1 ether);
+
+        assertEq(weth.balanceOf(address(etherfiARM)), wethBefore + assetsReceived, "ARM WETH balance");
+        assertEq(address(etherfiAssetAdapter).balance, 0, "adapter ETH balance");
+        assertEq(weth.balanceOf(address(etherfiAssetAdapter)), 0, "adapter WETH balance");
+        assertGe(assetsReceived, donatedETH + donatedWETH, "donations swept");
     }
 
     function test_WeETH_ConvertToAssets_And_ConvertToShares() public view {
@@ -66,6 +79,12 @@ contract Fork_Concrete_EtherFiARM_RequestWithdraw_Test_ is Fork_Shared_Test {
         vm.prank(0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705);
         etherfiWithdrawalNFT.finalizeRequests(requestId);
 
+        uint256 donatedETH = 0.2 ether;
+        uint256 donatedWETH = 0.3 ether;
+
+        vm.deal(address(weethAssetAdapter), donatedETH);
+        deal(address(weth), address(weethAssetAdapter), donatedWETH);
+
         uint256 wethBefore = weth.balanceOf(address(etherfiARM));
 
         vm.prank(operator);
@@ -75,6 +94,9 @@ contract Fork_Concrete_EtherFiARM_RequestWithdraw_Test_ is Fork_Shared_Test {
         assertEq(sharesClaimed, weethAmount, "shares claimed");
         assertEq(claimAssetsExpected, eethExpected, "claim assets expected");
         assertEq(assetsReceived, weth.balanceOf(address(etherfiARM)) - wethBefore, "assets received");
+        assertEq(address(weethAssetAdapter).balance, 0, "adapter ETH balance");
+        assertEq(weth.balanceOf(address(weethAssetAdapter)), 0, "adapter WETH balance");
+        assertGe(assetsReceived, donatedETH + donatedWETH, "donations swept");
 
         (,,,,, pendingRedeemAssets,,) = etherfiARM.baseAssetConfigs(address(weeth));
         assertEq(pendingRedeemAssets, 0, "pending redeem assets after claim");

--- a/test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol
+++ b/test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol
@@ -76,6 +76,28 @@ contract Fork_Concrete_LidoARM_ClaimLidoWithdrawals_Test_ is Fork_Shared_Test_ {
         assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + DEFAULT_AMOUNT);
     }
 
+    function test_ClaimLidoWithdrawals_SweepsDonatedETHAndWETH()
+        public
+        asOperator
+        requestLidoWithdrawalsOnLidoARM(amounts1)
+        mockFunctionClaimWithdrawOnLidoARM(DEFAULT_AMOUNT)
+    {
+        uint256 donatedETH = 0.2 ether;
+        uint256 donatedWETH = 0.3 ether;
+
+        vm.deal(stethAdapter, donatedETH);
+        deal(address(weth), stethAdapter, donatedWETH);
+
+        uint256 balanceBefore = weth.balanceOf(address(lidoARM));
+
+        (,, uint256 assetsReceived) = lidoARM.claimBaseAssetRedeem(address(steth), DEFAULT_AMOUNT);
+
+        assertEq(assetsReceived, DEFAULT_AMOUNT + donatedETH + donatedWETH, "assets received");
+        assertEq(weth.balanceOf(address(lidoARM)), balanceBefore + assetsReceived, "ARM WETH balance");
+        assertEq(address(stethAdapter).balance, 0, "adapter ETH balance");
+        assertEq(weth.balanceOf(stethAdapter), 0, "adapter WETH balance");
+    }
+
     function test_ClaimLidoWithdrawals_MultiRequest()
         public
         asOperator

--- a/test/fork/utils/MockCall.sol
+++ b/test/fork/utils/MockCall.sol
@@ -98,6 +98,6 @@ contract ETHSender {
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     function sendETH(address target) external {
-        vm.deal(target, address(this).balance);
+        vm.deal(target, target.balance + address(this).balance);
     }
 }


### PR DESCRIPTION
## Summary

- Sweep full adapter-held WETH to the ARM during Lido, eETH, and weETH claims
- Wrap the adapter’s full native ETH balance before sweeping WETH
- Document that `assetsReceived` may include previously donated ETH or WETH
- Add fork coverage for donated ETH/WETH recovery during claim

## Testing

- `forge test --match-path test/fork/LidoARM/ClaimStETHWithdrawalForWETH.t.sol`
- `forge test --match-path test/fork/EtherFiARM/RequestWithdraw.t.sol`