### PR TITLE
feat: pause mechanism and operator-triggered claimRedeem

### DIFF
--- a/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
+++ b/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
@@ -61,25 +61,20 @@ contract $028_UpgradeARMsPauseScript is AbstractDeployScript("028_UpgradeARMsPau
     }
 
     function _buildGovernanceProposal() internal override {
-        govProposal.setDescription("Upgrade LidoARM to add pause mechanism and operator-claim");
+        govProposal.setDescription("Upgrade LidoARM and EtherFiARM to add pause mechanism and operator-claim");
 
         govProposal.action(
             resolver.resolve("LIDO_ARM"), "upgradeTo(address)", abi.encode(resolver.resolve("LIDO_ARM_IMPL"))
         );
+
+        govProposal.action(
+            resolver.resolve("ETHER_FI_ARM"), "upgradeTo(address)", abi.encode(resolver.resolve("ETHERFI_ARM_IMPL"))
+        );
     }
 
-    /// @notice EtherFiARM and EthenaARM are owned by the multisig directly, so we upgrade them
+    /// @notice EthenaARM is owned by the multisig directly, so we upgrade it
     /// via a prank in fork simulation. On real deployment, the multisig will execute the upgrade.
     function _fork() internal override {
-        // EtherFiARM
-        Proxy etherFiProxy = Proxy(payable(resolver.resolve("ETHER_FI_ARM")));
-        address etherFiImpl = resolver.resolve("ETHERFI_ARM_IMPL");
-        if (etherFiProxy.implementation() != etherFiImpl) {
-            vm.startPrank(etherFiProxy.owner());
-            etherFiProxy.upgradeTo(etherFiImpl);
-            vm.stopPrank();
-        }
-
         // EthenaARM
         Proxy ethenaProxy = Proxy(payable(resolver.resolve("ETHENA_ARM")));
         address ethenaImpl = resolver.resolve("ETHENA_ARM_IMPL");

--- a/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
+++ b/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
@@ -3,11 +3,10 @@ pragma solidity 0.8.23;
 
 // Contracts
 import {Proxy} from "contracts/Proxy.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
 import {LidoARM} from "contracts/LidoARM.sol";
 import {EthenaARM} from "contracts/EthenaARM.sol";
 import {EtherFiARM} from "contracts/EtherFiARM.sol";
-import {OriginARM} from "contracts/OriginARM.sol";
-import {Mainnet} from "contracts/utils/Addresses.sol";
 
 // Deployment
 import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
@@ -23,7 +22,6 @@ contract $028_UpgradeARMsPauseScript is AbstractDeployScript("028_UpgradeARMsPau
     LidoARM public lidoARMImpl;
     EtherFiARM public etherFiARMImpl;
     EthenaARM public ethenaARMImpl;
-    OriginARM public oethARMImpl;
 
     function _execute() internal override {
         uint256 claimDelay = 10 minutes;
@@ -60,28 +58,13 @@ contract $028_UpgradeARMsPauseScript is AbstractDeployScript("028_UpgradeARMsPau
             100e18 // allocateThreshold
         );
         _recordDeployment("ETHENA_ARM_IMPL", address(ethenaARMImpl));
-
-        // 4. Origin (OETH) ARM
-        oethARMImpl = new OriginARM(
-            Mainnet.OETH,
-            Mainnet.WETH,
-            Mainnet.OETH_VAULT,
-            claimDelay,
-            1e7, // minSharesToRedeem
-            1e18 // allocateThreshold
-        );
-        _recordDeployment("OETH_ARM_IMPL", address(oethARMImpl));
     }
 
-    /// @notice LidoARM and OETH ARM are upgraded via a governance proposal.
     function _buildGovernanceProposal() internal override {
-        govProposal.setDescription("Upgrade LidoARM and OETH ARM to add pause mechanism and operator-claim");
+        govProposal.setDescription("Upgrade LidoARM to add pause mechanism and operator-claim");
 
         govProposal.action(
             resolver.resolve("LIDO_ARM"), "upgradeTo(address)", abi.encode(resolver.resolve("LIDO_ARM_IMPL"))
-        );
-        govProposal.action(
-            resolver.resolve("OETH_ARM"), "upgradeTo(address)", abi.encode(resolver.resolve("OETH_ARM_IMPL"))
         );
     }
 

--- a/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
+++ b/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {Proxy} from "contracts/Proxy.sol";
+import {LidoARM} from "contracts/LidoARM.sol";
+import {EthenaARM} from "contracts/EthenaARM.sol";
+import {EtherFiARM} from "contracts/EtherFiARM.sol";
+import {OriginARM} from "contracts/OriginARM.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";
+
+/// @notice Upgrades LidoARM, EtherFiARM, EthenaARM and OETH (Origin) ARM
+/// to the new AbstractARM implementation that adds the pause mechanism
+/// (pause/unpause + whenNotPaused on deposit/requestRedeem) and lets
+/// the operator claim withdrawal requests on behalf of users.
+contract $028_UpgradeARMsPauseScript is AbstractDeployScript("028_UpgradeARMsPauseScript") {
+    using GovHelper for GovProposal;
+
+    LidoARM public lidoARMImpl;
+    EtherFiARM public etherFiARMImpl;
+    EthenaARM public ethenaARMImpl;
+    OriginARM public oethARMImpl;
+
+    function _execute() internal override {
+        uint256 claimDelay = 10 minutes;
+
+        // 1. LidoARM
+        lidoARMImpl = new LidoARM(
+            Mainnet.STETH,
+            Mainnet.WETH,
+            Mainnet.LIDO_WITHDRAWAL,
+            claimDelay,
+            1e7, // minSharesToRedeem
+            1e18 // allocateThreshold
+        );
+        _recordDeployment("LIDO_ARM_IMPL", address(lidoARMImpl));
+
+        // 2. EtherFiARM
+        etherFiARMImpl = new EtherFiARM(
+            Mainnet.EETH,
+            Mainnet.WETH,
+            Mainnet.ETHERFI_WITHDRAWAL,
+            claimDelay,
+            1e7, // minSharesToRedeem
+            1e18, // allocateThreshold
+            Mainnet.ETHERFI_WITHDRAWAL_NFT
+        );
+        _recordDeployment("ETHERFI_ARM_IMPL", address(etherFiARMImpl));
+
+        // 3. EthenaARM
+        ethenaARMImpl = new EthenaARM(
+            Mainnet.USDE,
+            Mainnet.SUSDE,
+            claimDelay,
+            1e18, // minSharesToRedeem
+            100e18 // allocateThreshold
+        );
+        _recordDeployment("ETHENA_ARM_IMPL", address(ethenaARMImpl));
+
+        // 4. Origin (OETH) ARM
+        oethARMImpl = new OriginARM(
+            Mainnet.OETH,
+            Mainnet.WETH,
+            Mainnet.OETH_VAULT,
+            claimDelay,
+            1e7, // minSharesToRedeem
+            1e18 // allocateThreshold
+        );
+        _recordDeployment("OETH_ARM_IMPL", address(oethARMImpl));
+    }
+
+    /// @notice LidoARM and OETH ARM are upgraded via a governance proposal.
+    function _buildGovernanceProposal() internal override {
+        govProposal.setDescription("Upgrade LidoARM and OETH ARM to add pause mechanism and operator-claim");
+
+        govProposal.action(
+            resolver.resolve("LIDO_ARM"), "upgradeTo(address)", abi.encode(resolver.resolve("LIDO_ARM_IMPL"))
+        );
+        govProposal.action(
+            resolver.resolve("OETH_ARM"), "upgradeTo(address)", abi.encode(resolver.resolve("OETH_ARM_IMPL"))
+        );
+    }
+
+    /// @notice EtherFiARM and EthenaARM are owned by the multisig directly, so we upgrade them
+    /// via a prank in fork simulation. On real deployment, the multisig will execute the upgrade.
+    function _fork() internal override {
+        // EtherFiARM
+        Proxy etherFiProxy = Proxy(payable(resolver.resolve("ETHER_FI_ARM")));
+        address etherFiImpl = resolver.resolve("ETHERFI_ARM_IMPL");
+        if (etherFiProxy.implementation() != etherFiImpl) {
+            vm.startPrank(etherFiProxy.owner());
+            etherFiProxy.upgradeTo(etherFiImpl);
+            vm.stopPrank();
+        }
+
+        // EthenaARM
+        Proxy ethenaProxy = Proxy(payable(resolver.resolve("ETHENA_ARM")));
+        address ethenaImpl = resolver.resolve("ETHENA_ARM_IMPL");
+        if (ethenaProxy.implementation() != ethenaImpl) {
+            vm.startPrank(ethenaProxy.owner());
+            ethenaProxy.upgradeTo(ethenaImpl);
+            vm.stopPrank();
+        }
+    }
+}

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -129,7 +129,16 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @notice Percentage of available liquid assets to keep in the ARM. 100% = 1e18.
     uint256 public armBuffer;
 
-    uint256[38] private _gap;
+    /// @notice True when user-facing ARM actions are paused.
+    bool public paused;
+
+    uint256[37] private _gap;
+
+    ////////////////////////////////////////////////////
+    ///                 Errors
+    ////////////////////////////////////////////////////
+
+    error ContractPaused(); // 0xab35696f
 
     ////////////////////////////////////////////////////
     ///                 Events
@@ -151,6 +160,21 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     event MarketRemoved(address indexed market);
     event ARMBufferUpdated(uint256 armBuffer);
     event Allocated(address indexed market, int256 targetLiquidityDelta, int256 actualLiquidityDelta);
+    event Paused(address indexed account);
+    event Unpaused(address indexed account);
+
+    ////////////////////////////////////////////////////
+    ///                 Modifiers
+    ////////////////////////////////////////////////////
+
+    modifier whenNotPaused() {
+        if (paused) revert ContractPaused();
+        _;
+    }
+
+    ////////////////////////////////////////////////////
+    ///                 Constructor
+    ////////////////////////////////////////////////////
 
     constructor(
         address _token0,
@@ -535,7 +559,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// The caller needs to have approved the contract to transfer the assets.
     /// @param assets The amount of liquidity assets to deposit
     /// @return shares The amount of shares that were minted
-    function deposit(uint256 assets) external returns (uint256 shares) {
+    function deposit(uint256 assets) external whenNotPaused returns (uint256 shares) {
         shares = _deposit(assets, msg.sender);
     }
 
@@ -544,7 +568,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @param assets The amount of liquidity assets to deposit
     /// @param receiver The address that will receive shares.
     /// @return shares The amount of shares that were minted
-    function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+    function deposit(uint256 assets, address receiver) external whenNotPaused returns (uint256 shares) {
         shares = _deposit(assets, receiver);
     }
 
@@ -587,7 +611,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
     /// @return assets The max amount of liquidity assets that will be claimable by the redeemer.
     /// The amount can be less at claim time if ARM's assets per share has decreased. This can happen
     /// from a significant slashing event on the base asset, eg stETH.
-    function requestRedeem(uint256 shares) external returns (uint256 requestId, uint256 assets) {
+    function requestRedeem(uint256 shares) external whenNotPaused returns (uint256 requestId, uint256 assets) {
         // Calculate the amount of assets to transfer to the redeemer
         assets = convertToAssets(shares);
 
@@ -634,7 +658,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         require(request.claimTimestamp <= block.timestamp, "Claim delay not met");
         // Is there enough liquidity in the ARM and lending market to claim this request?
         require(request.queued <= claimable(), "Queue pending liquidity");
-        require(request.withdrawer == msg.sender, "Not requester");
+        require(request.withdrawer == msg.sender || msg.sender == operator, "Not requester or operator");
         require(request.claimed == false, "Already claimed");
 
         // In the scenario where the ARM has made a loss from after the redeem request, the asset value of
@@ -664,10 +688,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
             }
         }
 
-        // transfer the liquidity asset to the withdrawer
-        IERC20(liquidityAsset).transfer(msg.sender, assets);
+        // transfer the liquidity asset to the original withdrawer
+        IERC20(liquidityAsset).transfer(request.withdrawer, assets);
 
-        emit RedeemClaimed(msg.sender, requestId, assets);
+        emit RedeemClaimed(request.withdrawer, requestId, assets);
     }
 
     /// @notice Used to work out if an ARM's withdrawal request can be claimed.
@@ -1050,5 +1074,17 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable {
         armBuffer = _armBuffer;
 
         emit ARMBufferUpdated(_armBuffer);
+    }
+
+    /// @notice Pause user-facing ARM actions.
+    function pause() external onlyOperatorOrOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    /// @notice Unpause user-facing ARM actions.
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
     }
 }

--- a/test/fork/LidoARM/ClaimRedeem.t.sol
+++ b/test/fork/LidoARM/ClaimRedeem.t.sol
@@ -89,7 +89,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
 
         // Expect revert
         vm.startPrank(vm.randomAddress());
-        vm.expectRevert("Not requester");
+        vm.expectRevert("Not requester or operator");
         lidoARM.claimRedeem(0);
     }
 

