### PR TITLE
Document share-based redeem claimability caveat

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -790,7 +790,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         // Store the next withdrawal request id.
         nextWithdrawalIndex = requestId + 1;
 
-        // Cumulative shares queued including this request, used for the FIFO gate at claim.
+        // Cumulative shares queued including this request, used for the FIFO gate at claim. The
+        // request-time asset cap is tracked separately in `assets` and is not the claimability unit.
         uint128 queued = SafeCast.toUint128(withdrawsQueuedShares + shares);
         withdrawsQueuedShares = queued;
         // Reserve the request-time maximum liquidity payout.
@@ -812,7 +813,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     }
 
     /// @notice Claim liquidity assets from a matured LP withdrawal request.
-    /// @dev If assets per share decreased after request time, the claim uses the lower claim-time value.
+    /// @dev New requests use a share-denominated FIFO gate: `request.queued <= claimable()`.
+    /// If assets per share decreased after request time, the claim uses the lower claim-time value.
+    /// If non-liquid NAV increases without a matching increase in claimable liquidity, `claimable()` can
+    /// decrease in share terms even when the request-time asset cap is fully backed by liquid assets.
+    /// For example, a fully funded 90-share request can become pending if 90 liquid assets are valued
+    /// against 100.1 total assets and 100 total shares: `90 * 100 / 100.1 = 89.91` claimable shares.
     /// @param requestId LP withdrawal request id to claim.
     /// @return assets Liquidity assets transferred to the requester.
     function claimRedeem(uint256 requestId) external whenNotPaused nonReentrant returns (uint256 assets) {
@@ -879,6 +885,12 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     ////////////////////////////////////////////////////
 
     /// @notice Cumulative share queue frontier currently backed by claimable liquidity.
+    /// @dev Converts on-hand liquidity plus active-market `maxWithdraw` into shares at the current
+    /// `totalAssets()` valuation. Because this is share-denominated, non-liquid NAV gains from supported
+    /// base-asset donations, rebases, discounted buys, adapter queues, or active-market appreciation can
+    /// reduce the returned share frontier unless claimable liquidity increases proportionally. This can
+    /// make a request remain pending even when its request-time asset cap is fully backed by liquid assets.
+    /// Legacy requests use `_legacyClaimable()`, which is asset-denominated.
     /// @return claimableShares Requests with `queued <= claimableShares` can be claimed once their delay has elapsed.
     function claimable() public view returns (uint256 claimableShares) {
         uint256 claimableLiquidity = IERC20(liquidityAsset).balanceOf(address(this));

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -37,6 +37,31 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         originARM.claimRedeem(0);
     }
 
+    function test_RevertWhen_ClaimRedeem_Because_AssetsPerShareIncreaseReducesClaimableShares()
+        public
+        requestRedeemAll(alice)
+        timejump(CLAIM_DELAY)
+    {
+        (, bool claimed,, uint128 requestAssets, uint128 queuedShares, uint128 requestShares) =
+            originARM.withdrawalRequests(0);
+        assertFalse(claimed, "claimed");
+        assertEq(requestAssets, DEFAULT_AMOUNT, "request assets");
+        assertEq(queuedShares, DEFAULT_AMOUNT, "queued shares");
+        assertEq(requestShares, DEFAULT_AMOUNT, "request shares");
+        assertGe(weth.balanceOf(address(originARM)), requestAssets, "request cap is liquid funded");
+
+        uint256 assetsPerShareBefore = originARM.convertToAssets(1 ether);
+        deal(address(oeth), address(originARM), MIN_TOTAL_SUPPLY + 1e7);
+
+        assertGt(originARM.convertToAssets(1 ether), assetsPerShareBefore, "assets per share increased");
+        assertGe(weth.balanceOf(address(originARM)), requestAssets, "request cap remains liquid funded");
+        assertGt(originARM.convertToAssets(requestShares), requestAssets, "claim remains capped at request assets");
+        assertLt(originARM.claimable(), queuedShares, "claimable shares moved below request");
+
+        vm.expectRevert(bytes4(keccak256("QueuePendingLiquidity()")));
+        originARM.claimRedeem(0);
+    }
+
     function test_RevertWhen_ClaimRedeem_Because_NotWithdrawer()
         public
         requestRedeemAll(alice)


### PR DESCRIPTION
## Summary

- Update NatSpec/comments around LP redeem claimability to clarify that new requests use a share-denominated FIFO gate
- Document that `request.assets` is the request-time payout cap, not the claimability unit
- Highlight that non-liquid NAV gains can reduce `claimable()` in share terms even when the request cap is liquid-funded
- Add a unit test demonstrating claim failure after assets per share increases

## Motivation

The current share-based queue can make a matured redeem remain pending when assets per share increases without proportional claimable liquidity. In that case, the request may still be fully funded at its request-time asset cap, but `claimable()` converts liquid assets into fewer shares and the FIFO gate reverts with `QueuePendingLiquidity()`.

This PR documents that behavior without changing claim logic.

## Example

Assume the ARM has:

- `totalSupply = 100 shares`
- `totalAssets = 100 WETH`
- `liquid WETH = 100`

Alice requests to redeem `90 shares`.

At request time:

- `request.assets = 90 WETH`
- `request.queued = 90 shares`
- `reservedWithdrawLiquidity = 90 WETH`

The request is fully liquid-funded because the ARM has enough WETH to pay the capped request amount.

The share-based frontier is initially:

```text
claimableShares = liquidWETH * totalSupply / totalAssets
claimableShares = 100 * 100 / 100
claimableShares = 100 shares
```

So Alice is claimable:

```text
90 <= 100
```

Now suppose non-liquid NAV increases without adding liquid WETH. For example, the ARM receives or accrues `10.1 WETH` worth of supported base assets while `10 WETH` of excess liquidity is no longer liquid.

Afterward:

- `liquid WETH = 90`
- `supported base assets = 10.1 WETH value`
- `totalAssets = 100.1 WETH`
- `totalSupply = 100 shares`

The share-based frontier becomes:

```text
claimableShares = 90 * 100 / 100.1
claimableShares = 89.91 shares
```

Alice’s request is now blocked:

```text
90 <= 89.91 // false
```

But Alice’s payout is still capped at the request-time amount:

```text
assetsAtClaim = 90 shares * 100.1 / 100
assetsAtClaim = 90.09 WETH

payout = min(request.assets, assetsAtClaim)
payout = min(90, 90.09)
payout = 90 WETH
```

The ARM has exactly `90 WETH`, enough to pay Alice’s capped redeem, but the share-denominated FIFO gate still reverts with `QueuePendingLiquidity()`.

## Tests

- `forge test --match-path test/unit/OriginARM/ClaimRedeem.sol`
- `forge test --match-path 'test/unit/OriginARM/**/*.sol'`