### PR TITLE
Fix legacy withdraw queue migration initializer version

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -1215,7 +1215,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @notice Validate legacy queue compatibility during the Model A upgrade.
     /// @dev The legacy packed asset queue counter slot is preserved so old pending withdrawal
     /// requests can still be claimed after the upgrade.
-    function migrateLegacyWithdrawQueue() external onlyOwner reinitializer(2) {
+    function migrateLegacyWithdrawQueue() external onlyOwner reinitializer(3) {
         _checkNoLegacyWithdrawQueue();
 
         if (withdrawsQueuedShares != 0 || withdrawsClaimedShares != 0 || reservedWithdrawLiquidity != 0) {

--- a/test/deploy/EthenaUpgradeGuards.t.sol
+++ b/test/deploy/EthenaUpgradeGuards.t.sol
@@ -17,6 +17,8 @@ contract ExposedUpgradeEthenaARMScript is $028_UpgradeEthenaARMScript {
 }
 
 contract EthenaUpgradeGuardsTest is Test {
+    bytes32 internal constant INITIALIZABLE_STORAGE_SLOT =
+        0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
     uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
     uint256 internal constant ETHENA_LEGACY_COOLDOWN_AMOUNT_SLOT = 100;
@@ -45,6 +47,16 @@ contract EthenaUpgradeGuardsTest is Test {
         assertEq(EthenaARM(address(proxy)).reservedWithdrawLiquidity(), 0);
         assertEq(EthenaARM(address(proxy)).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
+    }
+
+    function test_UpgradeToAndCallMigratesWhenInitializerVersionTwoAlreadyUsed() external {
+        (Proxy proxy, EthenaARM newImpl) = _deployInitializedEthenaARMProxy();
+        vm.store(address(proxy), INITIALIZABLE_STORAGE_SLOT, bytes32(uint256(2)));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
+
+        proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
+
+        assertEq(EthenaARM(address(proxy)).legacyWithdrawalRequestCount(), 3);
     }
 
     function test_RevertWhen_UpgradeToAndCall_LegacyEthenaCooldownPending() external {

--- a/test/deploy/EtherFiUpgradeGuards.t.sol
+++ b/test/deploy/EtherFiUpgradeGuards.t.sol
@@ -17,6 +17,8 @@ contract ExposedUpgradeEtherFiARMSwapFeeScript is $029_UpgradeEtherFiARMSwapFeeS
 }
 
 contract EtherFiUpgradeGuardsTest is Test {
+    bytes32 internal constant INITIALIZABLE_STORAGE_SLOT =
+        0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
     uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
     uint256 internal constant ETHERFI_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT = 100;
@@ -45,6 +47,16 @@ contract EtherFiUpgradeGuardsTest is Test {
         assertEq(EtherFiARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
         assertEq(EtherFiARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
+    }
+
+    function test_UpgradeToAndCallMigratesWhenInitializerVersionTwoAlreadyUsed() external {
+        (Proxy proxy, EtherFiARM newImpl) = _deployInitializedEtherFiARMProxy();
+        vm.store(address(proxy), INITIALIZABLE_STORAGE_SLOT, bytes32(uint256(2)));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
+
+        proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
+
+        assertEq(EtherFiARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
     }
 
     function test_RevertWhen_UpgradeToAndCall_LegacyEtherFiWithdrawalsPending() external {

--- a/test/deploy/LidoUpgradeGuards.t.sol
+++ b/test/deploy/LidoUpgradeGuards.t.sol
@@ -17,6 +17,8 @@ contract ExposedUpgradeLidoARMSwapFeeScript is $030_UpgradeLidoARMSwapFeeScript 
 }
 
 contract LidoUpgradeGuardsTest is Test {
+    bytes32 internal constant INITIALIZABLE_STORAGE_SLOT =
+        0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
     uint256 internal constant LEGACY_PACKED_WITHDRAW_QUEUE_SLOT = 53;
     uint256 internal constant NEXT_WITHDRAWAL_INDEX_SLOT = 54;
     uint256 internal constant LIDO_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT = 100;
@@ -45,6 +47,16 @@ contract LidoUpgradeGuardsTest is Test {
         assertEq(LidoARM(payable(address(proxy))).reservedWithdrawLiquidity(), 0);
         assertEq(LidoARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
         assertEq(uint256(vm.load(address(proxy), bytes32(LEGACY_PACKED_WITHDRAW_QUEUE_SLOT))), packedLegacyQueue);
+    }
+
+    function test_UpgradeToAndCallMigratesWhenInitializerVersionTwoAlreadyUsed() external {
+        (Proxy proxy, LidoARM newImpl) = _deployInitializedLidoARMProxy();
+        vm.store(address(proxy), INITIALIZABLE_STORAGE_SLOT, bytes32(uint256(2)));
+        vm.store(address(proxy), bytes32(NEXT_WITHDRAWAL_INDEX_SLOT), bytes32(uint256(3)));
+
+        proxy.upgradeToAndCall(address(newImpl), script.migrateLegacyWithdrawQueueData());
+
+        assertEq(LidoARM(payable(address(proxy))).legacyWithdrawalRequestCount(), 3);
     }
 
     function test_RevertWhen_UpgradeToAndCall_LegacyLidoWithdrawalRequestsPending() external {

--- a/test/fork/LidoARM/SwapGasComparison.t.sol
+++ b/test/fork/LidoARM/SwapGasComparison.t.sol
@@ -21,6 +21,7 @@ abstract contract Fork_LidoARM_SwapGasComparison_Base is Test {
     bytes4 internal constant INVALID_INITIALIZATION = 0xf92ee8a9;
 
     uint256 internal constant FORK_BLOCK = 24_846_066;
+    uint256 internal constant LIDO_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT = 100;
     uint256 internal constant PRICE_SCALE = 1e36;
     uint256 internal constant LIQUIDITY_DEPOSIT = 1_000 ether;
     uint256 internal constant SWAP_INPUT = 100 ether;
@@ -135,6 +136,7 @@ contract Fork_Concrete_LidoARM_SwapGasUpgraded_Test is Fork_LidoARM_SwapGasCompa
         stdStorage.checked_write(
             stdStorage.sig(stdStorage.target(stdstore, address(lidoProxy)), "reservedWithdrawLiquidity()"), uint256(0)
         );
+        vm.store(address(lidoProxy), bytes32(LIDO_LEGACY_WITHDRAWAL_QUEUE_AMOUNT_SLOT), bytes32(0));
 
         vm.prank(lidoProxy.owner());
         _migrateLegacyWithdrawQueue();

--- a/test/smoke/AbstractSmokeTest.sol
+++ b/test/smoke/AbstractSmokeTest.sol
@@ -6,6 +6,8 @@ import {Test} from "forge-std/Test.sol";
 
 import {DeployManager} from "script/deploy/DeployManager.s.sol";
 import {$028_UpgradeEthenaARMScript} from "script/deploy/mainnet/028_UpgradeEthenaARMScript.s.sol";
+import {$029_UpgradeEtherFiARMSwapFeeScript} from "script/deploy/mainnet/029_UpgradeEtherFiARMSwapFeeScript.s.sol";
+import {$030_UpgradeLidoARMSwapFeeScript} from "script/deploy/mainnet/030_UpgradeLidoARMSwapFeeScript.s.sol";
 import {Resolver} from "script/deploy/helpers/Resolver.sol";
 import {Mainnet} from "contracts/utils/Addresses.sol";
 import {Proxy} from "contracts/Proxy.sol";
@@ -78,16 +80,10 @@ abstract contract AbstractSmokeTest is Test {
 
     function _upgradeLidoARM() internal {
         Proxy proxy = Proxy(payable(resolver.resolve("LIDO_ARM")));
-        LidoARM impl = new LidoARM(Mainnet.WETH, 10 minutes, 1e7, 1e18);
-        resolver.addContract("LIDO_ARM_IMPL", address(impl));
 
         _clearLegacyPendingAmount(address(proxy));
-
-        vm.prank(proxy.owner());
-        proxy.upgradeTo(address(impl));
-
         _clearLegacyWithdrawQueueForSmoke(address(proxy));
-        _migrateLegacyWithdrawQueue(address(proxy));
+        new $030_UpgradeLidoARMSwapFeeScript().run();
 
         StETHAssetAdapter stethAdapterImpl =
             new StETHAssetAdapter(address(proxy), Mainnet.WETH, Mainnet.STETH, Mainnet.LIDO_WITHDRAWAL);
@@ -117,16 +113,10 @@ abstract contract AbstractSmokeTest is Test {
 
     function _upgradeEtherFiARM() internal {
         Proxy proxy = Proxy(payable(resolver.resolve("ETHER_FI_ARM")));
-        EtherFiARM impl = new EtherFiARM(Mainnet.EETH, Mainnet.WETH, 10 minutes, 1e7, 1e18);
-        resolver.addContract("ETHER_FI_ARM_IMPL", address(impl));
 
         _clearLegacyPendingAmount(address(proxy));
-
-        vm.prank(proxy.owner());
-        proxy.upgradeTo(address(impl));
-
         _clearLegacyWithdrawQueueForSmoke(address(proxy));
-        _migrateLegacyWithdrawQueue(address(proxy));
+        new $029_UpgradeEtherFiARMSwapFeeScript().run();
 
         EtherFiAssetAdapter eethAdapterImpl = new EtherFiAssetAdapter(
             address(proxy), Mainnet.EETH, Mainnet.WETH, Mainnet.ETHERFI_WITHDRAWAL, Mainnet.ETHERFI_WITHDRAWAL_NFT


### PR DESCRIPTION
## Summary

- Bump `migrateLegacyWithdrawQueue()` to `reinitializer(3)` so it can run after initializer version 2 has already been consumed
- Add deploy guard regressions for Lido, EtherFi, and Ethena upgrade paths with initializer version 2 already used
- Route smoke setup through the Lido and EtherFi deploy scripts so `upgradeToAndCall` payloads are exercised

## Testing

- `forge test --match-path 'test/deploy/*UpgradeGuards.t.sol'`
- `make test-smoke`