### PR TITLE
Fix redeem claimability for non-liquid NAV gains

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -60,9 +60,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     uint256 internal _deprecatedTraderate1;
     uint256 internal _deprecatedCrossPrice;
 
-    /// @dev Legacy asset-denominated queue counters retained for storage layout compatibility.
-    uint128 internal _deprecatedWithdrawsQueued;
-    uint128 internal _deprecatedWithdrawsClaimed;
+    /// @notice Cumulative request-time liquidity asset caps queued for redemption.
+    uint128 public withdrawsQueuedAssets;
+    /// @notice Cumulative request-time liquidity asset caps claimed and released.
+    uint128 public withdrawsClaimedAssets;
     /// @notice Index of the next LP withdrawal request.
     uint256 public nextWithdrawalIndex;
 
@@ -140,7 +141,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @notice First withdrawal request id that uses the new share-escrow queue semantics.
     uint256 public legacyWithdrawalRequestCount;
 
-    uint256[31] private _gap;
+    /// @notice Cumulative request-time asset cap including a withdrawal request.
+    mapping(uint256 requestId => uint128 queuedAssets) public withdrawalRequestQueuedAssets;
+
+    uint256[30] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Errors
@@ -793,6 +797,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         // Cumulative shares queued including this request, used for the FIFO gate at claim.
         uint128 queued = SafeCast.toUint128(withdrawsQueuedShares + shares);
         withdrawsQueuedShares = queued;
+        // Cumulative request-time liquidity caps queued including this request. Build from the current
+        // reservation so post-upgrade requests stay behind any already-outstanding withdrawal caps.
+        uint128 queuedAssets = SafeCast.toUint128(withdrawsClaimedAssets + reservedWithdrawLiquidity + assets);
+        withdrawsQueuedAssets = queuedAssets;
         // Reserve the request-time maximum liquidity payout.
         reservedWithdrawLiquidity += assets;
 
@@ -805,6 +813,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
             queued: queued,
             shares: SafeCast.toUint128(shares)
         });
+        withdrawalRequestQueuedAssets[requestId] = queuedAssets;
 
         // Escrow the redeemer's shares so they stay in totalSupply() and share losses/gains pro-rata.
         _transfer(msg.sender, address(this), shares);
@@ -823,7 +832,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         if (legacyRequest) {
             if (request.queued > _legacyClaimable()) revert QueuePendingLiquidity();
         } else {
-            if (request.queued > claimable()) revert QueuePendingLiquidity();
+            if (!_requestClaimable(requestId, request)) revert QueuePendingLiquidity();
         }
         if (request.withdrawer != msg.sender && msg.sender != operator) revert NotRequesterOrOperator();
         if (request.claimed) revert AlreadyClaimed();