--- a/test/unit/OriginARM/ClaimRedeem.sol
+++ b/test/unit/OriginARM/ClaimRedeem.sol
@@ -33,14 +33,34 @@ contract Unit_Concrete_OriginARM_ClaimRedeem_Test_ is Unit_Shared_Test {
         originARM.claimRedeem(0);
     }
 
-    function test_RevertWhen_ClaimRedeem_Because_NotWithdrawer()
+    function test_RevertWhen_ClaimRedeem_Because_NotWithdrawerNorOperator()
         public
         requestRedeemAll(alice)
         timejump(CLAIM_DELAY)
-        asNot(alice)
     {
-        vm.expectRevert("Not requester");
+        // bob is neither the withdrawer (alice) nor the operator
+        vm.prank(bob);
+        vm.expectRevert("Not requester or operator");
         originARM.claimRedeem(0);
+    }
+
+    function test_ClaimRedeem_AsOperator() public requestRedeemAll(alice) timejump(CLAIM_DELAY) {
+        uint256 aliceBalanceBefore = weth.balanceOf(alice);
+        uint256 operatorBalanceBefore = weth.balanceOf(operator);
+
+        // Operator (not the withdrawer) claims on Alice's behalf
+        vm.prank(operator);
+        vm.expectEmit(address(originARM));
+        // Event reports the actual withdrawer (alice), not the caller
+        emit AbstractARM.RedeemClaimed(alice, 0, DEFAULT_AMOUNT);
+        originARM.claimRedeem(0);
+
+        (, bool claimed,,,,) = originARM.withdrawalRequests(0);
+        assertEq(claimed, true, "Claimed should be true");
+        assertEq(originARM.withdrawsClaimed(), DEFAULT_AMOUNT, "Claimed amount should be DEFAULT_AMOUNT");
+        // Funds go to the original withdrawer (alice), even though the operator triggered the claim
+        assertEq(weth.balanceOf(alice), aliceBalanceBefore + DEFAULT_AMOUNT, "Alice should receive the WETH");
+        assertEq(weth.balanceOf(operator), operatorBalanceBefore, "Operator balance unchanged");
     }
 
     function test_RevertWhen_ClaimRedeem_Because_AlreadyClaimed() public requestRedeemAll(alice) timejump(CLAIM_DELAY) {

--- a/test/unit/OriginARM/Pause.sol
+++ b/test/unit/OriginARM/Pause.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {Unit_Shared_Test} from "test/unit/shared/Shared.sol";
+import {AbstractARM} from "contracts/AbstractARM.sol";
+
+contract Unit_Concrete_OriginARM_Pause_Test_ is Unit_Shared_Test {
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Give Alice some WETH and approval so she can interact with the ARM in every test
+        deal(address(weth), alice, 1_000 * DEFAULT_AMOUNT);
+        vm.prank(alice);
+        weth.approve(address(originARM), type(uint256).max);
+    }
+
+    ////////////////////////////////////////////////////
+    /// --- pause()
+    ////////////////////////////////////////////////////
+    function test_RevertWhen_Pause_Because_NotOperatorNorGovernor() public asNotOperatorNorGovernor {
+        vm.expectRevert("ARM: Only operator or owner can call this function.");
+        originARM.pause();
+    }
+
+    function test_Pause_AsOperator() public {
+        assertEq(originARM.paused(), false, "ARM should not be paused before");
+
+        vm.expectEmit(address(originARM));
+        emit AbstractARM.Paused(operator);
+
+        vm.prank(operator);
+        originARM.pause();
+
+        assertEq(originARM.paused(), true, "ARM should be paused after");
+    }
+
+    function test_Pause_AsGovernor() public {
+        assertEq(originARM.paused(), false, "ARM should not be paused before");
+
+        vm.expectEmit(address(originARM));
+        emit AbstractARM.Paused(governor);
+
+        vm.prank(governor);
+        originARM.pause();
+
+        assertEq(originARM.paused(), true, "ARM should be paused after");
+    }
+
+    /// @notice Pausing an already-paused ARM is a no-op state-wise but still emits the event.
+    function test_Pause_WhenAlreadyPaused() public {
+        vm.prank(governor);
+        originARM.pause();
+        assertEq(originARM.paused(), true, "ARM should be paused");
+
+        vm.expectEmit(address(originARM));
+        emit AbstractARM.Paused(operator);
+
+        vm.prank(operator);
+        originARM.pause();
+
+        assertEq(originARM.paused(), true, "ARM should still be paused");
+    }
+
+    ////////////////////////////////////////////////////
+    /// --- unpause()
+    ////////////////////////////////////////////////////
+    function test_RevertWhen_Unpause_Because_NotGovernor() public asNotGovernor {
+        vm.expectRevert("ARM: Only owner can call this function.");
+        originARM.unpause();
+    }
+
+    function test_RevertWhen_Unpause_Because_OperatorCannotUnpause() public asOperator {
+        vm.expectRevert("ARM: Only owner can call this function.");
+        originARM.unpause();
+    }
+
+    function test_Unpause_AsGovernor() public {
+        // First pause the ARM
+        vm.prank(governor);
+        originARM.pause();
+        assertEq(originARM.paused(), true, "ARM should be paused before");
+
+        vm.expectEmit(address(originARM));
+        emit AbstractARM.Unpaused(governor);
+
+        vm.prank(governor);
+        originARM.unpause();
+
+        assertEq(originARM.paused(), false, "ARM should not be paused after");
+    }
+
+    ////////////////////////////////////////////////////
+    /// --- whenNotPaused: deposit() / requestRedeem()
+    ////////////////////////////////////////////////////
+    function test_RevertWhen_Deposit_Because_Paused() public {
+        vm.prank(operator);
+        originARM.pause();
+
+        vm.expectRevert(AbstractARM.ContractPaused.selector);
+        vm.prank(alice);
+        originARM.deposit(DEFAULT_AMOUNT);
+    }
+
+    function test_RevertWhen_DepositWithReceiver_Because_Paused() public {
+        vm.prank(operator);
+        originARM.pause();
+
+        vm.expectRevert(AbstractARM.ContractPaused.selector);
+        vm.prank(alice);
+        originARM.deposit(DEFAULT_AMOUNT, bob);
+    }
+
+    function test_RevertWhen_RequestRedeem_Because_Paused() public {
+        // First deposit so alice has shares to redeem
+        vm.prank(alice);
+        originARM.deposit(DEFAULT_AMOUNT);
+
+        vm.prank(operator);
+        originARM.pause();
+
+        vm.expectRevert(AbstractARM.ContractPaused.selector);
+        vm.prank(alice);
+        originARM.requestRedeem(DEFAULT_AMOUNT);
+    }
+
+    /// @notice After unpause, deposit and requestRedeem work again.
+    function test_DepositAndRedeem_After_Unpause() public {
+        // Pause then unpause
+        vm.prank(operator);
+        originARM.pause();
+        vm.prank(governor);
+        originARM.unpause();
+
+        // Deposit
+        vm.prank(alice);
+        uint256 shares = originARM.deposit(DEFAULT_AMOUNT);
+        assertGt(shares, 0, "Alice should have received shares");
+
+        // Request redeem
+        vm.prank(alice);
+        (uint256 requestId,) = originARM.requestRedeem(shares);
+        assertEq(requestId, 0, "First request");
+    }
+
+    /// @notice claimRedeem() is intentionally NOT gated by whenNotPaused so users
+    /// can always retrieve their already-queued liquidity, even while paused.
+    function test_ClaimRedeem_StillWorks_When_Paused() public {
+        // Alice deposits then requests a full redeem
+        vm.startPrank(alice);
+        uint256 shares = originARM.deposit(DEFAULT_AMOUNT);
+        originARM.requestRedeem(shares);
+        vm.stopPrank();
+
+        // Pause the ARM
+        vm.prank(operator);
+        originARM.pause();
+
+        // Wait for the claim delay
+        vm.warp(block.timestamp + CLAIM_DELAY);
+
+        uint256 balanceBefore = weth.balanceOf(alice);
+        vm.prank(alice);
+        originARM.claimRedeem(0);
+        assertEq(weth.balanceOf(alice), balanceBefore + DEFAULT_AMOUNT, "Alice should still be able to claim");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **pause mechanism** to `AbstractARM`: `paused` flag with `pause()` (operator or owner) and `unpause()` (owner). `deposit()` and `requestRedeem()` are gated by a new `whenNotPaused` modifier. `claimRedeem()` is intentionally **not** gated so LPs can always retrieve liquidity already in the queue.
- Lets the **operator call `claimRedeem()` on behalf of a user**. Funds and the `RedeemClaimed` event are routed to the original `request.withdrawer`, not `msg.sender` — the operator only triggers, the user receives.
- Declares the previously missing `Paused`/`Unpaused` events that `pause()`/`unpause()` were emitting.
- Adds **script 028** upgrading the 4 mainnet ARMs (Lido, EtherFi, Ethena, OETH) to the new implementation. LidoARM and OETH ARM go through a governance proposal; EtherFi and Ethena are upgraded by the multisig (covered in the fork hook).

## Storage layout

- New `bool public paused` slot; `_gap` reduced from `38` to `37`. No reordering of existing storage variables.

## Test plan

- [x] `make test-unit` — 106/106 pass (including 12 new tests in `Pause.sol` and the updated `ClaimRedeem.sol`)
- [x] `make test-fork` — 70/70 pass on changed paths; the 2 failures are pre-existing (`Harvester/Swap` requires Node 22 for an `npx hardhat` FFI call, unrelated to this PR)
- [x] `make test-smoke` — 50/50 pass across the 4 ARMs
- [x] `make simulate` — script 028 deploys the 4 impls, builds and successfully simulates the governance proposal (Lido + OETH `upgradeTo`)

## Files

- `src/contracts/AbstractARM.sol` — pause, operator-claim, missing events
- `test/unit/OriginARM/Pause.sol` — new, 12 tests
- `test/unit/OriginARM/ClaimRedeem.sol` — updated `NotWithdrawer` test + new `AsOperator` test
- `test/fork/LidoARM/ClaimRedeem.t.sol` — updated revert message
- `script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol` — new upgrade script for the 4 ARMs

Replaces #251 (same content, renamed branch).