### PR TITLE
Added backward compatibility to Hardhat tasks

### DIFF
--- a/src/js/actions/allocateEthena.js
+++ b/src/js/actions/allocateEthena.js
@@ -21,10 +21,16 @@ const handler = async (event) => {
 
   // References to contracts
   const arm = new ethers.Contract(mainnet.ethenaARM, armAbi, signer);
+  const armConfig = {
+    // Pre-upgrade default: omit armContractVersion so allocation auto-detects.
+    // Post-upgrade: keep omitted, or temporarily pin "v2" while rolling out.
+    // armContractVersion: "v2",
+  };
 
   await allocate({
     signer,
     arm,
+    ...armConfig,
     threshold: 5000,
     maxGasPrice: 5,
   });

--- a/src/js/actions/allocateEtherFi.js
+++ b/src/js/actions/allocateEtherFi.js
@@ -21,10 +21,16 @@ const handler = async (event) => {
 
   // References to contracts
   const arm = new ethers.Contract(mainnet.etherfiARM, armAbi, signer);
+  const armConfig = {
+    // Pre-upgrade default: omit armContractVersion so allocation auto-detects.
+    // Post-upgrade: keep omitted, or temporarily pin "v2" while rolling out.
+    // armContractVersion: "v2",
+  };
 
   await allocate({
     signer,
     arm,
+    ...armConfig,
     threshold: 20,
     maxGasPrice: 5,
   });

--- a/src/js/actions/allocateLido.js
+++ b/src/js/actions/allocateLido.js
@@ -21,10 +21,16 @@ const handler = async (event) => {
 
   // References to contracts
   const arm = new ethers.Contract(mainnet.lidoARM, armAbi, signer);
+  const armConfig = {
+    // Pre-upgrade default: omit armContractVersion so allocation auto-detects.
+    // Post-upgrade: keep omitted, or temporarily pin "v2" while rolling out.
+    // armContractVersion: "v2",
+  };
 
   await allocate({
     signer,
     arm,
+    ...armConfig,
     threshold: 200,
     maxGasPrice: 5,
   });

--- a/src/js/actions/allocateOETH.js
+++ b/src/js/actions/allocateOETH.js
@@ -21,10 +21,16 @@ const handler = async (event) => {
 
   // References to contracts
   const arm = new ethers.Contract(mainnet.OethARM, armAbi, signer);
+  const armConfig = {
+    // Pre-upgrade default: omit armContractVersion so allocation auto-detects.
+    // Post-upgrade: keep omitted, or temporarily pin "v2" while rolling out.
+    // armContractVersion: "v2",
+  };
 
   await allocate({
     signer,
     arm,
+    ...armConfig,
     threshold: 10000,
     maxGasPrice: 500,
   });

--- a/src/js/actions/allocateSonic.js
+++ b/src/js/actions/allocateSonic.js
@@ -21,13 +21,18 @@ const handler = async (event) => {
 
   // References to contracts
   const arm = new ethers.Contract(sonic.OriginARM, armAbi, signer);
+  const armConfig = {
+    // Pre-upgrade Sonic can be pinned to v1; omit this after upgrade for auto-detect.
+    armContractVersion: "v1",
+    // armContractVersion: "v2",
+  };
 
   await allocate({
     signer,
     arm,
+    ...armConfig,
     threshold: 10000,
     maxGasPrice: 500,
-    armContractVersion: "v1",
   });
 };
 

--- a/src/js/actions/autoClaimEthenaWithdraw.js
+++ b/src/js/actions/autoClaimEthenaWithdraw.js
@@ -1,6 +1,7 @@
 const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 const { claimEthenaWithdrawals } = require("../tasks/ethenaQueue");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const ethenaARMAbi = require("../../abis/EthenaARM.json");
 
@@ -21,10 +22,15 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(mainnet.ethenaARM, ethenaARMAbi, signer);
 
-  await claimEthenaWithdrawals({
-    signer,
-    arm,
-    armName: "Ethena",
+  await runForBases({
+    bases: ["SUSDE"],
+    actionName: "Claiming withdrawals",
+    fn: claimEthenaWithdrawals,
+    options: {
+      signer,
+      arm,
+      armName: "Ethena",
+    },
   });
 };
 

--- a/src/js/actions/autoClaimEtherFiWithdraw.js
+++ b/src/js/actions/autoClaimEtherFiWithdraw.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { claimEtherFiWithdrawals } = require("../tasks/etherfiQueue");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const etherFiARMAbi = require("../../abis/EtherFiARM.json");
 
@@ -22,10 +23,15 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(mainnet.etherfiARM, etherFiARMAbi, signer);
 
-  await claimEtherFiWithdrawals({
-    signer,
-    arm,
-    armName: "EtherFi",
+  await runForBases({
+    bases: ["EETH", "WEETH"],
+    actionName: "Claiming withdrawals",
+    fn: claimEtherFiWithdrawals,
+    options: {
+      signer,
+      arm,
+      armName: "EtherFi",
+    },
   });
 };
 

--- a/src/js/actions/autoClaimLidoWithdraw.js
+++ b/src/js/actions/autoClaimLidoWithdraw.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { claimLidoWithdrawals } = require("../tasks/lidoQueue");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const lidoWithdrawalQueueAbi = require("../../abis/LidoWithdrawQueue.json");
 const lidoARMAbi = require("../../abis/LidoARM.json");
@@ -28,11 +29,16 @@ const handler = async (event) => {
     signer,
   );
 
-  await claimLidoWithdrawals({
-    signer,
-    arm,
-    armName: "Lido",
-    withdrawalQueue,
+  await runForBases({
+    bases: ["STETH", "WSTETH"],
+    actionName: "Claiming withdrawals",
+    fn: claimLidoWithdrawals,
+    options: {
+      signer,
+      arm,
+      armName: "Lido",
+      withdrawalQueue,
+    },
   });
 };
 

--- a/src/js/actions/autoClaimWithdraw.js
+++ b/src/js/actions/autoClaimWithdraw.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { autoClaimWithdraw } = require("../tasks/liquidityAutomation");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const erc20Abi = require("../../abis/ERC20.json");
 const oethARMAbi = require("../../abis/OethARM.json");
@@ -26,13 +27,18 @@ const handler = async (event) => {
   const vault = new ethers.Contract(mainnet.OETHVaultProxy, vaultAbi, signer);
   const arm = new ethers.Contract(mainnet.OethARM, oethARMAbi, signer);
 
-  await autoClaimWithdraw({
-    signer,
-    liquidityAsset,
-    arm,
-    armName: "Oeth",
-    vault,
-    confirm: true,
+  await runForBases({
+    bases: ["OETH", "WOETH"],
+    actionName: "Claiming withdrawals",
+    fn: autoClaimWithdraw,
+    options: {
+      signer,
+      liquidityAsset,
+      arm,
+      armName: "Oeth",
+      vault,
+      confirm: true,
+    },
   });
 };
 

--- a/src/js/actions/autoClaimWithdrawSonic.js
+++ b/src/js/actions/autoClaimWithdrawSonic.js
@@ -2,7 +2,9 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { autoClaimWithdraw } = require("../tasks/liquidityAutomation");
+const { runForBases } = require("./priceActionUtils");
 const { sonic } = require("../utils/addresses");
+const { callAllocate, estimateAllocateGas } = require("../utils/arm");
 const { logTxDetails } = require("../utils/txLogger");
 const erc20Abi = require("../../abis/ERC20.json");
 const armAbi = require("../../abis/OriginARM.json");
@@ -27,25 +29,34 @@ const handler = async (event) => {
   const vault = new ethers.Contract(sonic.OSonicVaultProxy, vaultAbi, signer);
   const arm = new ethers.Contract(sonic.OriginARM, armAbi, signer);
 
-  const requestIds = await autoClaimWithdraw({
-    signer,
-    liquidityAsset,
-    arm,
-    armName: "Origin",
-    vault,
-    confirm: true,
-  });
+  const requestIds = (
+    await runForBases({
+      bases: ["OS", "WOS"],
+      actionName: "Claiming withdrawals",
+      fn: autoClaimWithdraw,
+      options: {
+        signer,
+        liquidityAsset,
+        arm,
+        armName: "Origin",
+        vault,
+        confirm: true,
+      },
+    })
+  )
+    .flat()
+    .filter((requestId) => requestId !== undefined);
 
   console.log(`Claimed requests "${requestIds}"`);
 
   // If any requests were claimed
   if (requestIds?.length > 0) {
     // Add 10% buffer to gas limit
-    let gasLimit = await arm.connect(signer).allocate.estimateGas();
+    let gasLimit = await estimateAllocateGas(arm, signer);
     gasLimit = (gasLimit * 12n) / 10n;
 
     // Allocate any excess liquidity to the lending market
-    const tx = await arm.allocate({ gasLimit });
+    const tx = await callAllocate(arm, signer, { gasLimit });
     await logTxDetails(tx, "allocate");
   }
 };

--- a/src/js/actions/autoRequestEthenaWithdraw.js
+++ b/src/js/actions/autoRequestEthenaWithdraw.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { requestEthenaWithdrawals } = require("../tasks/ethenaQueue");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const erc20Abi = require("../../abis/ERC20.json");
 const ethenaARMAbi = require("../../abis/EthenaARM.json");
@@ -24,13 +25,18 @@ const handler = async (event) => {
   const susde = new ethers.Contract(mainnet.sUSDe, erc20Abi, signer);
   const arm = new ethers.Contract(mainnet.ethenaARM, ethenaARMAbi, signer);
 
-  await requestEthenaWithdrawals({
-    signer,
-    susde,
-    arm,
-    armName: "Ethena",
-    minAmount: "100",
-    thresholdAmount: 1000,
+  await runForBases({
+    bases: ["SUSDE"],
+    actionName: "Requesting withdrawals",
+    fn: requestEthenaWithdrawals,
+    options: {
+      signer,
+      susde,
+      arm,
+      armName: "Ethena",
+      minAmount: "100",
+      thresholdAmount: 1000,
+    },
   });
 };
 

--- a/src/js/actions/autoRequestEtherFiWithdraw.js
+++ b/src/js/actions/autoRequestEtherFiWithdraw.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { requestEtherFiWithdrawals } = require("../tasks/etherfiQueue");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const erc20Abi = require("../../abis/ERC20.json");
 const etherFiARMAbi = require("../../abis/EtherFiARM.json");
@@ -24,13 +25,18 @@ const handler = async (event) => {
   const eeth = new ethers.Contract(mainnet.eETH, erc20Abi, signer);
   const arm = new ethers.Contract(mainnet.etherfiARM, etherFiARMAbi, signer);
 
-  await requestEtherFiWithdrawals({
-    signer,
-    eeth,
-    arm,
-    armName: "EtherFi",
-    minAmount: "0.1",
-    thresholdAmount: 10,
+  await runForBases({
+    bases: ["EETH", "WEETH"],
+    actionName: "Requesting withdrawals",
+    fn: requestEtherFiWithdrawals,
+    options: {
+      signer,
+      eeth,
+      arm,
+      armName: "EtherFi",
+      minAmount: "0.1",
+      thresholdAmount: 10,
+    },
   });
 };
 

--- a/src/js/actions/autoRequestLidoWithdraw.js
+++ b/src/js/actions/autoRequestLidoWithdraw.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { requestLidoWithdrawals } = require("../tasks/lidoQueue");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const erc20Abi = require("../../abis/ERC20.json");
 const lidoARMAbi = require("../../abis/LidoARM.json");
@@ -24,14 +25,19 @@ const handler = async (event) => {
   const steth = new ethers.Contract(mainnet.stETH, erc20Abi, signer);
   const arm = new ethers.Contract(mainnet.lidoARM, lidoARMAbi, signer);
 
-  await requestLidoWithdrawals({
-    signer,
-    steth,
-    arm,
-    armName: "Lido",
-    minAmount: "0.1",
-    thresholdAmount: 120,
-    maxAmount: 300,
+  await runForBases({
+    bases: ["STETH", "WSTETH"],
+    actionName: "Requesting withdrawals",
+    fn: requestLidoWithdrawals,
+    options: {
+      signer,
+      steth,
+      arm,
+      armName: "Lido",
+      minAmount: "0.1",
+      thresholdAmount: 120,
+      maxAmount: 300,
+    },
   });
 };
 

--- a/src/js/actions/autoRequestWithdraw.js
+++ b/src/js/actions/autoRequestWithdraw.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { autoRequestWithdraw } = require("../tasks/liquidityAutomation");
+const { runForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const oethARMAbi = require("../../abis/OethARM.json");
 
@@ -22,12 +23,17 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(mainnet.OethARM, oethARMAbi, signer);
 
-  await autoRequestWithdraw({
-    signer,
-    arm,
-    armName: "Oeth",
-    minAmount: "0.1",
-    thresholdAmount: 10,
+  await runForBases({
+    bases: ["OETH", "WOETH"],
+    actionName: "Requesting withdrawals",
+    fn: autoRequestWithdraw,
+    options: {
+      signer,
+      arm,
+      armName: "Oeth",
+      minAmount: "0.1",
+      thresholdAmount: 10,
+    },
   });
 };
 

--- a/src/js/actions/autoRequestWithdrawSonic.js
+++ b/src/js/actions/autoRequestWithdrawSonic.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { autoRequestWithdraw } = require("../tasks/liquidityAutomation");
+const { runForBases } = require("./priceActionUtils");
 const { sonic } = require("../utils/addresses");
 const armAbi = require("../../abis/OriginARM.json");
 
@@ -22,12 +23,17 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(sonic.OriginARM, armAbi, signer);
 
-  await autoRequestWithdraw({
-    signer,
-    arm,
-    armName: "Origin",
-    minAmount: "300",
-    thresholdAmount: 10000,
+  await runForBases({
+    bases: ["OS", "WOS"],
+    actionName: "Requesting withdrawals",
+    fn: autoRequestWithdraw,
+    options: {
+      signer,
+      arm,
+      armName: "Origin",
+      minAmount: "300",
+      thresholdAmount: 10000,
+    },
   });
 };
 

--- a/src/js/actions/priceActionUtils.js
+++ b/src/js/actions/priceActionUtils.js
@@ -1,0 +1,39 @@
+const legacyBaseMismatch = (error) =>
+  error?.message?.startsWith("Legacy ") &&
+  error.message.includes(" only supports ");
+
+const runForBases = async ({ bases, options, actionName, fn }) => {
+  const results = [];
+  for (const base of bases) {
+    try {
+      console.log(`${actionName} for ${options.armName} ARM ${base}`);
+      results.push(
+        await fn({
+          ...options,
+          base,
+        }),
+      );
+    } catch (error) {
+      if (!legacyBaseMismatch(error)) throw error;
+      console.log(`Skipping ${base}: ${error.message}`);
+    }
+  }
+  return results;
+};
+
+const setPricesForBases = async ({ setPrices, bases, options }) =>
+  runForBases({
+    bases,
+    options,
+    actionName: "Setting prices",
+    fn: (baseOptions) =>
+      setPrices({
+        ...options,
+        base: baseOptions.base,
+      }),
+  });
+
+module.exports = {
+  runForBases,
+  setPricesForBases,
+};

--- a/src/js/actions/setPricesEthena.js
+++ b/src/js/actions/setPricesEthena.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { setPrices } = require("../tasks/armPrices");
+const { setPricesForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const armAbi = require("../../abis/EthenaARM.json");
 
@@ -22,26 +23,30 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(mainnet.ethenaARM, armAbi, signer);
 
-  await setPrices({
-    signer,
-    arm,
-    armName: "Ethena",
-    // sellPrice: 0.9998,
-    // buyPrice: 0.9997,
-    maxSellPrice: 0.99999,
-    minSellPrice: 0.99996,
-    maxBuyPrice: 0.999,
-    minBuyPrice: 0.995,
-    // inch: true,
-    // curve: true,
-    kyber: true,
-    amount: 2000,
-    tolerance: 0.3,
-    fee: 2,
-    offset: 0.4,
-    priceOffset: true,
-    blockTag: "latest",
-    wrapped: true,
+  await setPricesForBases({
+    setPrices,
+    bases: ["SUSDE"],
+    options: {
+      signer,
+      arm,
+      armName: "Ethena",
+      // sellPrice: 0.9998,
+      // buyPrice: 0.9997,
+      maxSellPrice: 0.99999,
+      minSellPrice: 0.99996,
+      maxBuyPrice: 0.999,
+      minBuyPrice: 0.995,
+      // inch: true,
+      // curve: true,
+      kyber: true,
+      amount: 2000,
+      tolerance: 0.3,
+      fee: 2,
+      offset: 0.4,
+      priceOffset: true,
+      blockTag: "latest",
+      wrapped: true,
+    },
   });
 };
 

--- a/src/js/actions/setPricesEtherFi.js
+++ b/src/js/actions/setPricesEtherFi.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { setPrices } = require("../tasks/armPrices");
+const { setPricesForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const armAbi = require("../../abis/EtherFiARM.json");
 
@@ -22,25 +23,29 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(mainnet.etherfiARM, armAbi, signer);
 
-  await setPrices({
-    signer,
-    arm,
-    armName: "EtherFi",
-    // sellPrice: 0.9998,
-    // buyPrice: 0.9997,
-    maxSellPrice: 1.0,
-    minSellPrice: 0.99996,
-    maxBuyPrice: 0.9996,
-    minBuyPrice: 0.9985,
-    // inch: true,
-    // curve: true,
-    kyber: true,
-    amount: 10,
-    tolerance: 0.2,
-    fee: 0.5,
-    offset: 0.3,
-    priceOffset: true,
-    blockTag: "latest",
+  await setPricesForBases({
+    setPrices,
+    bases: ["EETH", "WEETH"],
+    options: {
+      signer,
+      arm,
+      armName: "EtherFi",
+      // sellPrice: 0.9998,
+      // buyPrice: 0.9997,
+      maxSellPrice: 1.0,
+      minSellPrice: 0.99996,
+      maxBuyPrice: 0.9996,
+      minBuyPrice: 0.9985,
+      // inch: true,
+      // curve: true,
+      kyber: true,
+      amount: 10,
+      tolerance: 0.2,
+      fee: 0.5,
+      offset: 0.3,
+      priceOffset: true,
+      blockTag: "latest",
+    },
   });
 };
 

--- a/src/js/actions/setPricesLido.js
+++ b/src/js/actions/setPricesLido.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { setPrices } = require("../tasks/armPrices");
+const { setPricesForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const lidoARMAbi = require("../../abis/LidoARM.json");
 
@@ -22,25 +23,29 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(mainnet.lidoARM, lidoARMAbi, signer);
 
-  await setPrices({
-    signer,
-    arm,
-    armName: "Lido",
-    // sellPrice: 0.9998,
-    // buyPrice: 0.9997,
-    maxSellPrice: 1.0,
-    minSellPrice: 0.9999,
-    maxBuyPrice: 0.999,
-    minBuyPrice: 0.998,
-    // inch: true,
-    // curve: true,
-    kyber: true,
-    amount: 100,
-    tolerance: 0.1,
-    fee: 0.5,
-    offset: 0.1,
-    priceOffset: true,
-    blockTag: "latest",
+  await setPricesForBases({
+    setPrices,
+    bases: ["STETH", "WSTETH"],
+    options: {
+      signer,
+      arm,
+      armName: "Lido",
+      // sellPrice: 0.9998,
+      // buyPrice: 0.9997,
+      maxSellPrice: 1.0,
+      minSellPrice: 0.9999,
+      maxBuyPrice: 0.999,
+      minBuyPrice: 0.998,
+      // inch: true,
+      // curve: true,
+      kyber: true,
+      amount: 100,
+      tolerance: 0.1,
+      fee: 0.5,
+      offset: 0.1,
+      priceOffset: true,
+      blockTag: "latest",
+    },
   });
 };
 

--- a/src/js/actions/setPricesOETH.js
+++ b/src/js/actions/setPricesOETH.js
@@ -2,6 +2,7 @@ const { Defender } = require("@openzeppelin/defender-sdk");
 const { ethers } = require("ethers");
 
 const { setPrices } = require("../tasks/armPrices");
+const { setPricesForBases } = require("./priceActionUtils");
 const { mainnet } = require("../utils/addresses");
 const armAbi = require("../../abis/OriginARM.json");
 
@@ -22,25 +23,29 @@ const handler = async (event) => {
   // References to contracts
   const arm = new ethers.Contract(mainnet.OethARM, armAbi, signer);
 
-  await setPrices({
-    signer,
-    arm,
-    armName: "Oeth",
-    // sellPrice: 0.9998,
-    // buyPrice: 0.9997,
-    maxSellPrice: 0.9999,
-    minSellPrice: 0.9995,
-    maxBuyPrice: 0.9995,
-    minBuyPrice: 0.996,
-    // inch: true,
-    // curve: true,
-    kyber: true,
-    amount: 10,
-    tolerance: 0.3,
-    fee: 5,
-    offset: 1.0,
-    priceOffset: true,
-    blockTag: "latest",
+  await setPricesForBases({
+    setPrices,
+    bases: ["OETH", "WOETH"],
+    options: {
+      signer,
+      arm,
+      armName: "Oeth",
+      // sellPrice: 0.9998,
+      // buyPrice: 0.9997,
+      maxSellPrice: 0.9999,
+      minSellPrice: 0.9995,
+      maxBuyPrice: 0.9995,
+      minBuyPrice: 0.996,
+      // inch: true,
+      // curve: true,
+      kyber: true,
+      amount: 10,
+      tolerance: 0.3,
+      fee: 5,
+      offset: 1.0,
+      priceOffset: true,
+      blockTag: "latest",
+    },
   });
 };
 

--- a/src/js/tasks/admin.js
+++ b/src/js/tasks/admin.js
@@ -3,6 +3,13 @@ const { ethers } = require("ethers");
 const erc20Abi = require("../../abis/ERC20.json");
 
 const { logTxDetails } = require("../utils/txLogger");
+const {
+  callAllocate,
+  estimateAllocateGas,
+  estimateSetArmBufferGas,
+  setArmBuffer,
+  staticCallAllocate,
+} = require("../utils/arm");
 
 const log = require("../utils/logger")("task:admin");
 
@@ -30,8 +37,7 @@ async function allocate({
   threshold,
   execute = true,
   maxGasPrice: maxGasPriceGwei = 10,
-  // V1 on sonic everywhere else V2
-  armContractVersion = "v2",
+  armContractVersion,
 }) {
   const activeMarketAddress = await arm.activeMarket();
   if (activeMarketAddress === ethers.ZeroAddress) {
@@ -46,14 +52,11 @@ async function allocate({
 
   let liquidityDelta;
   if (armContractVersion === "v1") {
-    // The old implementation returns only liquidityDelta
     liquidityDelta = await arm.allocate.staticCall();
   } else if (armContractVersion === "v2") {
-    // 1. Call the allocate static call to get the return values
-    // Returned value is a tuple of two int256 values
     [, liquidityDelta] = await arm.allocate.staticCall();
   } else {
-    throw new Error("Invalid ARM contract version");
+    liquidityDelta = await staticCallAllocate(arm);
   }
 
   const thresholdBN = parseUnits((threshold || "10").toString(), 18);
@@ -110,10 +113,10 @@ async function allocate({
 
   if (execute) {
     // Add 10% buffer to gas limit
-    let gasLimit = await arm.connect(signer).allocate.estimateGas();
+    let gasLimit = await estimateAllocateGas(arm, signer);
     gasLimit = (gasLimit * 11n) / 10n;
 
-    const tx = await arm.connect(signer).allocate({ gasLimit });
+    const tx = await callAllocate(arm, signer, { gasLimit });
     await logTxDetails(tx, "allocate");
   }
 }
@@ -160,11 +163,11 @@ async function setARMBuffer({ arm, signer, buffer }) {
   const bufferBN = parseUnits((buffer || "0").toString(), 18);
 
   // Add 10% buffer to gas limit
-  let gasLimit = await arm.connect(signer).setARMBuffer.estimateGas(bufferBN);
+  let gasLimit = await estimateSetArmBufferGas(arm, signer, bufferBN);
   gasLimit = (gasLimit * 11n) / 10n;
 
   log(`About to set ARM buffer to ${formatUnits(bufferBN)}`);
-  const tx = await arm.connect(signer).setARMBuffer(bufferBN, { gasLimit });
+  const tx = await setArmBuffer(arm, signer, bufferBN, { gasLimit });
   await logTxDetails(tx, "setARMBuffer");
 }
 module.exports = {

--- a/src/js/tasks/admin.js
+++ b/src/js/tasks/admin.js
@@ -170,8 +170,59 @@ async function setARMBuffer({ arm, signer, buffer }) {
   const tx = await setArmBuffer(arm, signer, bufferBN, { gasLimit });
   await logTxDetails(tx, "setARMBuffer");
 }
+
+const CAP_MANAGER_ABI = [
+  "function setLiquidityProviderCaps(address[] liquidityProviders, uint256 cap)",
+  "function setTotalAssetsCap(uint248 totalAssetsCap)",
+];
+
+// Resolve the CapManager contract of an ARM.
+async function resolveCapManager(arm, signer) {
+  const capManagerAddress = await arm.capManager();
+  if (capManagerAddress === ethers.ZeroAddress) {
+    throw new Error("No CapManager configured for the ARM");
+  }
+  return new ethers.Contract(capManagerAddress, CAP_MANAGER_ABI, signer);
+}
+
+async function setTotalAssetsCap({ arm, armName = "ARM", cap, signer }) {
+  const capBn = parseUnits(cap.toString());
+
+  const capManager = await resolveCapManager(arm, signer);
+
+  log(`About to set total asset cap of ${cap} for the ${armName} ARM`);
+  const tx = await capManager.setTotalAssetsCap(capBn);
+  await logTxDetails(tx, "setTotalAssetsCap");
+}
+
+async function setLiquidityProviderCaps({
+  accounts,
+  arm,
+  armName = "ARM",
+  cap,
+  signer,
+}) {
+  const capBn = parseUnits(cap.toString());
+
+  const liquidityProviders = Array.isArray(accounts)
+    ? accounts
+    : accounts.split(",");
+
+  const capManager = await resolveCapManager(arm, signer);
+
+  log(
+    `About to set deposit cap of ${cap} for liquidity providers ${liquidityProviders} for the ${armName} ARM`,
+  );
+  const tx = await capManager.setLiquidityProviderCaps(
+    liquidityProviders,
+    capBn,
+  );
+  await logTxDetails(tx, "setLiquidityProviderCaps");
+}
 module.exports = {
   allocate,
   collectFees,
   setARMBuffer,
+  setLiquidityProviderCaps,
+  setTotalAssetsCap,
 };

--- a/src/js/tasks/armPrices.js
+++ b/src/js/tasks/armPrices.js
@@ -1,17 +1,22 @@
-const { formatUnits, parseUnits } = require("ethers");
+const { formatUnits, parseUnits, ZeroAddress } = require("ethers");
 
 const addresses = require("../utils/addresses");
 const {
   adapterContract,
   parseSwapCap,
   resolveArmBase,
+  setArmPrices,
 } = require("../utils/arm");
 const { abs } = require("../utils/maths");
 const { getCurvePrices } = require("../utils/curve");
 const { getKyberPrices } = require("../utils/kyber");
 const { get1InchPrices } = require("../utils/1Inch");
 const { logTxDetails } = require("../utils/txLogger");
-const { rangeSellPrice, rangeBuyPrice } = require("../utils/pricing");
+const {
+  convertToAsset,
+  rangeSellPrice,
+  rangeBuyPrice,
+} = require("../utils/pricing");
 
 const log = require("../utils/logger")("task:prices");
 
@@ -61,13 +66,13 @@ const setPrices = async (options) => {
   } = options;
 
   // 1. Get current ARM prices
-  const { baseSymbol, baseAddress, liquidityAddress, config } =
-    await resolveArmBase({
-      arm,
-      armName: options.armName,
-      base,
-      blockTag: options.blockTag,
-    });
+  const baseContext = await resolveArmBase({
+    arm,
+    armName: options.armName,
+    base,
+    blockTag: options.blockTag,
+  });
+  const { baseSymbol, baseAddress, liquidityAddress, config } = baseContext;
   const shouldAdjustWrapped =
     wrapped !== undefined ? wrapped : !config.peggedToLiquidityAsset;
 
@@ -119,9 +124,13 @@ const setPrices = async (options) => {
 
       // Adjust price down if a wrapped asset like sUSDe or wstETH
       if (shouldAdjustWrapped) {
-        const adapter = await adapterContract(config.adapter, signer);
         const amountIn = parseUnits(options.amount.toString(), 18);
-        const convertedAssets = await adapter.convertToAssets(amountIn);
+        const convertedAssets =
+          config.adapter === ZeroAddress
+            ? await convertToAsset(baseAddress, options.amount, signer)
+            : await (
+                await adapterContract(config.adapter, signer)
+              ).convertToAssets(amountIn);
         const wrapPrice = (convertedAssets * parseUnits("1")) / amountIn;
 
         log(`Base asset price : ${formatUnits(wrapPrice, 18)} base/liquid`);
@@ -304,15 +313,14 @@ const setPrices = async (options) => {
       return;
     }
 
-    const tx = await arm
-      .connect(signer)
-      .setPrices(
-        baseAddress,
-        targetBuyPrice,
-        targetSellPrice,
-        parseSwapCap(buyAmount),
-        parseSwapCap(sellAmount),
-      );
+    const tx = await setArmPrices({
+      baseContext,
+      signer,
+      buyPrice: targetBuyPrice,
+      sellPrice: targetSellPrice,
+      buyAmount: parseSwapCap(buyAmount),
+      sellAmount: parseSwapCap(sellAmount),
+    });
 
     await logTxDetails(tx, "setPrices", options.confirm);
   } else {

--- a/src/js/tasks/ethenaQueue.js
+++ b/src/js/tasks/ethenaQueue.js
@@ -2,14 +2,22 @@ const { formatUnits, parseUnits } = require("ethers");
 const { ethers } = require("ethers");
 
 const { baseWithdrawAmount } = require("./liquidityAutomation");
-const { adapterContract, resolveArmBase } = require("../utils/arm");
+const {
+  adapterContract,
+  claimBaseAssetWithdrawal,
+  requestBaseAssetWithdrawal,
+  resolveArmBase,
+} = require("../utils/arm");
 const { logTxDetails } = require("../utils/txLogger");
 const log = require("../utils/logger")("task:ethenaQueue");
 
 const requestEthenaWithdrawals = async (options) => {
-  const { signer, arm, amount } = options;
-  const { baseAddress, config } = await resolveArmBase(options);
-  const adapter = await adapterContract(config.adapter, signer);
+  const { signer, amount } = options;
+  const baseContext = await resolveArmBase(options);
+  const requestDelayContract =
+    baseContext.version === "legacy"
+      ? baseContext.compatibleArm.connect(signer)
+      : await adapterContract(baseContext.config.adapter, signer);
 
   // 1. Determine withdrawal amount: Explicit Input OR calculate from ARM and lending market balances
   const withdrawAmount = amount
@@ -18,8 +26,8 @@ const requestEthenaWithdrawals = async (options) => {
   if (!withdrawAmount || withdrawAmount === 0n) return;
 
   // 2. Check the contract request delay has passed since the last withdrawal request
-  const lastRequestTime = await adapter.lastRequestTimestamp();
-  const requestDelay = Number(await adapter.DELAY_REQUEST());
+  const lastRequestTime = await requestDelayContract.lastRequestTimestamp();
+  const requestDelay = Number(await requestDelayContract.DELAY_REQUEST());
   const currentTime = Math.floor(Date.now() / 1000);
   const timeSinceLastRequest = currentTime - Number(lastRequestTime);
   if (timeSinceLastRequest < requestDelay) {
@@ -32,9 +40,11 @@ const requestEthenaWithdrawals = async (options) => {
 
   // 3. Execution
   log(`Requesting withdrawal for ${formatUnits(withdrawAmount)} sUSDe...`);
-  const tx = await arm
-    .connect(signer)
-    .requestBaseAssetRedeem(baseAddress, withdrawAmount);
+  const tx = await requestBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    amount: withdrawAmount,
+  });
   await logTxDetails(tx, "requestEthenaWithdrawal");
 };
 
@@ -43,6 +53,20 @@ const SUSDE_ADDRESS = "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497";
 const SUSDE_ABI = [
   "function cooldowns(address) view returns (uint104,uint152)",
 ];
+
+const legacyEthenaUnstakers = async (legacyArm) => {
+  const unstakers = [];
+  for (let i = 0; ; i++) {
+    try {
+      const unstaker = await legacyArm.unstakers(i);
+      if (unstaker === ethers.ZeroAddress) break;
+      unstakers.push({ address: unstaker, index: i });
+    } catch {
+      break;
+    }
+  }
+  return unstakers;
+};
 
 // --- HELPER: CORE LOGIC ---
 // Fetches data for a list of addresses in PARALLEL (much faster)
@@ -73,8 +97,12 @@ const fetchUnstakerStates = async (signer, adapter, addresses) => {
   return Promise.all(
     addresses.map(async ({ address, index }) => {
       const [cooldownEnd, underlyingAmount] = await contract.cooldowns(address);
-      const shares = await adapter["requestShares(address)"](address);
-      const expectedAssets = await adapter["requestAssets(address)"](address);
+      const shares = adapter
+        ? await adapter["requestShares(address)"](address)
+        : underlyingAmount;
+      const expectedAssets = adapter
+        ? await adapter["requestAssets(address)"](address)
+        : underlyingAmount;
       const amountStr = formatUnits(underlyingAmount, 18);
       const isBalancePositive = underlyingAmount > 0 || shares > 0;
 
@@ -110,11 +138,20 @@ const fetchUnstakerStates = async (signer, adapter, addresses) => {
 // --- MAIN FUNCTIONS ---
 const ethenaWithdrawStatus = async (options) => {
   const { signer } = options;
-  const { config } = await resolveArmBase(options);
-  const adapter = await adapterContract(config.adapter, signer);
+  const baseContext = await resolveArmBase(options);
+  const adapter =
+    baseContext.version === "legacy"
+      ? undefined
+      : await adapterContract(baseContext.config.adapter, signer);
 
   // Reuse the core logic
-  const allStates = await fetchUnstakerStates(signer, adapter);
+  const allStates = await fetchUnstakerStates(
+    signer,
+    adapter,
+    baseContext.version === "legacy"
+      ? await legacyEthenaUnstakers(baseContext.compatibleArm)
+      : undefined,
+  );
 
   // Filter and Log
   const active = allStates.filter((s) => s.hasBalance);
@@ -140,14 +177,23 @@ const ethenaWithdrawStatus = async (options) => {
 };
 
 const claimEthenaWithdrawals = async (options) => {
-  const { arm, signer } = options;
-  const { baseAddress, config } = await resolveArmBase(options);
-  const adapter = await adapterContract(config.adapter, signer);
+  const { signer } = options;
+  const baseContext = await resolveArmBase(options);
+  const adapter =
+    baseContext.version === "legacy"
+      ? undefined
+      : await adapterContract(baseContext.config.adapter, signer);
 
   log(`Checking Ethena adapter withdrawal status...`);
 
   // 1. Fetch all data in parallel first (Fast)
-  const states = await fetchUnstakerStates(signer, adapter);
+  const states = await fetchUnstakerStates(
+    signer,
+    adapter,
+    baseContext.version === "legacy"
+      ? await legacyEthenaUnstakers(baseContext.compatibleArm)
+      : undefined,
+  );
 
   // 2. Log status for everyone
   states.forEach((s) => {
@@ -167,6 +213,21 @@ const claimEthenaWithdrawals = async (options) => {
   if (claimable.length > 0) {
     log(`About to claim ${claimable.length} withdrawal requests...`);
 
+    if (baseContext.version === "legacy") {
+      for (const item of claimable) {
+        log(
+          ` - Processing claim for index ${item.index}, ${item.amount} USDe and address ${item.address}`,
+        );
+        const tx = await claimBaseAssetWithdrawal({
+          baseContext,
+          signer,
+          unstakerIndex: item.index,
+        });
+        await logTxDetails(tx, `claimEthenaWithdrawal for ${item.address}`);
+      }
+      return;
+    }
+
     let shares = 0n;
     for (const item of claimable) {
       log(
@@ -175,9 +236,11 @@ const claimEthenaWithdrawals = async (options) => {
       shares += item.shares;
     }
 
-    const tx = await arm
-      .connect(signer)
-      .claimBaseAssetRedeem(baseAddress, shares);
+    const tx = await claimBaseAssetWithdrawal({
+      baseContext,
+      signer,
+      shares,
+    });
     await logTxDetails(tx, `claimEthenaWithdrawal`);
   } else {
     log("No ready USDe withdrawal requests found.");

--- a/src/js/tasks/etherfiQueue.js
+++ b/src/js/tasks/etherfiQueue.js
@@ -2,7 +2,12 @@ const { gql } = require("@apollo/client/core");
 const { parseUnits } = require("ethers");
 
 const { baseWithdrawAmount } = require("./liquidityAutomation");
-const { adapterContract, resolveArmBase } = require("../utils/arm");
+const {
+  adapterContract,
+  claimBaseAssetWithdrawal,
+  requestBaseAssetWithdrawal,
+  resolveArmBase,
+} = require("../utils/arm");
 const { createApolloClient } = require("../utils/apollo");
 const { logTxDetails } = require("../utils/txLogger");
 
@@ -11,8 +16,9 @@ const log = require("../utils/logger")("task:etherfiQueue");
 const uri = "https://origin.squids.live/ops-squid/graphql";
 
 const requestEtherFiWithdrawals = async (options) => {
-  const { signer, arm, amount } = options;
-  const { baseSymbol, baseAddress } = await resolveArmBase(options);
+  const { signer, amount } = options;
+  const baseContext = await resolveArmBase(options);
+  const { baseSymbol } = baseContext;
 
   const withdrawAmount = amount
     ? parseUnits(amount.toString())
@@ -20,17 +26,18 @@ const requestEtherFiWithdrawals = async (options) => {
   if (!withdrawAmount || withdrawAmount === 0n) return;
 
   log(`Requesting withdrawal for ${withdrawAmount} ${baseSymbol}...`);
-  const tx = await arm
-    .connect(signer)
-    .requestBaseAssetRedeem(baseAddress, withdrawAmount);
+  const tx = await requestBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    amount: withdrawAmount,
+  });
 
   await logTxDetails(tx, "requestEtherFiWithdrawal");
 };
 
 const claimEtherFiWithdrawals = async (options) => {
-  const { arm, signer, id } = options;
-  const { baseAddress, config } = await resolveArmBase(options);
-  const adapter = await adapterContract(config.adapter, signer);
+  const { signer, id } = options;
+  const baseContext = await resolveArmBase(options);
 
   const requestIds = id
     ? // If an id is provided, just claim that one
@@ -38,6 +45,24 @@ const claimEtherFiWithdrawals = async (options) => {
     : // Get the outstanding EtherFi withdrawal requests for the ARM
       await claimableEtherFiRequests();
 
+  if (baseContext.version === "legacy") {
+    if (requestIds.length > 0) {
+      log(
+        `About to claim ${requestIds.length} withdrawal requests with\nids: ${requestIds}`,
+      );
+      const tx = await claimBaseAssetWithdrawal({
+        baseContext,
+        signer,
+        requestIds,
+      });
+      await logTxDetails(tx, "claim EtherFi withdraws");
+    } else {
+      log("No EtherFi withdrawal requests to claim");
+    }
+    return;
+  }
+
+  const adapter = await adapterContract(baseContext.config.adapter, signer);
   let shares = 0n;
   for (const requestId of requestIds) {
     shares += await adapter["requestShares(uint256)"](requestId);
@@ -51,9 +76,11 @@ const claimEtherFiWithdrawals = async (options) => {
   log(
     `About to claim ${requestIds.length} withdrawal requests with\nids: ${requestIds}`,
   );
-  const tx = await arm
-    .connect(signer)
-    .claimBaseAssetRedeem(baseAddress, shares);
+  const tx = await claimBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    shares,
+  });
   await logTxDetails(tx, "claim EtherFi withdraws");
 };
 

--- a/src/js/tasks/lido.js
+++ b/src/js/tasks/lido.js
@@ -20,7 +20,11 @@ const {
   parseDeployedAddress,
 } = require("../utils/addressParser");
 const { resolveAsset } = require("../utils/assets");
-const { adapterContract, resolveArmBase } = require("../utils/arm");
+const {
+  adapterContract,
+  getArmBuffer,
+  resolveArmBase,
+} = require("../utils/arm");
 const { logWithdrawalQueue } = require("./liquidity");
 const { swap } = require("./swap");
 
@@ -121,7 +125,12 @@ const snapLido = async ({
   if (lido) {
     await logLidoQueue(signer, blockTag);
 
-    await logLidoWithdrawals(baseContext.config.adapter, blockTag);
+    await logLidoWithdrawals(
+      baseContext.version === "legacy"
+        ? await lidoARM.getAddress()
+        : baseContext.config.adapter,
+      blockTag,
+    );
   }
   if (queue) {
     await logWithdrawalQueue(lidoARM, blockTag, liquidityWeth);
@@ -301,7 +310,7 @@ const logAssets = async (arm, blockTag, baseContext) => {
     blockTag,
   });
 
-  const buffer = await arm.armBuffer({ blockTag });
+  const buffer = await getArmBuffer(arm, blockTag);
   const bufferPercent = (buffer * 10000n) / parseUnits("1");
 
   const { amount: morphoRewards } = await getMerklRewards({

--- a/src/js/tasks/lidoQueue.js
+++ b/src/js/tasks/lidoQueue.js
@@ -1,34 +1,123 @@
 const { formatUnits, parseUnits } = require("ethers");
 const { baseWithdrawAmount } = require("./liquidityAutomation");
 
-const { adapterContract, resolveArmBase } = require("../utils/arm");
+const {
+  adapterContract,
+  claimBaseAssetWithdrawal,
+  requestBaseAssetWithdrawal,
+  resolveArmBase,
+} = require("../utils/arm");
 const { logTxDetails } = require("../utils/txLogger");
 
 const log = require("../utils/logger")("task:lidoQueue");
 
 const requestLidoWithdrawals = async (options) => {
-  const { amount, signer, arm } = options;
-  const { baseSymbol, baseAddress } = await resolveArmBase(options);
+  const { amount, signer } = options;
+  const baseContext = await resolveArmBase(options);
+  const { baseSymbol } = baseContext;
 
   const withdrawAmount = amount
     ? parseUnits(amount.toString())
     : await baseWithdrawAmount(options);
   if (!withdrawAmount || withdrawAmount === 0n) return;
 
+  if (baseContext.version === "legacy") {
+    const maxAmountBI =
+      options.maxAmount === undefined
+        ? withdrawAmount
+        : parseUnits(options.maxAmount.toString());
+    let remainingAmount = withdrawAmount;
+    while (remainingAmount > 0n) {
+      const requestAmount =
+        remainingAmount > maxAmountBI ? maxAmountBI : remainingAmount;
+      log(
+        `About to request ${formatUnits(
+          requestAmount,
+        )} ${baseSymbol} withdrawal from Lido`,
+      );
+      remainingAmount -= requestAmount;
+    }
+  }
+
   log(
     `About to request ${formatUnits(withdrawAmount)} ${baseSymbol} withdrawal from Lido`,
   );
 
-  const tx = await arm
-    .connect(signer)
-    .requestBaseAssetRedeem(baseAddress, withdrawAmount);
+  const tx = await requestBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    amount: withdrawAmount,
+    maxAmount: options.maxAmount,
+  });
 
   await logTxDetails(tx, "requestRedeem");
 };
 
 const claimLidoWithdrawals = async (options) => {
-  const { signer, arm, id } = options;
-  const { baseAddress, config } = await resolveArmBase(options);
+  const { signer, id, withdrawalQueue } = options;
+  const baseContext = await resolveArmBase(options);
+  const { config } = baseContext;
+
+  if (baseContext.version === "legacy") {
+    if (!withdrawalQueue) {
+      throw new Error("Legacy Lido claims require the Lido withdrawal queue");
+    }
+
+    const finalizedIds = [];
+    if (id) {
+      finalizedIds.push(id);
+    } else {
+      const requestIds = await withdrawalQueue.getWithdrawalRequests(
+        await baseContext.arm.getAddress(),
+      );
+      log(`Found ${requestIds.length} withdrawal requests`);
+
+      if (requestIds.length === 0) return;
+
+      const statuses = await withdrawalQueue.getWithdrawalStatus([
+        ...requestIds,
+      ]);
+      log(`Got ${statuses.length} statuses`);
+
+      for (const [index, status] of statuses.entries()) {
+        const requestId = requestIds[index];
+        log(
+          `Withdrawal request ${requestId} finalized ${status.isFinalized}, claimed ${status.isClaimed}`,
+        );
+        if (status.isFinalized && !status.isClaimed) {
+          finalizedIds.push(requestId);
+        }
+      }
+    }
+
+    if (finalizedIds.length === 0) {
+      log("No finalized Lido withdrawal requests to claim");
+      return;
+    }
+
+    const sortedFinalizedIds = finalizedIds.sort((a, b) =>
+      a > b ? 1 : a < b ? -1 : 0,
+    );
+    const lastIndex = await withdrawalQueue.getLastCheckpointIndex();
+    const hintIds = await withdrawalQueue.findCheckpointHints(
+      sortedFinalizedIds,
+      "1",
+      lastIndex,
+    );
+
+    log(
+      `About to claim ${sortedFinalizedIds.length} withdrawal requests with\nids: ${sortedFinalizedIds}\nhints: ${hintIds}`,
+    );
+    const tx = await claimBaseAssetWithdrawal({
+      baseContext,
+      signer,
+      requestIds: sortedFinalizedIds,
+      hintIds: hintIds.toArray(),
+    });
+    await logTxDetails(tx, "claim Lido withdraws");
+    return;
+  }
+
   const adapter = await adapterContract(config.adapter, signer);
 
   let shares;
@@ -47,9 +136,11 @@ const claimLidoWithdrawals = async (options) => {
   }
 
   log(`About to claim ${formatUnits(shares)} Lido adapter shares`);
-  const tx = await arm
-    .connect(signer)
-    .claimBaseAssetRedeem(baseAddress, shares);
+  const tx = await claimBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    shares,
+  });
   await logTxDetails(tx, "claimRedeem");
 };
 

--- a/src/js/tasks/liquidity.js
+++ b/src/js/tasks/liquidity.js
@@ -15,7 +15,13 @@ const { getMerklRewards } = require("../utils/merkl");
 const { convertToAsset } = require("../utils/pricing");
 const { logTxDetails } = require("../utils/txLogger");
 const { getSigner } = require("../utils/signers");
-const { adapterContract, resolveArmBase } = require("../utils/arm");
+const {
+  adapterContract,
+  claimBaseAssetWithdrawal,
+  getArmBuffer,
+  requestBaseAssetWithdrawal,
+  resolveArmBase,
+} = require("../utils/arm");
 
 const log = require("../utils/logger")("task:liquidity");
 
@@ -24,17 +30,20 @@ dayjs.extend(utc);
 
 const requestWithdraw = async ({ amount, signer, arm, armName, base }) => {
   const amountBI = parseUnits(amount.toString(), 18);
-  const { baseAddress, baseSymbol } = await resolveArmBase({
+  const baseContext = await resolveArmBase({
     arm,
     armName,
     base,
   });
+  const { baseSymbol } = baseContext;
 
   log(`About to request ${amount} ${baseSymbol} withdrawal`);
 
-  const tx = await arm
-    .connect(signer)
-    .requestBaseAssetRedeem(baseAddress, amountBI);
+  const tx = await requestBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    amount: amountBI,
+  });
 
   await logTxDetails(tx, "requestRedeem");
 
@@ -42,16 +51,22 @@ const requestWithdraw = async ({ amount, signer, arm, armName, base }) => {
 };
 
 const claimWithdraw = async ({ id, signer, arm, armName, base }) => {
-  const { baseAddress, config } = await resolveArmBase({
+  const baseContext = await resolveArmBase({
     arm,
     armName,
     base,
   });
-  const adapter = await adapterContract(config.adapter, signer);
-  const shares = await adapter["requestShares(uint256)"](id);
-  const tx = await arm
-    .connect(signer)
-    .claimBaseAssetRedeem(baseAddress, shares);
+  let shares = 0n;
+  if (baseContext.version !== "legacy") {
+    const adapter = await adapterContract(baseContext.config.adapter, signer);
+    shares = await adapter["requestShares(uint256)"](id);
+  }
+  const tx = await claimBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    shares,
+    requestIds: [id],
+  });
 
   log(`About to claim withdrawal request ${id}`);
   await logTxDetails(tx, "claimRedeem");
@@ -187,9 +202,16 @@ const logLiquidity = async ({ block, arm, base }) => {
   const baseBalance = await baseAsset.balanceOf(armAddress, { blockTag });
   const baseBalanceAssets = config.peggedToLiquidityAsset
     ? baseBalance
-    : await (
-        await adapterContract(config.adapter, armContract.runner)
-      ).convertToAssets(baseBalance);
+    : config.adapter === ethers.ZeroAddress
+      ? await (
+          await ethers.getContractAt(
+            ["function convertToAssets(uint256) view returns (uint256)"],
+            baseAddress,
+          )
+        ).convertToAssets(baseBalance, { blockTag })
+      : await (
+          await adapterContract(config.adapter, armContract.runner)
+        ).convertToAssets(baseBalance);
 
   const baseWithdraws = config.pendingRedeemAssets;
 
@@ -241,7 +263,7 @@ const logLiquidity = async ({ block, arm, base }) => {
     blockTag,
   });
   const accruedFees = await armContract.feesAccrued({ blockTag });
-  const buffer = await armContract.armBuffer({ blockTag });
+  const buffer = await getArmBuffer(armContract, blockTag);
   const bufferPercent = (buffer * 10000n) / parseUnits("1");
   const lendingMarketLiquidityShortfall =
     lendingMarketBalance - lendingMarketRedeemableBalance;

--- a/src/js/tasks/liquidityAutomation.js
+++ b/src/js/tasks/liquidityAutomation.js
@@ -3,7 +3,12 @@ const dayjs = require("dayjs");
 const utc = require("dayjs/plugin/utc");
 
 const { claimableRequests } = require("../utils/armQueue");
-const { adapterContract, resolveArmBase } = require("../utils/arm");
+const {
+  adapterContract,
+  claimBaseAssetWithdrawal,
+  requestBaseAssetWithdrawal,
+  resolveArmBase,
+} = require("../utils/arm");
 const { logTxDetails } = require("../utils/txLogger");
 
 const log = require("../utils/logger")("task:liquidity");
@@ -12,8 +17,9 @@ const log = require("../utils/logger")("task:liquidity");
 dayjs.extend(utc);
 
 const autoRequestWithdraw = async (options) => {
-  const { amount, arm, signer } = options;
-  const { baseSymbol, baseAddress } = await resolveArmBase(options);
+  const { amount, signer } = options;
+  const baseContext = await resolveArmBase(options);
+  const { baseSymbol } = baseContext;
 
   const withdrawAmount = amount
     ? parseUnits(amount.toString())
@@ -24,9 +30,11 @@ const autoRequestWithdraw = async (options) => {
     `About to request withdrawal of ${formatUnits(withdrawAmount)} ${baseSymbol}`,
   );
 
-  const tx = await arm
-    .connect(signer)
-    .requestBaseAssetRedeem(baseAddress, withdrawAmount);
+  const tx = await requestBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    amount: withdrawAmount,
+  });
   await logTxDetails(tx, "requestRedeem");
 };
 
@@ -39,8 +47,12 @@ const autoClaimWithdraw = async ({
   vault,
   confirm,
 }) => {
-  const { baseAddress, config } = await resolveArmBase({ arm, armName, base });
-  const adapter = await adapterContract(config.adapter, signer);
+  const baseContext = await resolveArmBase({ arm, armName, base });
+  const { config } = baseContext;
+  const adapter =
+    baseContext.version === "legacy"
+      ? undefined
+      : await adapterContract(config.adapter, signer);
   const liquiditySymbol = await liquidityAsset.symbol();
   // Get amount of requests that have already been claimed
   const { claimed } = await vault.withdrawalQueueMetadata();
@@ -67,7 +79,10 @@ const autoClaimWithdraw = async ({
 
   // get claimable withdrawal requests
   let requestIds = await claimableRequests({
-    withdrawer: config.adapter,
+    withdrawer:
+      baseContext.version === "legacy"
+        ? await arm.getAddress()
+        : config.adapter,
     queuedAmountClaimable,
     claimCutoff,
   });
@@ -80,13 +95,18 @@ const autoClaimWithdraw = async ({
   log(`About to claim requests: ${requestIds} `);
 
   let shares = 0n;
-  for (const requestId of requestIds) {
-    shares += await adapter["requestShares(uint256)"](requestId);
+  if (baseContext.version !== "legacy") {
+    for (const requestId of requestIds) {
+      shares += await adapter["requestShares(uint256)"](requestId);
+    }
   }
 
-  const tx = await arm
-    .connect(signer)
-    .claimBaseAssetRedeem(baseAddress, shares);
+  const tx = await claimBaseAssetWithdrawal({
+    baseContext,
+    signer,
+    shares,
+    requestIds,
+  });
   await logTxDetails(tx, "claimRedeem", confirm);
 
   return requestIds;

--- a/src/js/tasks/liquidityProvider.js
+++ b/src/js/tasks/liquidityProvider.js
@@ -1,5 +1,9 @@
 const { parseUnits } = require("ethers");
 
+const {
+  setLiquidityProviderCaps: setLiquidityProviderCapsCore,
+  setTotalAssetsCap: setTotalAssetsCapCore,
+} = require("./admin");
 const { getSigner } = require("../utils/signers");
 const {
   parseDeployedAddress,
@@ -95,42 +99,27 @@ async function claimRedeemARM({ arm, id }) {
 
 async function setLiquidityProviderCaps({ accounts, arm, cap }) {
   const signer = await getSigner();
-
-  const capBn = parseUnits(cap.toString());
-
-  const liquidityProviders = accounts.split(",");
-
   const armContract = await resolveArmContract(arm);
-  const capManagerAddress = await armContract.capManager();
-  const capManager = await ethers.getContractAt(
-    "CapManager",
-    capManagerAddress,
-  );
 
-  log(
-    `About to set deposit cap of ${cap} WETH for liquidity providers ${liquidityProviders} for the ${arm} ARM`,
-  );
-  const tx = await capManager
-    .connect(signer)
-    .setLiquidityProviderCaps(liquidityProviders, capBn);
-  await logTxDetails(tx, "setLiquidityProviderCaps");
+  await setLiquidityProviderCapsCore({
+    accounts,
+    arm: armContract,
+    armName: arm,
+    cap,
+    signer,
+  });
 }
 
 async function setTotalAssetsCap({ arm, cap }) {
   const signer = await getSigner();
-
-  const capBn = parseUnits(cap.toString());
-
   const armContract = await resolveArmContract(arm);
-  const capManagerAddress = await armContract.capManager();
-  const capManager = await ethers.getContractAt(
-    "CapManager",
-    capManagerAddress,
-  );
 
-  log(`About to set total asset cap of ${cap} for the ${arm} ARM`);
-  const tx = await capManager.connect(signer).setTotalAssetsCap(capBn);
-  await logTxDetails(tx, "setTotalAssetsCap");
+  await setTotalAssetsCapCore({
+    arm: armContract,
+    armName: arm,
+    cap,
+    signer,
+  });
 }
 
 module.exports = {

--- a/src/js/tasks/osSiloPrice.js
+++ b/src/js/tasks/osSiloPrice.js
@@ -10,7 +10,7 @@ const { get1InchSwapQuote } = require("../utils/1Inch");
 const { flyTradeQuote } = require("../utils/fly");
 const { logTxDetails } = require("../utils/txLogger");
 const { rangeSellPrice, rangeBuyPrice } = require("../utils/pricing");
-const { parseSwapCap, resolveArmBase } = require("../utils/arm");
+const { parseSwapCap, resolveArmBase, setArmPrices } = require("../utils/arm");
 
 const log = require("../utils/logger")("task:osSiloPrice");
 
@@ -36,11 +36,12 @@ const setOSSiloPrice = async (options) => {
   } = options;
 
   log("Computing optimal price...");
-  const { baseAddress, config } = await resolveArmBase({
+  const baseContext = await resolveArmBase({
     arm,
     armName: "Origin",
     blockTag,
   });
+  const { config } = baseContext;
 
   // 1. Get annual rate scaled to 1e18 from lending markets with added premium
   const currentAnnualLendingRate = await getLendingMarketRate(
@@ -181,15 +182,14 @@ const setOSSiloPrice = async (options) => {
     }
 
     log("Updating ARM prices...");
-    const tx = await arm
-      .connect(signer)
-      .setPrices(
-        baseAddress,
-        targetBuyPrice.toString(),
-        targetSellPrice.toString(),
-        parseSwapCap(),
-        parseSwapCap(),
-      );
+    const tx = await setArmPrices({
+      baseContext,
+      signer,
+      buyPrice: targetBuyPrice.toString(),
+      sellPrice: targetSellPrice.toString(),
+      buyAmount: parseSwapCap(),
+      sellAmount: parseSwapCap(),
+    });
 
     await logTxDetails(tx, "setOSSiloPrice");
   }

--- a/src/js/tasks/tasks.js
+++ b/src/js/tasks/tasks.js
@@ -617,13 +617,13 @@ task("claimRedeemARM").setAction(async (_, __, runSuper) => {
 subtask("setLiquidityProviderCaps", "Set deposit cap for liquidity providers")
   .addParam(
     "arm",
-    "Name of the ARM. eg Lido, Origin or EtherFi",
-    "Lido",
+    "Name of the ARM. eg Lido, EtherFi or Ethena",
+    undefined,
     types.string,
   )
   .addParam(
     "cap",
-    "Amount of WETH not scaled to 18 decimals",
+    "Deposit cap per account in liquidity asset units, not scaled to 18 decimals. eg 20000 = 20,000 USDe",
     undefined,
     types.float,
   )
@@ -641,13 +641,13 @@ task("setLiquidityProviderCaps").setAction(async (_, __, runSuper) => {
 subtask("setTotalAssetsCap", "Set total assets cap")
   .addParam(
     "arm",
-    "Name of the ARM. eg Lido, Origin or EtherFi",
-    "Lido",
+    "Name of the ARM. eg Lido, EtherFi or Ethena",
+    undefined,
     types.string,
   )
   .addParam(
     "cap",
-    "Amount of WETH not scaled to 18 decimals",
+    "Total assets cap in liquidity asset units, not scaled to 18 decimals. eg 100000 = 100,000 USDe",
     undefined,
     types.float,
   )
@@ -1069,13 +1069,13 @@ task("allocate").setAction(async (_, __, runSuper) => {
 });
 
 subtask("setARMBuffer", "Set the ARM buffer percentage")
-  .addOptionalParam(
+  .addParam(
     "arm",
     "The name of the ARM. eg Lido, Origin, EtherFi or Ethena",
-    "Origin",
+    undefined,
     types.string,
   )
-  .addOptionalParam(
+  .addParam(
     "buffer",
     "The new buffer value (eg 0.1 -> 10%)",
     undefined,

--- a/src/js/utils/arm.js
+++ b/src/js/utils/arm.js
@@ -4,6 +4,34 @@ const addresses = require("./addresses");
 const { parseAddress } = require("./addressParser");
 
 const MAX_SWAP_LIQUIDITY = (1n << 128n) - 1n;
+const PRICE_SCALE = parseUnits("1", 36);
+
+const LEGACY_ARM_ABI = [
+  "function activeMarket() view returns (address)",
+  "function allocate() returns (int256)",
+  "function armBuffer() view returns (uint256)",
+  "function baseAsset() view returns (address)",
+  "function DELAY_REQUEST() view returns (uint256)",
+  "function claimEtherFiWithdrawals(uint256[])",
+  "function claimBaseWithdrawals(uint8)",
+  "function claimLidoWithdrawals(uint256[],uint256[])",
+  "function claimOriginWithdrawals(uint256[]) returns (uint256)",
+  "function crossPrice() view returns (uint256)",
+  "function etherfiWithdrawalQueueAmount() view returns (uint256)",
+  "function lidoWithdrawalQueueAmount() view returns (uint256)",
+  "function liquidityAsset() view returns (address)",
+  "function lastRequestTimestamp() view returns (uint32)",
+  "function requestEtherFiWithdrawal(uint256) returns (uint256)",
+  "function requestBaseWithdrawal(uint256)",
+  "function requestLidoWithdrawals(uint256[]) returns (uint256[])",
+  "function requestOriginWithdrawal(uint256) returns (uint256)",
+  "function setARMBuffer(uint256)",
+  "function setPrices(uint256,uint256,uint256,uint256)",
+  "function traderate0() view returns (uint256)",
+  "function traderate1() view returns (uint256)",
+  "function unstakers(uint256) view returns (address)",
+  "function vaultWithdrawalAmount() view returns (uint256)",
+];
 
 const ARM_BASES = {
   Lido: { defaultBase: "STETH", liquidity: "WETH" },
@@ -24,6 +52,21 @@ const BASE_ALIASES = {
   OS: "OS",
   WOS: "WOS",
 };
+
+const assetAddressesBySymbol = () => ({
+  STETH: addresses.mainnet.stETH,
+  WSTETH: addresses.mainnet.wstETH,
+  EETH: addresses.mainnet.eETH,
+  WEETH: addresses.mainnet.weETH,
+  SUSDE: addresses.mainnet.sUSDe,
+  OETH: addresses.mainnet.OETHProxy,
+  WOETH: addresses.mainnet.WOETH,
+  OS: addresses.sonic.OSonicProxy,
+  WOS: addresses.sonic.WOS,
+  WETH: addresses.mainnet.WETH,
+  USDE: addresses.mainnet.USDe,
+  WS: addresses.sonic.WS,
+});
 
 const normalizeBaseSymbol = (base) => {
   if (!base) return undefined;
@@ -46,22 +89,19 @@ const liquiditySymbol = (armName) => {
 };
 
 const resolveAssetAddress = async (symbol) => {
-  const address = {
-    STETH: addresses.mainnet.stETH,
-    WSTETH: addresses.mainnet.wstETH,
-    EETH: addresses.mainnet.eETH,
-    WEETH: addresses.mainnet.weETH,
-    SUSDE: addresses.mainnet.sUSDe,
-    OETH: addresses.mainnet.OETHProxy,
-    WOETH: addresses.mainnet.WOETH,
-    OS: addresses.sonic.OSonicProxy,
-    WOS: addresses.sonic.WOS,
-    WETH: addresses.mainnet.WETH,
-    USDE: addresses.mainnet.USDe,
-    WS: addresses.sonic.WS,
-  }[symbol];
+  const address = assetAddressesBySymbol()[symbol];
 
   return address ?? parseAddress(symbol);
+};
+
+const symbolForAddress = async (address) => {
+  const lowerAddress = address.toLowerCase();
+  for (const [symbol, knownAddress] of Object.entries(
+    assetAddressesBySymbol(),
+  )) {
+    if (knownAddress?.toLowerCase() === lowerAddress) return symbol;
+  }
+  return address;
 };
 
 const parseSwapCap = (amount) => {
@@ -83,24 +123,311 @@ const toConfigObject = (config) => ({
   adapter: config.adapter ?? config[7],
 });
 
-const resolveArmBase = async ({ arm, armName, base, blockTag }) => {
-  const baseSymbol = normalizeBaseSymbol(base) ?? defaultBaseSymbol(armName);
-  const baseAddress = await resolveAssetAddress(baseSymbol);
-  const liquidityAddress = await arm.liquidityAsset({ blockTag });
-  const config = toConfigObject(
-    await arm.baseAssetConfigs(baseAddress, { blockTag }),
+const callOptional = async (contract, fn, args = [], fallback = 0n) => {
+  if (!contract[fn]) return fallback;
+  try {
+    return await contract[fn](...args);
+  } catch {
+    return fallback;
+  }
+};
+
+const isMissingSelectorError = (err) =>
+  (err instanceof TypeError && err.message.includes("is not a function")) ||
+  err?.code === "BAD_DATA" ||
+  err?.code === "CALL_EXCEPTION" ||
+  err?.data === "0x" ||
+  err?.info?.error?.data === "0x";
+
+const legacyArmContract = async (arm, signerOrProvider) =>
+  new Contract(
+    await arm.getAddress(),
+    LEGACY_ARM_ABI,
+    signerOrProvider ?? arm.runner,
   );
 
-  if (config.adapter === ZeroAddress) {
-    throw new Error(`${baseSymbol} is not configured on ${armName} ARM`);
+const legacyPendingRedeemAssets = async (legacyArm, armName, blockTag) => {
+  const opts = blockTag === undefined ? [] : [{ blockTag }];
+  if (armName === "Lido") {
+    return callOptional(legacyArm, "lidoWithdrawalQueueAmount", opts);
+  }
+  if (armName === "EtherFi") {
+    return callOptional(legacyArm, "etherfiWithdrawalQueueAmount", opts);
+  }
+  if (armName === "Oeth" || armName === "Origin") {
+    return callOptional(legacyArm, "vaultWithdrawalAmount", opts);
+  }
+  return 0n;
+};
+
+const resolveLegacyArmBase = async ({
+  arm,
+  armName,
+  requestedBaseSymbol,
+  requestedBaseAddress,
+  blockTag,
+}) => {
+  const legacyArm = await legacyArmContract(arm);
+  const callOpts = blockTag === undefined ? [] : [{ blockTag }];
+  const [
+    legacyBaseAddress,
+    liquidityAddress,
+    traderate0,
+    buyPrice,
+    crossPrice,
+  ] = await Promise.all([
+    legacyArm.baseAsset(...callOpts),
+    legacyArm.liquidityAsset(...callOpts),
+    legacyArm.traderate0(...callOpts),
+    legacyArm.traderate1(...callOpts),
+    legacyArm.crossPrice(...callOpts),
+  ]);
+
+  if (
+    requestedBaseAddress &&
+    requestedBaseAddress.toLowerCase() !== legacyBaseAddress.toLowerCase()
+  ) {
+    const legacyBaseSymbol = await symbolForAddress(legacyBaseAddress);
+    throw new Error(
+      `Legacy ${armName} ARM only supports ${legacyBaseSymbol} as its base asset`,
+    );
   }
 
+  const baseSymbol =
+    requestedBaseSymbol ?? (await symbolForAddress(legacyBaseAddress));
+  const pendingRedeemAssets = await legacyPendingRedeemAssets(
+    legacyArm,
+    armName,
+    blockTag,
+  );
+
   return {
+    version: "legacy",
+    armName,
+    arm,
+    compatibleArm: legacyArm,
     baseSymbol,
-    baseAddress,
+    baseAddress: legacyBaseAddress,
     liquidityAddress,
-    config,
+    config: {
+      buyPrice,
+      sellPrice: (PRICE_SCALE * PRICE_SCALE) / traderate0,
+      buyLiquidityRemaining: MAX_SWAP_LIQUIDITY,
+      sellLiquidityRemaining: MAX_SWAP_LIQUIDITY,
+      crossPrice,
+      pendingRedeemAssets,
+      peggedToLiquidityAsset: armName !== "Ethena",
+      adapter: ZeroAddress,
+    },
   };
+};
+
+const resolveArmBase = async ({ arm, armName, base, blockTag }) => {
+  const requestedBaseSymbol = normalizeBaseSymbol(base);
+  const baseSymbol = requestedBaseSymbol ?? defaultBaseSymbol(armName);
+  const baseAddress = await resolveAssetAddress(baseSymbol);
+
+  let liquidityAddress;
+  try {
+    liquidityAddress = await arm.liquidityAsset({ blockTag });
+    const config = toConfigObject(
+      await arm.baseAssetConfigs(baseAddress, { blockTag }),
+    );
+
+    if (config.adapter === ZeroAddress) {
+      throw new Error(`${baseSymbol} is not configured on ${armName} ARM`);
+    }
+
+    return {
+      version: "multiBase",
+      armName,
+      arm,
+      compatibleArm: arm,
+      baseSymbol,
+      baseAddress,
+      liquidityAddress,
+      config,
+    };
+  } catch (err) {
+    if (!isMissingSelectorError(err)) throw err;
+    return resolveLegacyArmBase({
+      arm,
+      armName,
+      requestedBaseSymbol,
+      requestedBaseAddress: requestedBaseSymbol ? baseAddress : undefined,
+      blockTag,
+    });
+  }
+};
+
+const setArmPrices = async ({
+  baseContext,
+  signer,
+  buyPrice,
+  sellPrice,
+  buyAmount,
+  sellAmount,
+}) => {
+  if (baseContext.version === "legacy") {
+    return baseContext.compatibleArm
+      .connect(signer)
+      .setPrices(buyPrice, sellPrice, buyAmount, sellAmount);
+  }
+
+  return baseContext.arm
+    .connect(signer)
+    .setPrices(
+      baseContext.baseAddress,
+      buyPrice,
+      sellPrice,
+      buyAmount,
+      sellAmount,
+    );
+};
+
+const requestBaseAssetWithdrawal = async ({
+  baseContext,
+  signer,
+  amount,
+  maxAmount,
+}) => {
+  if (baseContext.version !== "legacy") {
+    return baseContext.arm
+      .connect(signer)
+      .requestBaseAssetRedeem(baseContext.baseAddress, amount);
+  }
+
+  const legacyArm = baseContext.compatibleArm.connect(signer);
+  if (baseContext.armName === "Lido" || baseContext.baseSymbol === "STETH") {
+    const maxRequestAmount =
+      maxAmount === undefined ? amount : parseUnits(maxAmount.toString(), 18);
+    const requestAmounts = [];
+    let remainingAmount = amount;
+    while (remainingAmount > 0n) {
+      const requestAmount =
+        remainingAmount > maxRequestAmount ? maxRequestAmount : remainingAmount;
+      requestAmounts.push(requestAmount);
+      remainingAmount -= requestAmount;
+    }
+    return legacyArm.requestLidoWithdrawals(requestAmounts);
+  }
+  if (baseContext.armName === "EtherFi") {
+    return legacyArm.requestEtherFiWithdrawal(amount);
+  }
+  if (baseContext.armName === "Oeth" || baseContext.armName === "Origin") {
+    return legacyArm.requestOriginWithdrawal(amount);
+  }
+  if (baseContext.armName === "Ethena") {
+    return legacyArm.requestBaseWithdrawal(amount);
+  }
+
+  throw new Error(
+    `Legacy ${baseContext.armName} ARM withdrawals are unsupported`,
+  );
+};
+
+const claimBaseAssetWithdrawal = async ({
+  baseContext,
+  signer,
+  shares,
+  requestIds,
+  hintIds,
+  unstakerIndex,
+}) => {
+  if (baseContext.version !== "legacy") {
+    return baseContext.arm
+      .connect(signer)
+      .claimBaseAssetRedeem(baseContext.baseAddress, shares);
+  }
+
+  const legacyArm = baseContext.compatibleArm.connect(signer);
+  if (baseContext.armName === "Lido" || baseContext.baseSymbol === "STETH") {
+    return legacyArm.claimLidoWithdrawals(requestIds, hintIds);
+  }
+  if (baseContext.armName === "EtherFi") {
+    return legacyArm.claimEtherFiWithdrawals(requestIds);
+  }
+  if (baseContext.armName === "Oeth" || baseContext.armName === "Origin") {
+    return legacyArm.claimOriginWithdrawals(requestIds);
+  }
+  if (baseContext.armName === "Ethena") {
+    return legacyArm.claimBaseWithdrawals(unstakerIndex);
+  }
+
+  throw new Error(`Legacy ${baseContext.armName} ARM claims are unsupported`);
+};
+
+const staticCallAllocate = async (arm) => {
+  try {
+    const result = await arm.allocate.staticCall();
+    return Array.isArray(result) ? result[1] : result;
+  } catch (err) {
+    if (!isMissingSelectorError(err)) throw err;
+    const legacyArm = await legacyArmContract(arm);
+    return legacyArm.allocate.staticCall();
+  }
+};
+
+const estimateAllocateGas = async (arm, signer) => {
+  try {
+    return await arm.connect(signer).allocate.estimateGas();
+  } catch (err) {
+    if (!isMissingSelectorError(err)) throw err;
+    const legacyArm = await legacyArmContract(arm, signer);
+    return legacyArm.allocate.estimateGas();
+  }
+};
+
+const callAllocate = async (arm, signer, overrides = {}) => {
+  try {
+    return await arm.connect(signer).allocate(overrides);
+  } catch (err) {
+    if (!isMissingSelectorError(err)) throw err;
+    const legacyArm = await legacyArmContract(arm, signer);
+    return legacyArm.allocate(overrides);
+  }
+};
+
+const getArmBuffer = async (arm, blockTag) => {
+  try {
+    return await arm.armBuffer({ blockTag });
+  } catch (err) {
+    if (!isMissingSelectorError(err)) throw err;
+    const legacyArm = await legacyArmContract(arm);
+    try {
+      return await legacyArm.armBuffer({ blockTag });
+    } catch {
+      throw new Error("ARM does not expose armBuffer()");
+    }
+  }
+};
+
+const setArmBuffer = async (arm, signer, buffer, overrides = {}) => {
+  try {
+    return await arm.connect(signer).setARMBuffer(buffer, overrides);
+  } catch (err) {
+    if (!isMissingSelectorError(err)) throw err;
+    const legacyArm = await legacyArmContract(arm, signer);
+    try {
+      return await legacyArm.setARMBuffer(buffer, overrides);
+    } catch {
+      throw new Error("ARM does not expose setARMBuffer(uint256)");
+    }
+  }
+};
+
+const estimateSetArmBufferGas = async (arm, signer, buffer) => {
+  try {
+    return await arm.connect(signer).setARMBuffer.estimateGas(buffer);
+  } catch (err) {
+    if (!isMissingSelectorError(err)) throw err;
+    const legacyArm = await legacyArmContract(arm, signer);
+    try {
+      return await legacyArm.setARMBuffer.estimateGas(buffer);
+    } catch {
+      throw new Error("ARM does not expose setARMBuffer(uint256)");
+    }
+  }
 };
 
 const adapterContract = async (adapterAddress, signerOrProvider) =>
@@ -128,11 +455,21 @@ const adapterContract = async (adapterAddress, signerOrProvider) =>
 module.exports = {
   MAX_SWAP_LIQUIDITY,
   adapterContract,
+  callAllocate,
   defaultBaseSymbol,
+  estimateAllocateGas,
+  estimateSetArmBufferGas,
+  getArmBuffer,
+  legacyArmContract,
   liquiditySymbol,
   normalizeBaseSymbol,
   parseSwapCap,
+  requestBaseAssetWithdrawal,
   resolveArmBase,
   resolveAssetAddress,
+  setArmBuffer,
+  setArmPrices,
+  staticCallAllocate,
+  claimBaseAssetWithdrawal,
   toConfigObject,
 };


### PR DESCRIPTION
## Summary

Adds backward compatibility for ARM Hardhat tasks and Talos actions across legacy single-base and upgraded multi-base ARM contracts.

- Introduces version-aware ARM helpers for pricing, withdrawals, allocation, and buffer operations.
- Updates price/request/claim actions to iterate over each ARM’s supported base assets.
- Safely skips unsupported legacy bases while preserving pre-upgrade action compatibility.