### PR TITLE
Make setARMBuffer, setTotalAssetsCap and setLiquidityProviderCaps Talos-ready

### DIFF
--- a/src/js/tasks/admin.js
+++ b/src/js/tasks/admin.js
@@ -170,8 +170,59 @@ async function setARMBuffer({ arm, signer, buffer }) {
   const tx = await setArmBuffer(arm, signer, bufferBN, { gasLimit });
   await logTxDetails(tx, "setARMBuffer");
 }
+
+const CAP_MANAGER_ABI = [
+  "function setLiquidityProviderCaps(address[] liquidityProviders, uint256 cap)",
+  "function setTotalAssetsCap(uint248 totalAssetsCap)",
+];
+
+// Resolve the CapManager contract of an ARM.
+async function resolveCapManager(arm, signer) {
+  const capManagerAddress = await arm.capManager();
+  if (capManagerAddress === ethers.ZeroAddress) {
+    throw new Error("No CapManager configured for the ARM");
+  }
+  return new ethers.Contract(capManagerAddress, CAP_MANAGER_ABI, signer);
+}
+
+async function setTotalAssetsCap({ arm, armName = "ARM", cap, signer }) {
+  const capBn = parseUnits(cap.toString());
+
+  const capManager = await resolveCapManager(arm, signer);
+
+  log(`About to set total asset cap of ${cap} for the ${armName} ARM`);
+  const tx = await capManager.setTotalAssetsCap(capBn);
+  await logTxDetails(tx, "setTotalAssetsCap");
+}
+
+async function setLiquidityProviderCaps({
+  accounts,
+  arm,
+  armName = "ARM",
+  cap,
+  signer,
+}) {
+  const capBn = parseUnits(cap.toString());
+
+  const liquidityProviders = Array.isArray(accounts)
+    ? accounts
+    : accounts.split(",");
+
+  const capManager = await resolveCapManager(arm, signer);
+
+  log(
+    `About to set deposit cap of ${cap} for liquidity providers ${liquidityProviders} for the ${armName} ARM`,
+  );
+  const tx = await capManager.setLiquidityProviderCaps(
+    liquidityProviders,
+    capBn,
+  );
+  await logTxDetails(tx, "setLiquidityProviderCaps");
+}
 module.exports = {
   allocate,
   collectFees,
   setARMBuffer,
+  setLiquidityProviderCaps,
+  setTotalAssetsCap,
 };

--- a/src/js/tasks/liquidityProvider.js
+++ b/src/js/tasks/liquidityProvider.js
@@ -1,5 +1,9 @@
 const { parseUnits } = require("ethers");
 
