### PR TITLE
Migrate to Talos

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -255,6 +255,18 @@
             "proposalId": 1,
             "tsDeployment": 1777952339,
             "tsGovernance": 0
+        },
+        {
+            "name": "029_SetTalosKMSOperatorScript",
+            "proposalId": 0,
+            "tsDeployment": 1781035763,
+            "tsGovernance": 0
+        },
+        {
+            "name": "030_SetEthenaTalosKMSOperatorScript",
+            "proposalId": 1,
+            "tsDeployment": 1781035763,
+            "tsGovernance": 0
         }
     ]
 }

--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -258,7 +258,7 @@
         },
         {
             "name": "029_SetTalosKMSOperatorScript",
-            "proposalId": 0,
+            "proposalId": "12986865731251129814295460769943611973912941096599758191915201739619928664693",
             "tsDeployment": 1781035763,
             "tsGovernance": 0
         },

--- a/build/deployments-146.json
+++ b/build/deployments-146.json
@@ -55,7 +55,7 @@
       "tsGovernance": 1
     },
     {
-      "name": "003_UpgradeOriginARMScriptScript",
+      "name": "003_UpgradeOriginARMScript",
       "proposalId": 1,
       "tsDeployment": 1748603225,
       "tsGovernance": 1
@@ -71,6 +71,12 @@
       "proposalId": 1,
       "tsDeployment": 1755782543,
       "tsGovernance": 1
+    },
+    {
+      "name": "006_SetOriginARMTalosOperatorScript",
+      "proposalId": 1,
+      "tsDeployment": 1781037496,
+      "tsGovernance": 0
     }
   ]
 }