@@ -831,7 +840,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         if (legacyRequest) {
             assets = request.assets;
             // Legacy requests used asset-denominated cumulative queue accounting.
-            _deprecatedWithdrawsClaimed += SafeCast.toUint128(assets);
+            withdrawsClaimedAssets += SafeCast.toUint128(assets);
         } else {
             // In the scenario where the ARM has made a loss after the redeem request, the asset value of
             // the redeemed shares at the time of the claim is used.
@@ -843,6 +852,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
 
             // Release the full request-time reservation, even when a loss-adjusted payout is lower.
             reservedWithdrawLiquidity -= request.assets;
+            // Cumulative claimed request-time caps, used by the asset-denominated FIFO gate.
+            withdrawsClaimedAssets += request.assets;
             // Cumulative claimed amount in shares, used by the FIFO gate above.
             withdrawsClaimedShares += request.shares;
 
@@ -878,10 +889,41 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     ///                 Accounting
     ////////////////////////////////////////////////////
 
-    /// @notice Cumulative share queue frontier currently backed by claimable liquidity.
-    /// @return claimableShares Requests with `queued <= claimableShares` can be claimed once their delay has elapsed.
-    function claimable() public view returns (uint256 claimableShares) {
-        uint256 claimableLiquidity = IERC20(liquidityAsset).balanceOf(address(this));
+    /// @notice Cumulative asset-cap and share queue frontiers currently backed by claimable liquidity.
+    /// @return claimableAssetCaps Requests with `queuedAssets <= claimableAssetCaps` can be claimed by asset cap.
+    /// @return claimableShares Requests with `queued <= claimableShares` can be claimed by current share value.
+    function claimable() public view returns (uint256 claimableAssetCaps, uint256 claimableShares) {
+        uint256 claimableLiquidity = _claimableLiquidity();
+        claimableAssetCaps = withdrawsClaimedAssets + claimableLiquidity;
+        claimableShares = withdrawsClaimedShares + convertToShares(claimableLiquidity);
+    }
+
+    /// @notice True if an LP withdrawal request is mature, unclaimed, and backed by claimable liquidity.
+    /// @param requestId LP withdrawal request id.
+    /// @return canClaim True when the request can be claimed by the withdrawer or operator.
+    function isClaimable(uint256 requestId) public view returns (bool canClaim) {
+        WithdrawalRequest memory request = withdrawalRequests[requestId];
+        if (request.claimTimestamp > block.timestamp || request.claimed) return false;
+
+        bool legacyRequest = requestId < legacyWithdrawalRequestCount;
+        if (legacyRequest) return request.queued <= _legacyClaimable();
+
+        return _requestClaimable(requestId, request);
+    }
+
+    /// @dev True if a non-legacy request is liquid-funded by either capped assets or current share value.
+    function _requestClaimable(uint256 requestId, WithdrawalRequest memory request) internal view returns (bool) {
+        uint256 claimableLiquidity = _claimableLiquidity();
+
+        uint256 queuedAssets = withdrawalRequestQueuedAssets[requestId];
+        if (queuedAssets != 0 && queuedAssets <= withdrawsClaimedAssets + claimableLiquidity) return true;
+
+        return request.queued <= withdrawsClaimedShares + convertToShares(claimableLiquidity);
+    }
+
+    /// @dev Liquidity assets currently available to settle LP withdrawal claims.
+    function _claimableLiquidity() internal view returns (uint256 claimableLiquidity) {
+        claimableLiquidity = IERC20(liquidityAsset).balanceOf(address(this));
 
         // If there is an active lending market, add to the claimable amount.
         address activeMarketMem = activeMarket;
@@ -890,13 +932,11 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
             // maxWithdraw may return less than convertToAssets.
             claimableLiquidity += IERC4626(activeMarketMem).maxWithdraw(address(this));
         }
-
-        claimableShares = withdrawsClaimedShares + convertToShares(claimableLiquidity);
     }
 
     /// @dev Legacy asset-denominated queue frontier for pre-upgrade withdrawal requests.
     function _legacyClaimable() internal view returns (uint256 claimableAmount) {
-        claimableAmount = _deprecatedWithdrawsClaimed + IERC20(liquidityAsset).balanceOf(address(this));
+        claimableAmount = withdrawsClaimedAssets + IERC20(liquidityAsset).balanceOf(address(this));
 
         address activeMarketMem = activeMarket;
         if (activeMarketMem != address(0)) {

--- a/test/fork/LidoARM/ClaimRedeem.t.sol
+++ b/test/fork/LidoARM/ClaimRedeem.t.sol
@@ -133,7 +133,8 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         if (ac) assertEq(capManager.liquidityProviderCaps(address(this)), 0);
         assertEqQueueMetadata(DEFAULT_AMOUNT, 0, 1);
         assertEqUserRequest(0, address(this), false, block.timestamp, DEFAULT_AMOUNT, DEFAULT_AMOUNT, DEFAULT_AMOUNT);
-        assertEq(lidoARM.claimable(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
+        (, uint256 claimableSharesBefore) = lidoARM.claimable();
+        assertEq(claimableSharesBefore, MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
 
         // Expected events
         vm.expectEmit({emitter: address(weth)});
@@ -156,7 +157,8 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEqQueueMetadata(0, DEFAULT_AMOUNT, 1);
         assertEqUserRequest(0, address(this), true, block.timestamp, DEFAULT_AMOUNT, DEFAULT_AMOUNT, DEFAULT_AMOUNT);
         assertEq(assets, DEFAULT_AMOUNT);
-        assertEq(lidoARM.claimable(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
+        (, uint256 claimableSharesAfter) = lidoARM.claimable();
+        assertEq(claimableSharesAfter, MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
     }
 
     function test_ClaimRequest_JustEnoughLiquidity_()
@@ -230,7 +232,8 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         assertEqUserRequest(
             1, address(this), false, block.timestamp + delay, DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT, DEFAULT_AMOUNT / 2
         );
-        assertEq(lidoARM.claimable(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
+        (, uint256 claimableSharesBefore) = lidoARM.claimable();
+        assertEq(claimableSharesBefore, MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
 
         // Expected events
         vm.expectEmit({emitter: address(weth)});
@@ -259,7 +262,8 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
             1, address(this), true, block.timestamp, DEFAULT_AMOUNT / 2, DEFAULT_AMOUNT, DEFAULT_AMOUNT / 2
         );
         assertEq(assets, DEFAULT_AMOUNT / 2);
-        assertEq(lidoARM.claimable(), MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
+        (, uint256 claimableSharesAfter) = lidoARM.claimable();
+        assertEq(claimableSharesAfter, MIN_TOTAL_SUPPLY + DEFAULT_AMOUNT);
     }
 
     function test_ClaimRequest_AfterSlashing()

--- a/test/fork/OriginARM/TotalAsset.sol
+++ b/test/fork/OriginARM/TotalAsset.sol
@@ -20,7 +20,7 @@ contract Fork_Concrete_OriginARM_TotalAsset_Test_ is Fork_Shared_Test {
         allocate
     {
         uint256 totalAsset = originARM.totalAssets();
-        uint256 claimableBefore = originARM.claimable();
+        (, uint256 claimableBefore) = originARM.claimable();
         _marketUtilizedAt(1e18);
 
         ISilo.UtilizationData memory utilizationAfter = silo.utilizationData();
@@ -34,6 +34,7 @@ contract Fork_Concrete_OriginARM_TotalAsset_Test_ is Fork_Shared_Test {
         assertEq(market.maxWithdraw(address(originARM)), 0, "Max withdraw should be 0");
         assertEq(originARM.totalAssets(), totalAsset, "Total asset should be the same");
         assertApproxEqAbs(claimableBefore, totalAsset, 1, "Claimable before should be the same as total asset");
-        assertEq(originARM.claimable(), 0, "Claimable after should be 0 as 100% allocated and 100% borrowed");
+        (, uint256 claimableAfter) = originARM.claimable();
+        assertEq(claimableAfter, 0, "Claimable after should be 0 as 100% allocated and 100% borrowed");
     }
 }

--- a/test/invariants/EthenaARM/TargetFunctions.sol
+++ b/test/invariants/EthenaARM/TargetFunctions.sol
@@ -151,7 +151,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         address user;
         uint256 requestId;
         uint256 claimTimestamp;
-        uint256 claimable = arm.claimable();
+        (, uint256 claimable) = arm.claimable();
         uint256 availableLiquidity = usde.balanceOf(address(arm));
         address market = arm.activeMarket();
         if (market != address(0)) {

--- a/test/invariants/LidoARM/TargetFunction.sol
+++ b/test/invariants/LidoARM/TargetFunction.sol
@@ -163,7 +163,8 @@ abstract contract TargetFunction is Properties {
         (,,, uint128 requestAssets, uint128 queued, uint128 shares) = lidoARM.withdrawalRequests(requestId);
         (,, uint40 claimTimestamp,,,) = lidoARM.withdrawalRequests(requestId);
         vm.assume(block.timestamp + lidoARM.claimDelay() >= claimTimestamp);
-        vm.assume(lidoARM.claimable() >= queued);
+        (, uint256 claimableShares) = lidoARM.claimable();
+        vm.assume(claimableShares >= queued);
 
         // Timejump to request deadline
         skip(lidoARM.claimDelay());

--- a/test/invariants/OriginARM/FuzzerFoundry.sol
+++ b/test/invariants/OriginARM/FuzzerFoundry.sol
@@ -56,6 +56,9 @@ contract FuzzerFoundry_OriginARM is TargetFunction {
         assertTrue(property_lp_J(), "INVARIANT J");
         assertTrue(property_lp_K(), "INVARIANT K");
         assertTrue(property_lp_L(), "INVARIANT L");
+        assertTrue(property_lp_M(), "INVARIANT M");
+        assertTrue(property_lp_N(), "INVARIANT N");
+        assertTrue(property_lp_O(), "INVARIANT O");
     }
 
     function afterInvariant() public {

--- a/test/invariants/OriginARM/Helpers.sol
+++ b/test/invariants/OriginARM/Helpers.sol
@@ -125,7 +125,7 @@ abstract contract Helpers is Setup, Logger {
         // Find a random element on the list with a condition, using Fisher-Yates shuffle
         uint256 len = lps.length;
         uint256[] memory indices = new uint256[](len);
-        uint256 claimable = originARM.claimable();
+        (, uint256 claimable) = originARM.claimable();
 
         // 1. Fill the indices array with 0 to n-1
         for (uint256 i; i < len; i++) {

--- a/test/invariants/OriginARM/Properties.sol
+++ b/test/invariants/OriginARM/Properties.sol
@@ -35,6 +35,9 @@ abstract contract Properties is Setup, Helpers {
     // [x] Invariant J: withdrawsClaimedShares == ∑claimed request.shares
     // [x] Invariant K: ARM escrowed shares == withdrawsQueuedShares - withdrawsClaimedShares
     // [x] Invariant L: ∑feesCollected == feeCollector.balance
+    // [x] Invariant M: withdrawsQueuedAssets >= withdrawsClaimedAssets
+    // [x] Invariant N: withdrawsQueuedAssets == ∑request.assets
+    // [x] Invariant O: withdrawsClaimedAssets == ∑claimed request.assets
     // * invariants tested directly in the handlers.
 
     using MathComparisons for uint256;
@@ -110,6 +113,18 @@ abstract contract Properties is Setup, Helpers {
         return ws.balanceOf(feeCollector) == sum_feesCollected;
     }
 
+    function property_lp_M() public view returns (bool) {
+        return originARM.withdrawsQueuedAssets() >= originARM.withdrawsClaimedAssets();
+    }
+
+    function property_lp_N() public view returns (bool) {
+        return originARM.withdrawsQueuedAssets() == sumOfRequestRedeemAmount();
+    }
+
+    function property_lp_O() public view returns (bool) {
+        return originARM.withdrawsClaimedAssets() == sumOfClaimedRequestRedeemAmount();
+    }
+
     function sumOfShares() public view returns (uint256 usersShares) {
         for (uint256 i; i < lps.length; i++) {
             usersShares += originARM.balanceOf(lps[i]);
@@ -123,6 +138,22 @@ abstract contract Properties is Setup, Helpers {
         for (uint256 i; i < len; i++) {
             (, bool claimed,, uint128 amount,,) = originARM.withdrawalRequests(i);
             if (!claimed) sum += amount;
+        }
+    }
+
+    function sumOfRequestRedeemAmount() public view returns (uint256 sum) {
+        uint256 len = originARM.nextWithdrawalIndex();
+        for (uint256 i; i < len; i++) {
+            (,,, uint128 amount,,) = originARM.withdrawalRequests(i);
+            sum += amount;
+        }
+    }
+
+    function sumOfClaimedRequestRedeemAmount() public view returns (uint256 sum) {
+        uint256 len = originARM.nextWithdrawalIndex();
+        for (uint256 i; i < len; i++) {
+            (, bool claimed,, uint128 amount,,) = originARM.withdrawalRequests(i);
+            if (claimed) sum += amount;
         }
     }
 }

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -23,6 +23,7 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
     }
 
     function test_RevertWhen_ClaimRedeem_Because_DelayNotMet() public requestRedeemAll(alice) {
+        assertFalse(originARM.isClaimable(0), "not mature");
         vm.expectRevert(bytes4(keccak256("ClaimDelayNotMet()")));
         originARM.claimRedeem(0);
     }
@@ -35,6 +36,61 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
     {
         vm.expectRevert(bytes4(keccak256("QueuePendingLiquidity()")));
         originARM.claimRedeem(0);
+    }
+
+    function test_ClaimRedeem_WhenSupportedBaseAssetDonationReducesShareFrontier()
+        public
+        requestRedeemAll(alice)
+        timejump(CLAIM_DELAY)
+    {
+        deal(address(oeth), address(originARM), MIN_TOTAL_SUPPLY + 1e7);
+
+        (uint256 claimableAssets, uint256 claimableShares) = originARM.claimable();
+        assertLt(claimableShares, DEFAULT_AMOUNT, "share frontier");
+        assertEq(claimableAssets, DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "asset frontier");
+        assertTrue(originARM.isClaimable(0), "is claimable");
+
+        uint256 aliceBalanceBefore = weth.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 assets = originARM.claimRedeem(0);
+
+        assertEq(assets, DEFAULT_AMOUNT, "claimed assets");
+        assertEq(weth.balanceOf(alice), aliceBalanceBefore + DEFAULT_AMOUNT, "alice WETH");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.withdrawsClaimedAssets(), DEFAULT_AMOUNT, "claimed asset caps");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "claimed shares");
+    }
+
+    function test_ClaimRedeem_WhenDiscountedBaseAssetBuyReducesShareFrontier()
+        public
+        requestRedeemAll(alice)
+        timejump(CLAIM_DELAY)
+    {
+        address swapper = makeAddr("swapper");
+        deal(address(oeth), swapper, 1 ether);
+
+        vm.startPrank(swapper);
+        oeth.approve(address(originARM), type(uint256).max);
+        originARM.swapTokensForExactTokens(oeth, weth, MIN_TOTAL_SUPPLY, type(uint256).max, swapper);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(originARM)), DEFAULT_AMOUNT, "liquid WETH");
+        (uint256 claimableAssets, uint256 claimableShares) = originARM.claimable();
+        assertLt(claimableShares, DEFAULT_AMOUNT, "share frontier");
+        assertEq(claimableAssets, DEFAULT_AMOUNT, "asset frontier");
+        assertTrue(originARM.isClaimable(0), "is claimable");
+
+        uint256 aliceBalanceBefore = weth.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 assets = originARM.claimRedeem(0);
+
+        assertEq(assets, DEFAULT_AMOUNT, "claimed assets");
+        assertEq(weth.balanceOf(alice), aliceBalanceBefore + DEFAULT_AMOUNT, "alice WETH");
+        assertEq(originARM.reservedWithdrawLiquidity(), 0, "reserved liquidity");
+        assertEq(originARM.withdrawsClaimedAssets(), DEFAULT_AMOUNT, "claimed asset caps");
+        assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "claimed shares");
     }
 
     function test_RevertWhen_ClaimRedeem_Because_NotWithdrawer()
@@ -62,7 +118,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), aliceBalanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
         assertEq(weth.balanceOf(operator), operatorBalanceBefore, "Operator should not receive WETH");
-        assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
+        (, uint256 claimableShares) = originARM.claimable();
+        assertEq(claimableShares, DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }
 
     function test_ClaimRedeem_WhenLegacyRequestClaimedByWithdrawer() public timejump(CLAIM_DELAY) {
@@ -146,6 +203,7 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         // Alice claims her redeem
         vm.prank(alice);
         originARM.claimRedeem(0);
+        assertFalse(originARM.isClaimable(0), "already claimed");
 
         // Attempt to claim again
         vm.prank(alice);
@@ -167,7 +225,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "Reserved liquidity should be released");
         assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
-        assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
+        (, uint256 claimableShares) = originARM.claimable();
+        assertEq(claimableShares, DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }
 
     function test_ClaimRedeem_WithActiveMarket_EnoughLiquidity()
@@ -191,7 +250,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "Reserved liquidity should be released");
         assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
-        assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
+        (, uint256 claimableShares) = originARM.claimable();
+        assertEq(claimableShares, DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }
 
     function test_ClaimRedeem_WithActiveMarket_NotEnoughLiquidity()
@@ -215,7 +275,8 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         assertEq(originARM.reservedWithdrawLiquidity(), 0, "Reserved liquidity should be released");
         assertEq(originARM.withdrawsClaimedShares(), DEFAULT_AMOUNT, "Claimed shares should be DEFAULT_AMOUNT");
         assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should receive her WETH");
-        assertEq(originARM.claimable(), DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
+        (, uint256 claimableShares) = originARM.claimable();
+        assertEq(claimableShares, DEFAULT_AMOUNT + MIN_TOTAL_SUPPLY, "Claimable should be updated");
     }
 
     function _writeLegacyWithdrawQueue(uint128 legacyQueued, uint128 legacyClaimed) internal {

--- a/test/unit/OriginARM/TotalAssets.sol
+++ b/test/unit/OriginARM/TotalAssets.sol
@@ -135,7 +135,8 @@ contract Unit_Concrete_OriginARM_TotalAssets_Test_ is Unit_Shared_Test {
 
         assertEq(originARM.totalAssets(), totalAssetsBefore, "total assets should use convertToAssets");
         assertEq(originARM.convertToAssets(1 ether), assetsPerShareBefore, "asset per share should be unchanged");
-        assertEq(originARM.claimable(), 0, "claimable should still reflect liquidity constraints");
+        (, uint256 claimableShares) = originARM.claimable();
+        assertEq(claimableShares, 0, "claimable should still reflect liquidity constraints");
         assertEq(market.previewRedeem(marketShares), 0, "previewRedeem should be constrained");
         assertEq(market.convertToAssets(marketShares), marketValue, "convertToAssets should still show economic value");
     }


### PR DESCRIPTION
## Summary

- Track cumulative request-time asset caps alongside the share-based redeem queue
- Allow non-legacy redeem claims when either the asset-cap frontier or share frontier is funded
- Return both asset-cap and share frontiers from `claimable()`
- Add `isClaimable(requestId)` for the actual claimability check
- Add regressions for supported base-asset donations and discounted base-asset buys reducing the share frontier
- Add invariants for restored asset-cap queue counters

## Motivation

The share-based FIFO gate can move backward when non-liquid NAV increases without a matching increase in liquid WETH or active-market `maxWithdraw`. This can make a matured, fully funded request unclaimable even though its payout remains capped at the request-time asset amount.

The hybrid gate preserves the existing share-based loss-socialization path while allowing capped withdrawals to proceed when their request-time asset liabilities are liquid-funded.

### Example

Assume the ARM has:

- `totalSupply = 100 shares`
- `totalAssets = 100 WETH`
- `liquid WETH = 100`

Alice requests to redeem `90 shares`.

At request time:

- `request.assets = 90 WETH`
- `request.queued = 90 shares`
- `reservedWithdrawLiquidity = 90 WETH`

The request is fully liquid-funded because the ARM has `100 WETH`.

Before this fix, the FIFO gate used only the share frontier:

```solidity
claimableShares = liquidWETH * totalSupply / totalAssets;
claimableShares = 100 * 100 / 100;
claimableShares = 100 shares;
```

So Alice is claimable:

```text
90 <= 100
```

Now suppose the ARM buys base assets at a discount using only unreserved liquidity.

It spends `10 WETH` and receives base assets valued at `10.1 WETH`.

After the trade:

- `liquid WETH = 90`
- `base assets = 10.1 WETH value`
- `totalAssets = 100.1 WETH`
- `totalSupply = 100 shares`

The old share frontier becomes:

```solidity
claimableShares = 90 * 100 / 100.1;
claimableShares = 89.91 shares;
```

Alice’s request is now blocked:

```text
90 <= 89.91 // false
```

But Alice’s capped payout is still only `90 WETH`:

```solidity
assetsAtClaim = 90 shares * 100.1 / 100; // 90.09 WETH
payout = min(request.assets, assetsAtClaim);
payout = min(90, 90.09);
payout = 90 WETH;
```

The ARM has exactly `90 WETH`, enough to pay Alice, but the share-based gate still reverts.

With this fix, the claim can pass through the asset-cap frontier:

```solidity
claimableAssetCaps = claimedAssets + liquidWETH;
claimableAssetCaps = 0 + 90;
claimableAssetCaps = 90 WETH;
```

Alice’s cumulative asset-cap queue position is:

```text
requestQueuedAssets = 90 WETH
```

So the claim succeeds:

```text
90 <= 90 // true
```

Alice can claim her capped `90 WETH` payout, while the share frontier remains available for NAV-loss cases.

## Tests

- `forge test --match-path test/unit/OriginARM/ClaimRedeem.sol`
- `forge test --match-path 'test/unit/OriginARM/**/*.sol'`
- `forge test --match-path 'test/invariants/OriginARM/**/*.sol'`