+const {
+  setLiquidityProviderCaps: setLiquidityProviderCapsCore,
+  setTotalAssetsCap: setTotalAssetsCapCore,
+} = require("./admin");
 const { getSigner } = require("../utils/signers");
 const {
   parseDeployedAddress,
@@ -95,42 +99,27 @@ async function claimRedeemARM({ arm, id }) {
 
 async function setLiquidityProviderCaps({ accounts, arm, cap }) {
   const signer = await getSigner();
-
-  const capBn = parseUnits(cap.toString());
-
-  const liquidityProviders = accounts.split(",");
-
   const armContract = await resolveArmContract(arm);
-  const capManagerAddress = await armContract.capManager();
-  const capManager = await ethers.getContractAt(
-    "CapManager",
-    capManagerAddress,
-  );
 
-  log(
-    `About to set deposit cap of ${cap} WETH for liquidity providers ${liquidityProviders} for the ${arm} ARM`,
-  );
-  const tx = await capManager
-    .connect(signer)
-    .setLiquidityProviderCaps(liquidityProviders, capBn);
-  await logTxDetails(tx, "setLiquidityProviderCaps");
+  await setLiquidityProviderCapsCore({
+    accounts,
+    arm: armContract,
+    armName: arm,
+    cap,
+    signer,
+  });
 }
 
 async function setTotalAssetsCap({ arm, cap }) {
   const signer = await getSigner();
-
-  const capBn = parseUnits(cap.toString());
-
   const armContract = await resolveArmContract(arm);
-  const capManagerAddress = await armContract.capManager();
-  const capManager = await ethers.getContractAt(
-    "CapManager",
-    capManagerAddress,
-  );
 
-  log(`About to set total asset cap of ${cap} for the ${arm} ARM`);
-  const tx = await capManager.connect(signer).setTotalAssetsCap(capBn);
-  await logTxDetails(tx, "setTotalAssetsCap");
+  await setTotalAssetsCapCore({
+    arm: armContract,
+    armName: arm,
+    cap,
+    signer,
+  });
 }
 
 module.exports = {

--- a/src/js/tasks/tasks.js
+++ b/src/js/tasks/tasks.js
@@ -617,13 +617,13 @@ task("claimRedeemARM").setAction(async (_, __, runSuper) => {
 subtask("setLiquidityProviderCaps", "Set deposit cap for liquidity providers")
   .addParam(
     "arm",
-    "Name of the ARM. eg Lido, Origin or EtherFi",
-    "Lido",
+    "Name of the ARM. eg Lido, EtherFi or Ethena",
+    undefined,
     types.string,
   )
   .addParam(
     "cap",
-    "Amount of WETH not scaled to 18 decimals",
+    "Deposit cap per account in liquidity asset units, not scaled to 18 decimals. eg 20000 = 20,000 USDe",
     undefined,
     types.float,
   )
@@ -641,13 +641,13 @@ task("setLiquidityProviderCaps").setAction(async (_, __, runSuper) => {
 subtask("setTotalAssetsCap", "Set total assets cap")
   .addParam(
     "arm",
-    "Name of the ARM. eg Lido, Origin or EtherFi",
-    "Lido",
+    "Name of the ARM. eg Lido, EtherFi or Ethena",
+    undefined,
     types.string,
   )
   .addParam(
     "cap",
-    "Amount of WETH not scaled to 18 decimals",
+    "Total assets cap in liquidity asset units, not scaled to 18 decimals. eg 100000 = 100,000 USDe",
     undefined,
     types.float,
   )
@@ -1069,13 +1069,13 @@ task("allocate").setAction(async (_, __, runSuper) => {
 });
 
 subtask("setARMBuffer", "Set the ARM buffer percentage")
-  .addOptionalParam(
+  .addParam(
     "arm",
     "The name of the ARM. eg Lido, Origin, EtherFi or Ethena",
-    "Origin",
+    undefined,
     types.string,
   )
-  .addOptionalParam(
+  .addParam(
     "buffer",
     "The new buffer value (eg 0.1 -> 10%)",
     undefined,


### PR DESCRIPTION
## Summary

Prepares the three remaining permissioned admin tasks (`setARMBuffer`, `setTotalAssetsCap`, `setLiquidityProviderCaps`) so they can be invoked from a Talos schedule command, e.g.:

```
cd /app && pnpm hardhat setTotalAssetsCap --network mainnet --arm Ethena --cap 100000
cd /app && pnpm hardhat setARMBuffer --network mainnet --arm Lido --buffer 0.5
cd /app && pnpm hardhat setLiquidityProviderCaps --network mainnet --arm Ethena --accounts 0x...,0x... --cap 20000
```

## Changes

### `tasks/admin.js` (purely additive)
- New `setTotalAssetsCap` and `setLiquidityProviderCaps` core functions with an injected signer and the ARM contract as a parameter, following the same pattern as `allocate`/`collectFees`/`setARMBuffer` (and the `action()` wrapper principle on the talos branch).
- `resolveCapManager` helper: resolves the ARM's CapManager via `arm.capManager()` with a clear error when none is configured, using a minimal inline ABI.

### `tasks/liquidityProvider.js`
- The two cap functions become thin Hardhat wrappers (resolve signer + ARM contract by name, then delegate to `admin.js`). Same CLI interface as before. The previous implementation relied on the Hardhat-global `ethers.getContractAt`, which made the logic unusable outside the Hardhat runtime.

### `tasks/tasks.js`
- All params of the three tasks are now **required with no defaults**:
  - `setARMBuffer`: omitting `--buffer` previously wrote a buffer of **0** on-chain silently (`buffer || "0"` fallback); `--arm` defaulted to `Origin`.
  - `setTotalAssetsCap` / `setLiquidityProviderCaps`: `--arm` defaulted to `Lido`.
  - These are punctual state-changing admin actions: a missing flag should fail at CLI parsing (HH306), not write a surprise value to the wrong ARM.
- Param descriptions fixed (liquidity asset units with examples instead of "Amount of WETH").

No defaults is intentional — the Talos actions catalog will report `hasDefault: false` for these flags so the UI knows they are mandatory.