--- a/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
+++ b/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
@@ -18,12 +18,8 @@ contract $029_SetTalosKMSOperatorScript is AbstractDeployScript("029_SetTalosKMS
     function _buildGovernanceProposal() internal override {
         govProposal.setDescription("Migrate LidoARM and EtherFiARM operator to the new Talos KMS signer");
 
-        govProposal.action(
-            resolver.resolve("LIDO_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_RELAYER)
-        );
+        govProposal.action(resolver.resolve("LIDO_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_RELAYER));
 
-        govProposal.action(
-            resolver.resolve("ETHER_FI_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_RELAYER)
-        );
+        govProposal.action(resolver.resolve("ETHER_FI_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_RELAYER));
     }
 }

--- a/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
+++ b/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {Mainnet} from "contracts/utils/Addresses.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";
+
+/// @notice Migrates the operator of LidoARM and EtherFiARM (both owned by the
+/// mainnet Timelock) from the ARM Operations Defender relayer to the new Talos
+/// KMS signer. setOperator is onlyOwner on OwnableOperable, so this routes
+/// through a GovernorSix -> Timelock proposal.
+contract $029_SetTalosKMSOperatorScript is AbstractDeployScript("029_SetTalosKMSOperatorScript") {
+    using GovHelper for GovProposal;
+
+    function _buildGovernanceProposal() internal override {
+        govProposal.setDescription("Migrate LidoARM and EtherFiARM operator to the new Talos KMS signer");
+
+        govProposal.action(
+            resolver.resolve("LIDO_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_KMS_RELAYER)
+        );
+
+        govProposal.action(
+            resolver.resolve("ETHER_FI_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_KMS_RELAYER)
+        );
+    }
+}

--- a/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
+++ b/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
@@ -19,11 +19,11 @@ contract $029_SetTalosKMSOperatorScript is AbstractDeployScript("029_SetTalosKMS
         govProposal.setDescription("Migrate LidoARM and EtherFiARM operator to the new Talos KMS signer");
 
         govProposal.action(
-            resolver.resolve("LIDO_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_KMS_RELAYER)
+            resolver.resolve("LIDO_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_RELAYER)
         );
 
         govProposal.action(
-            resolver.resolve("ETHER_FI_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_KMS_RELAYER)
+            resolver.resolve("ETHER_FI_ARM"), "setOperator(address)", abi.encode(Mainnet.TALOS_RELAYER)
         );
     }
 }

--- a/script/deploy/mainnet/030_SetEthenaTalosKMSOperatorScript.s.sol
+++ b/script/deploy/mainnet/030_SetEthenaTalosKMSOperatorScript.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {Mainnet} from "contracts/utils/Addresses.sol";
+import {OwnableOperable} from "contracts/OwnableOperable.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+
+/// @notice Migrates the operator of EthenaARM from the ARM Operations Defender
+/// relayer to the new Talos KMS signer. Unlike LidoARM/EtherFiARM (owned by the
+/// mainnet Timelock and migrated via a governance proposal in 029), EthenaARM is
+/// owned by the 5/8 Guardian Safe (GOV_MULTISIG) directly, so setOperator
+/// (onlyOwner on OwnableOperable) is executed by that Safe. We simulate it with a
+/// prank in fork; on real deployment the multisig executes the call.
+contract $030_SetEthenaTalosKMSOperatorScript is AbstractDeployScript("030_SetEthenaTalosKMSOperatorScript") {
+    function _fork() internal override {
+        OwnableOperable ethenaARM = OwnableOperable(resolver.resolve("ETHENA_ARM"));
+
+        if (ethenaARM.operator() != Mainnet.TALOS_RELAYER) {
+            vm.startPrank(ethenaARM.owner());
+            ethenaARM.setOperator(Mainnet.TALOS_RELAYER);
+            vm.stopPrank();
+        }
+    }
+}

--- a/script/deploy/sonic/006_SetOriginARMTalosOperatorScript.s.sol
+++ b/script/deploy/sonic/006_SetOriginARMTalosOperatorScript.s.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {Sonic} from "contracts/utils/Addresses.sol";
+import {OwnableOperable} from "contracts/OwnableOperable.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+
+/// @notice Migrates the operator of OriginARM on Sonic from the old relayer EOA
+/// to the new Talos KMS signer. OriginARM on Sonic is owned by the Sonic Timelock
+/// (not the 5/8 admin), so setOperator (onlyOwner on OwnableOperable) must go
+/// through the timelock. The real migration is a Sonic Timelock schedule/execute
+/// driven by the Sonic 5/8 admin, performed manually as a separate step:
+/// arm-oeth has no auto-JSON generation for the Sonic timelock, and
+/// origin-dollar's 030_migrate_sonic_operators_to_talos covers only the
+/// OSonicVault + SonicStakingStrategy timelock actions, NOT this OriginARM
+/// setOperator. This script only implements _fork() to validate the operator
+/// change against a Sonic fork by pranking the owner (the Sonic Timelock).
+contract $006_SetOriginARMTalosOperatorScript is AbstractDeployScript("006_SetOriginARMTalosOperatorScript") {
+    // ────────────────────────────────────────────────────────────────────────────────────────
+    // MANUAL SONIC TIMELOCK MIGRATION — reference calldata
+    // Generated with `cast`; the operation id is verified against the live Sonic Timelock.
+    //
+    // OriginARM.setOperator() is onlyOwner, and OriginARM's owner is the Sonic Timelock
+    // (0x31a91336414d3B955E494E7d485a6B06b55FC8fB, an OpenZeppelin TimelockController).
+    // So the change is a two-step, time-locked operation driven by the Sonic 5/8 admin Safe
+    // (0xAdDEA7933Db7d83855786EB43a238111C69B00b6), which holds both PROPOSER and EXECUTOR roles:
+    //     1) Safe -> Timelock.schedule(...)   queues the op and starts the 48h timer
+    //     2) wait getMinDelay() = 172800s (48h)
+    //     3) Safe -> Timelock.execute(...)    runs the op; the Timelock then calls setOperator
+    // Send BOTH transactions TO the Timelock 0x31a91336414d3B955E494E7d485a6B06b55FC8fB, value 0.
+    //
+    // HOW THE CALLDATA IS STRUCTURED
+    // Solidity ABI-encoding = 4-byte selector, then a 32-byte "head" word per top-level argument,
+    // then a "tail" holding the contents of any dynamic (`bytes`) argument. A `bytes` argument does
+    // not sit inline in the head; its head word is an OFFSET (measured from the first byte after the
+    // selector) pointing into the tail, where the layout is [32-byte length][content padded up to a
+    // 32-byte boundary]. address/uint256/bytes32 are static and sit inline in the head, left-padded.
+    //
+    // ── Inner call the Timelock performs (this is the `data`/`payload` bytes carried below) ──
+    //   target   = OriginARM 0x2F872623d1E1Af5835b08b0E49aAd2d81d649D30
+    //   function = setOperator(address)                      selector 0xb3ab15fb
+    //   arg      = Sonic.TALOS_RELAYER 0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b
+    //   data (36 bytes) = 0xb3ab15fb000000000000000000000000739212d5bafe6aac8be49a60b7d003bd41dbf38b
+    //                      └ selector (4) ┘└──────── address, left-padded to 32 bytes ────────┘
+    //
+    // ── Operation id = keccak256(abi.encode(target, value, data, predecessor, salt)) ──
+    //   0xdafe6d5b3c6dee208b6146e82e0e73acfab9e6a4c60f00f95ea9ef4b4ff6fcc5
+    //   (emitted in CallScheduled; pass it to cancel() / isOperationReady() / isOperationDone())
+    //
+    // ════════════ STEP 1 — Timelock.schedule(address,uint256,bytes,bytes32,bytes32,uint256) ════════════
+    // selector 0x01d5062a. The head has 6 words, so the `data` offset is 6*32 = 0xc0.
+    //   0x01d5062a
+    //   0000000000000000000000002f872623d1e1af5835b08b0e49aad2d81d649d30  target       = OriginARM
+    //   0000000000000000000000000000000000000000000000000000000000000000  value        = 0
+    //   00000000000000000000000000000000000000000000000000000000000000c0  offset->data = 0xc0 (192)
+    //   0000000000000000000000000000000000000000000000000000000000000000  predecessor  = 0x0 (no dependency)
+    //   0000000000000000000000000000000000000000000000000000000000000000  salt         = 0x0
+    //   000000000000000000000000000000000000000000000000000000000002a300  delay        = 0x2a300 (172800)
+    //   0000000000000000000000000000000000000000000000000000000000000024  data.length  = 0x24 (36 bytes)
+    //   b3ab15fb000000000000000000000000739212d5bafe6aac8be49a60b7d003bd41dbf38b          data (36 bytes)
+    //   00000000000000000000000000000000000000000000000000000000          right-pad to a 32-byte boundary
+    //
+    // STEP 1 one-line calldata:
+    // 0x01d5062a0000000000000000000000002f872623d1e1af5835b08b0e49aad2d81d649d30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a3000000000000000000000000000000000000000000000000000000000000000024b3ab15fb000000000000000000000000739212d5bafe6aac8be49a60b7d003bd41dbf38b00000000000000000000000000000000000000000000000000000000
+    //
+    // ════════════ STEP 2 — Timelock.execute(address,uint256,bytes,bytes32,bytes32) ════════════
+    // selector 0x134008d3. Callable only after the 48h delay. predecessor + salt MUST match STEP 1,
+    // otherwise the recomputed operation id won't be the one that was scheduled. Here the head has 5
+    // words, so the `payload` offset is 5*32 = 0xa0 (the only structural difference from schedule).
+    //   0x134008d3
+    //   0000000000000000000000002f872623d1e1af5835b08b0e49aad2d81d649d30  target          = OriginARM
+    //   0000000000000000000000000000000000000000000000000000000000000000  value           = 0
+    //   00000000000000000000000000000000000000000000000000000000000000a0  offset->payload = 0xa0 (160)
+    //   0000000000000000000000000000000000000000000000000000000000000000  predecessor     = 0x0
+    //   0000000000000000000000000000000000000000000000000000000000000000  salt            = 0x0
+    //   0000000000000000000000000000000000000000000000000000000000000024  payload.length  = 0x24 (36 bytes)
+    //   b3ab15fb000000000000000000000000739212d5bafe6aac8be49a60b7d003bd41dbf38b          payload (36 bytes)
+    //   00000000000000000000000000000000000000000000000000000000          right-pad to a 32-byte boundary
+    //
+    // STEP 2 one-line calldata:
+    // 0x134008d30000000000000000000000002f872623d1e1af5835b08b0e49aad2d81d649d30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024b3ab15fb000000000000000000000000739212d5bafe6aac8be49a60b7d003bd41dbf38b00000000000000000000000000000000000000000000000000000000
+    //
+    // predecessor = 0x0 means the op depends on nothing. salt = 0x0 is fine for a one-off; if an
+    // identical op (same target/value/data/predecessor/salt) is already queued, schedule() reverts
+    // with "TimelockController: operation already scheduled" — bump salt to any unique bytes32 and
+    // recompute BOTH calls (and the operation id) with the same salt. delay must be >= getMinDelay();
+    // 172800 is exactly the current minimum.
+    // ────────────────────────────────────────────────────────────────────────────────────────
+    function _fork() internal override {
+        OwnableOperable arm = OwnableOperable(resolver.resolve("ORIGIN_ARM"));
+
+        if (arm.operator() != Sonic.TALOS_RELAYER) {
+            vm.startPrank(arm.owner());
+            arm.setOperator(Sonic.TALOS_RELAYER);
+            vm.stopPrank();
+        }
+    }
+}

--- a/src/contracts/utils/Addresses.sol
+++ b/src/contracts/utils/Addresses.sol
@@ -20,7 +20,7 @@ library Mainnet {
     address public constant ARM_MULTISIG = 0xC8F2cF4742C86295653f893214725813B16f7410;
     address public constant OETH_RELAYER = 0x4b91827516f79d6F6a1F292eD99671663b09169a;
     address public constant ARM_RELAYER = 0x39878253374355DBcc15C86458F084fb6f2d6DE7;
-    address public constant TALOS_KMS_RELAYER = 0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b;
+    address public constant TALOS_RELAYER = 0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b;
     address public constant BUYBACK_OPERATOR = 0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c;
 
     // Tokens

--- a/src/contracts/utils/Addresses.sol
+++ b/src/contracts/utils/Addresses.sol
@@ -98,6 +98,7 @@ library Sonic {
     // 5/8 multisig
     address public constant ADMIN = 0xAdDEA7933Db7d83855786EB43a238111C69B00b6;
     address public constant RELAYER = 0x531B8D5eD6db72A56cF1238D4cE478E7cB7f2825;
+    address public constant TALOS_RELAYER = 0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b;
 
     // Tokens
     address public constant OS = 0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794;

--- a/src/contracts/utils/Addresses.sol
+++ b/src/contracts/utils/Addresses.sol
@@ -20,6 +20,7 @@ library Mainnet {
     address public constant ARM_MULTISIG = 0xC8F2cF4742C86295653f893214725813B16f7410;
     address public constant OETH_RELAYER = 0x4b91827516f79d6F6a1F292eD99671663b09169a;
     address public constant ARM_RELAYER = 0x39878253374355DBcc15C86458F084fb6f2d6DE7;
+    address public constant TALOS_KMS_RELAYER = 0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b;
     address public constant BUYBACK_OPERATOR = 0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c;
 
     // Tokens

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -24,7 +24,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         super.setUp();
         usde = IERC20(Mainnet.USDE);
         susde = IERC20(Mainnet.SUSDE);
-        operator = Mainnet.ARM_RELAYER;
+        operator = Mainnet.TALOS_RELAYER;
 
         vm.label(address(usde), "USDE");
         vm.label(address(susde), "SUSDE");
@@ -42,7 +42,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         assertEq(ethenaARM.name(), "Ethena Staked USDe ARM", "Name");
         assertEq(ethenaARM.symbol(), "ARM-sUSDe-USDe", "Symbol");
         assertEq(ethenaARM.owner(), Mainnet.TIMELOCK, "Owner");
-        assertEq(ethenaARM.operator(), Mainnet.ARM_RELAYER, "Operator");
+        assertEq(ethenaARM.operator(), Mainnet.TALOS_RELAYER, "Operator");
         assertEq(ethenaARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
         assertEq((100 * uint256(ethenaARM.fee())) / ethenaARM.FEE_SCALE(), 20, "Performance fee as a percentage");
 
@@ -99,7 +99,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
             expectedOut = amountIn * 1e36 / price;
             expectedOut = IStakedUSDe(address(susde)).convertToShares(expectedOut);
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             ethenaARM.setPrices(0.99e36, price);
         } else {
             // Trader is selling sUSDe and buying USDE
@@ -110,7 +110,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
             expectedOut = amountIn * price / 1e36;
             expectedOut = IStakedUSDe(address(susde)).convertToAssets(expectedOut);
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             uint256 sellPrice = price < 0.9997e36 ? 0.99996e36 : price + 2e32;
             ethenaARM.setPrices(price, sellPrice);
         }
@@ -136,7 +136,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
 
             expectedIn = IStakedUSDe(address(susde)).convertToAssets(amountOut) * price / 1e36;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             ethenaARM.setPrices(0.99e36, price);
         } else {
             // Trader is selling sUSDe and buying USDE
@@ -147,7 +147,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
 
             expectedIn = IStakedUSDe(address(susde)).convertToShares(amountOut) * 1e36 / price + 3;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             uint256 sellPrice = price < 0.9997e36 ? 0.99996e36 : price + 2e32;
             ethenaARM.setPrices(price, sellPrice);
         }
@@ -209,7 +209,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
 
         // Operator requests an Ethena withdrawal
         skip(ethenaARM.DELAY_REQUEST() + 1);
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         ethenaARM.requestBaseWithdrawal(10 ether);
     }
 
@@ -236,7 +236,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         skip(7 days);
 
         // Claim the withdrawal
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         ethenaARM.claimBaseWithdrawals(uint8(nextUnstakerIndex));
     }
 
@@ -244,7 +244,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
     function test_allocate_AAVEMarket_withoutYield() external {
         _swapExactTokensForTokens(usde, susde, 0.99996e36, 1_000 ether);
 
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         ethenaARM.setARMBuffer(5000); // 50%
         address activeMarket = ethenaARM.activeMarket();
 
@@ -258,7 +258,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
     function test_allocate_AAVEMarket_withYield() external {
         _swapExactTokensForTokens(usde, susde, 0.99996e36, 1_000 ether);
 
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         ethenaARM.setARMBuffer(5000); // 50%
 
         // Allocate
@@ -273,7 +273,7 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         IERC20(aUSDE).transfer(activeMarket, 10 ether);
 
         // Deallocate
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         ethenaARM.setActiveMarket(address(0));
         uint256 balanceAfter = usde.balanceOf(address(ethenaARM));
 

--- a/test/smoke/EtherFiARMSmokeTest.t.sol
+++ b/test/smoke/EtherFiARMSmokeTest.t.sol
@@ -25,7 +25,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         super.setUp();
         weth = IERC20(Mainnet.WETH);
         eeth = IERC20(Mainnet.EETH);
-        operator = Mainnet.ARM_RELAYER;
+        operator = Mainnet.TALOS_RELAYER;
 
         vm.label(address(weth), "WETH");
         vm.label(address(eeth), "eETH");
@@ -45,7 +45,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         assertEq(etherFiARM.name(), "Ether.fi ARM", "Name");
         assertEq(etherFiARM.symbol(), "ARM-WETH-eETH", "Symbol");
         assertEq(etherFiARM.owner(), Mainnet.TIMELOCK, "Owner");
-        assertEq(etherFiARM.operator(), Mainnet.ARM_RELAYER, "Operator");
+        assertEq(etherFiARM.operator(), Mainnet.TALOS_RELAYER, "Operator");
         assertEq(etherFiARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
         assertEq((100 * uint256(etherFiARM.fee())) / etherFiARM.FEE_SCALE(), 20, "Performance fee as a percentage");
         // LidoLiquidityManager
@@ -102,7 +102,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
 
             expectedOut = amountIn * 1e36 / price;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             etherFiARM.setPrices(price - 2e32, price);
         } else {
             // Trader is selling eETH and buying WETH
@@ -112,7 +112,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
 
             expectedOut = amountIn * price / 1e36;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             uint256 sellPrice = price < 0.9997e36 ? 0.99996e36 : price + 2e32;
             etherFiARM.setPrices(price, sellPrice);
         }
@@ -138,7 +138,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
 
             expectedIn = amountOut * price / 1e36;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             etherFiARM.setPrices(price - 2e32, price);
         } else {
             // Trader is selling eETH and buying WETH
@@ -149,7 +149,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
 
             expectedIn = amountOut * 1e36 / price + 3;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             uint256 sellPrice = price < 0.9997e36 ? 0.99996e36 : price + 2e32;
             etherFiARM.setPrices(price, sellPrice);
         }
@@ -217,7 +217,7 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         emit EtherFiARM.RequestEtherFiWithdrawal(10 ether, 0);
 
         // Operator requests an Ether.fi withdrawal
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         etherFiARM.requestEtherFiWithdrawal(10 ether);
     }
 
@@ -274,11 +274,11 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         uint256 marketBalanceBefore = morphoMarket.maxWithdraw(address(etherFiARM));
 
         // Set buffer to 0% so all liquidity goes to the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         etherFiARM.setARMBuffer(0);
 
         // Allocate liquidity to the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         (, int256 actualDelta) = etherFiARM.allocate();
 
         uint256 armWethAfter = weth.balanceOf(address(etherFiARM));
@@ -303,20 +303,20 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
 
         // Deal WETH to the ARM and allocate to market with buffer at 0%
         deal(address(weth), address(etherFiARM), 100 ether);
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         etherFiARM.setARMBuffer(0);
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         etherFiARM.allocate();
 
         uint256 armWethBefore = weth.balanceOf(address(etherFiARM));
         uint256 marketBalanceBefore = morphoMarket.maxWithdraw(address(etherFiARM));
 
         // Set buffer to 100% so liquidity comes back from the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         etherFiARM.setARMBuffer(1e18);
 
         // Allocate liquidity from the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         (, int256 actualDelta) = etherFiARM.allocate();
 
         uint256 armWethAfter = weth.balanceOf(address(etherFiARM));

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -24,7 +24,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         super.setUp();
         weth = IERC20(Mainnet.WETH);
         steth = IERC20(Mainnet.STETH);
-        operator = Mainnet.ARM_RELAYER;
+        operator = Mainnet.TALOS_RELAYER;
 
         vm.label(address(weth), "WETH");
         vm.label(address(steth), "stETH");
@@ -43,7 +43,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         assertEq(lidoARM.name(), "Lido ARM", "Name");
         assertEq(lidoARM.symbol(), "ARM-WETH-stETH", "Symbol");
         assertEq(lidoARM.owner(), Mainnet.TIMELOCK, "Owner");
-        assertEq(lidoARM.operator(), Mainnet.ARM_RELAYER, "Operator");
+        assertEq(lidoARM.operator(), Mainnet.TALOS_RELAYER, "Operator");
         assertEq(lidoARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
         assertEq((100 * uint256(lidoARM.fee())) / lidoARM.FEE_SCALE(), 20, "Performance fee as a percentage");
         // LidoLiquidityManager
@@ -98,7 +98,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
 
             expectedOut = amountIn * 1e36 / price;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             lidoARM.setPrices(price - 2e32, price);
         } else {
             // Trader is selling stETH and buying WETH
@@ -108,7 +108,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
 
             expectedOut = amountIn * price / 1e36;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             uint256 sellPrice = price < 0.9997e36 ? 0.99996e36 : price + 2e32;
             lidoARM.setPrices(price, sellPrice);
         }
@@ -134,7 +134,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
 
             expectedIn = amountOut * price / 1e36;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             lidoARM.setPrices(price - 2e32, price);
         } else {
             // Trader is selling stETH and buying WETH
@@ -145,7 +145,7 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
 
             expectedIn = amountOut * 1e36 / price + 3;
 
-            vm.prank(Mainnet.ARM_RELAYER);
+            vm.prank(Mainnet.TALOS_RELAYER);
             uint256 sellPrice = price < 0.9997e36 ? 0.99996e36 : price + 2e32;
             lidoARM.setPrices(price, sellPrice);
         }
@@ -249,11 +249,11 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         uint256 marketBalanceBefore = morphoMarket.maxWithdraw(address(lidoARM));
 
         // Set buffer to 0% so all liquidity goes to the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         lidoARM.setARMBuffer(0);
 
         // Allocate liquidity to the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         (, int256 actualDelta) = lidoARM.allocate();
 
         uint256 armWethAfter = weth.balanceOf(address(lidoARM));
@@ -279,20 +279,20 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         // Deal enough WETH to cover the outstanding withdrawal queue plus extra to deposit
         uint256 outstandingWithdrawals = lidoARM.withdrawsQueued() - lidoARM.withdrawsClaimed();
         deal(address(weth), address(lidoARM), outstandingWithdrawals + 100 ether);
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         lidoARM.setARMBuffer(0);
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         lidoARM.allocate();
 
         uint256 armWethBefore = weth.balanceOf(address(lidoARM));
         uint256 marketBalanceBefore = morphoMarket.maxWithdraw(address(lidoARM));
 
         // Set buffer to 100% so liquidity comes back from the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         lidoARM.setARMBuffer(1e18);
 
         // Allocate liquidity from the lending market
-        vm.prank(Mainnet.ARM_RELAYER);
+        vm.prank(Mainnet.TALOS_RELAYER);
         (, int256 actualDelta) = lidoARM.allocate();
 
         uint256 armWethAfter = weth.balanceOf(address(lidoARM));


### PR DESCRIPTION
Migrates the operator role on all Origin ARMs to the new Talos relayer signer (0x739212…Bf38b), added as TALOS_RELAYER in Addresses.sol (mainnet + Sonic).

  **Mainnet**
  - **029 gov proposal** — Lido ARM + EtherFi ARM → TALOS_RELAYER (Timelock-owned, executed via governance).
  - **030 script** — Ethena ARM → TALOS_RELAYER (owned by the 5/8 Guardian Safe, so setOperator is run by the Safe, not governance).

  **Sonic**
  - **006 script** — Origin ARM → TALOS_RELAYER.

  Tests — Lido / EtherFi / Ethena smoke tests updated to expect TALOS_RELAYER as the operator.