### PR TITLE
[ARM] Deploy 031 EthenaARM upgrade with sUSDe asset adapter

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -1,278 +1,292 @@
 {
-  "contracts": [
-    {
-      "implementation": "0xE11EDbd5AE4Fa434Af7f8D7F03Da1742996e7Ab2",
-      "name": "ARM_ZAPPER"
-    },
-    {
-      "implementation": "0xCEDa2d856238aA0D12f6329de20B9115f07C366d",
-      "name": "ETHENA_ARM"
-    },
-    {
-      "implementation": "0x7073F39ae371962C2469D72f01f907375bB11E08",
-      "name": "ETHENA_ARM_CAP_IMPL"
-    },
-    {
-      "implementation": "0x687AFB5A52A15122fD5FC54A8B52cfd58346fb0C",
-      "name": "ETHENA_ARM_CAP_MAN"
-    },
-    {
-      "implementation": "0xA60c11292a3053b5161466229D9E113B18cA2a83",
-      "name": "ETHENA_ARM_IMPL"
-    },
-    {
-      "implementation": "0x6DB596b66FED6a9994e09EeD70b6d210F01705E5",
-      "name": "ETHERFI_ARM_IMPL"
-    },
-    {
-      "implementation": "0xfB0A3CF9B019BFd8827443d131b235B3E0FC58d2",
-      "name": "ETHER_FI_ARM"
-    },
-    {
-      "implementation": "0xe27720Fc3f3707D47015e274D81a99e5B0800472",
-      "name": "ETHER_FI_ARM_CAP_IMPL"
-    },
-    {
-      "implementation": "0xf2A18F7330141Ec737EB73A0A5Ea8E4d7e9bE7ec",
-      "name": "ETHER_FI_ARM_CAP_MAN"
-    },
-    {
-      "implementation": "0x00B53CEE151c043CBe4bbFe4cfD2938Cb4fabCEB",
-      "name": "ETHER_FI_ARM_IMPL"
-    },
-    {
-      "implementation": "0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6",
-      "name": "LIDO_ARM"
-    },
-    {
-      "implementation": "0x8506486813d025C5935dF481E450e27D2e483dc9",
-      "name": "LIDO_ARM_CAP_IMPL"
-    },
-    {
-      "implementation": "0xf54ebff575f699d281645c6F14Fe427dFFE629CF",
-      "name": "LIDO_ARM_CAP_MAN"
-    },
-    {
-      "implementation": "0x850da2E21F1F71479E2A307EDab114777D9F6217",
-      "name": "LIDO_ARM_IMPL"
-    },
-    {
-      "implementation": "0x01F30B7358Ba51f637d1aa05D9b4A60f76DAD680",
-      "name": "LIDO_ARM_ZAPPER"
-    },
-    {
-      "implementation": "0x8Cf42b82fFFa3E7714D62a2cA223acBeC1Eef095",
-      "name": "MORPHO_MARKET_ETHERFI"
-    },
-    {
-      "implementation": "0xB7CeFE4CB483Be80C2963D3D9Edb991e69ff39cf",
-      "name": "MORPHO_MARKET_LIDO"
-    },
-    {
-      "implementation": "0xa52cC5aDFE6C638cE31694eAFfD8F993A0324f22",
-      "name": "MORPHO_MARKET_LIDO_IMPL"
-    },
-    {
-      "implementation": "0x2a1b59870f7806E60dF58415B0C220C096f57658",
-      "name": "MORPHO_MARKET_ETHERFI_IMPL"
-    },
-    {
-      "implementation": "0x29c4Bb7B1eBcc53e8CBd16480B5bAe52C69806D3",
-      "name": "MORPHO_MARKET_MEVCAPITAL"
-    },
-    {
-      "implementation": "0x90c7ABC962f96de171ee395A242D2Ff794D0a04c",
-      "name": "MORPHO_MARKET_MEVCAPITAL_IMP"
-    },
-    {
-      "implementation": "0x0ad39D67404aE36Fe476eFDDE1306a5414383544",
-      "name": "MORPHO_MARKET_ORIGIN"
-    },
-    {
-      "implementation": "0x2ea9D1827973813D77aA8f35BD23cb1F1311A648",
-      "name": "MORPHO_MARKET_ORIGIN_IMPL"
-    },
-    {
-      "implementation": "0x6bac785889A4127dB0e0CeFEE88E0a9F1Aaf3cC7",
-      "name": "OETH_ARM"
-    },
-    {
-      "implementation": "0x9A2be51E45Eec98F75b3e6e1b334246c94663641",
-      "name": "OETH_ARM_IMPL"
-    },
-    {
-      "implementation": "0xbcae2Eb1cc47F137D8B2D351B0E0ea8DdA4C6184",
-      "name": "PENDLE_ORIGIN_ARM_SY"
-    }
-  ],
-  "executions": [
-    {
-      "name": "001_CoreMainnet",
-      "proposalId": 1,
-      "tsDeployment": 1723685111,
-      "tsGovernance": 1
-    },
-    {
-      "name": "002_UpgradeMainnet",
-      "proposalId": 1,
-      "tsDeployment": 1726812322,
-      "tsGovernance": 1
-    },
-    {
-      "name": "003_UpgradeLidoARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1729073099,
-      "tsGovernance": 1
-    },
-    {
-      "name": "004_UpdateCrossPriceScript",
-      "proposalId": "35014690349432723957288190501753589450218643401938485181692293616657480917203",
-      "tsDeployment": 1739872607,
-      "tsGovernance": 1741006739
-    },
-    {
-      "name": "005_RegisterLidoWithdrawalsScript",
-      "proposalId": "64044440920440270085747261797126167860462634313138171523652997655161275965731",
-      "tsDeployment": 1743500783,
-      "tsGovernance": 1744160999
-    },
-    {
-      "name": "006_ChangeFeeCollector",
-      "proposalId": "109363689626229981205538511015089771588377155562499137759609037731650725632486",
-      "tsDeployment": 1751894483,
-      "tsGovernance": 1752344483
-    },
-    {
-      "name": "007_UpgradeLidoARMMorphoScript",
-      "proposalId": "59265604807181750059374521697037203647325806747129712398293966379088988710865",
-      "tsDeployment": 1754407535,
-      "tsGovernance": 1755065999
-    },
-    {
-      "name": "008_DeployPendleAdaptor",
-      "proposalId": 1,
-      "tsDeployment": 1755770303,
-      "tsGovernance": 1
-    },
-    {
-      "name": "009_UpgradeLidoARMSetBufferScript",
-      "proposalId": "102890619681967819838810828305071236237724717056692746223348120761300245862771",
-      "tsDeployment": 1755692387,
-      "tsGovernance": 1756300859
-    },
-    {
-      "name": "010_UpgradeLidoARMAssetScript",
-      "proposalId": "37708940508805836655115654926134468712278199739053834927259119548435770049054",
-      "tsDeployment": 1764755207,
-      "tsGovernance": 1765250063
-    },
-    {
-      "name": "011_DeployEtherFiARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1761812927,
-      "tsGovernance": 1
-    },
-    {
-      "name": "012_UpgradeEtherFiARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1763557643,
-      "tsGovernance": 1
-    },
-    {
-      "name": "013_UpgradeOETHARMScript",
-      "proposalId": "13037237308267442172275484225525115297039100275207017031248147012600338883646",
-      "tsDeployment": 1765353455,
-      "tsGovernance": 1765977443
-    },
-    {
-      "name": "014_DeployEthenaARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1764664655,
-      "tsGovernance": 1
-    },
-    {
-      "name": "015_UpgradeEthenaARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1766319523,
-      "tsGovernance": 1
-    },
-    {
-      "name": "016_UpgradeLidoARMCrossPriceScript",
-      "proposalId": "31708125563490321189508956336526281463837110092407433451282139238539907004461",
-      "tsDeployment": 1767616727,
-      "tsGovernance": 1768078823
-    },
-    {
-      "name": "017_DeployNewMorphoMarketForEtherFiARM",
-      "proposalId": 1,
-      "tsDeployment": 1770197063,
-      "tsGovernance": 1
-    },
-    {
-      "name": "018_DeployNewMorphoMarketForLidoARM",
-      "proposalId": "104193745767957728487777538680481562234753615557563590994770579038567345820296",
-      "tsDeployment": 1770716663,
-      "tsGovernance": 1771230167
-    },
-    {
-      "name": "019_DeployPendleAdaptor_EtherFi",
-      "proposalId": 1,
-      "tsDeployment": 1770793835,
-      "tsGovernance": 1
-    },
-    {
-      "name": "020_UpgradeEthenaARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1771799051,
-      "tsGovernance": 1
-    },
-    {
-      "name": "021_UpgradeEtherFiARMCrossPriceScript",
-      "proposalId": "114812379648161625831369461227769038450456221701260101122620166047089230034199",
-      "tsDeployment": 1774843907,
-      "tsGovernance": 1775301371
-    },
-    {
-      "name": "022_UpgradeEtherFiARMDepositScript",
-      "proposalId": 1,
-      "tsDeployment": 1763557667,
-      "tsGovernance": 1
-    },
-    {
-      "name": "023_UpgradeEthenaARMDepositScript",
-      "proposalId": 1,
-      "tsDeployment": 1771799087,
-      "tsGovernance": 1
-    },
-    {
-      "name": "026_UpgradeEthenaARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1775631059,
-      "tsGovernance": 1
-    },
-    {
-      "name": "027_UpgradeEthenaARMScript",
-      "proposalId": 1,
-      "tsDeployment": 1777952339,
-      "tsGovernance": 1
-    },
-    {
-      "name": "028_UpgradeARMsPauseScript",
-      "proposalId": "107456588163205703004763727598618132346480115183205972270610010610877561869240",
-      "tsDeployment": 1780037867,
-      "tsGovernance": 1781164307
-    },
-    {
-      "name": "029_SetTalosKMSOperatorScript",
-      "proposalId": "12986865731251129814295460769943611973912941096599758191915201739619928664693",
-      "tsDeployment": 1781035763,
-      "tsGovernance": 1781594591
-    },
-    {
-      "name": "030_SetEthenaTalosKMSOperatorScript",
-      "proposalId": 1,
-      "tsDeployment": 1781035763,
-      "tsGovernance": 1
-    }
-  ]
+    "contracts": [
+        {
+            "implementation": "0xE11EDbd5AE4Fa434Af7f8D7F03Da1742996e7Ab2",
+            "name": "ARM_ZAPPER"
+        },
+        {
+            "implementation": "0xCEDa2d856238aA0D12f6329de20B9115f07C366d",
+            "name": "ETHENA_ARM"
+        },
+        {
+            "implementation": "0x7073F39ae371962C2469D72f01f907375bB11E08",
+            "name": "ETHENA_ARM_CAP_IMPL"
+        },
+        {
+            "implementation": "0x687AFB5A52A15122fD5FC54A8B52cfd58346fb0C",
+            "name": "ETHENA_ARM_CAP_MAN"
+        },
+        {
+            "implementation": "0x028b9077f7E97E2F3E8AFC6eaaD310eB36A2bB39",
+            "name": "ETHENA_ARM_IMPL"
+        },
+        {
+            "implementation": "0x6DB596b66FED6a9994e09EeD70b6d210F01705E5",
+            "name": "ETHERFI_ARM_IMPL"
+        },
+        {
+            "implementation": "0xfB0A3CF9B019BFd8827443d131b235B3E0FC58d2",
+            "name": "ETHER_FI_ARM"
+        },
+        {
+            "implementation": "0xe27720Fc3f3707D47015e274D81a99e5B0800472",
+            "name": "ETHER_FI_ARM_CAP_IMPL"
+        },
+        {
+            "implementation": "0xf2A18F7330141Ec737EB73A0A5Ea8E4d7e9bE7ec",
+            "name": "ETHER_FI_ARM_CAP_MAN"
+        },
+        {
+            "implementation": "0x00B53CEE151c043CBe4bbFe4cfD2938Cb4fabCEB",
+            "name": "ETHER_FI_ARM_IMPL"
+        },
+        {
+            "implementation": "0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6",
+            "name": "LIDO_ARM"
+        },
+        {
+            "implementation": "0x8506486813d025C5935dF481E450e27D2e483dc9",
+            "name": "LIDO_ARM_CAP_IMPL"
+        },
+        {
+            "implementation": "0xf54ebff575f699d281645c6F14Fe427dFFE629CF",
+            "name": "LIDO_ARM_CAP_MAN"
+        },
+        {
+            "implementation": "0x850da2E21F1F71479E2A307EDab114777D9F6217",
+            "name": "LIDO_ARM_IMPL"
+        },
+        {
+            "implementation": "0x01F30B7358Ba51f637d1aa05D9b4A60f76DAD680",
+            "name": "LIDO_ARM_ZAPPER"
+        },
+        {
+            "implementation": "0x8Cf42b82fFFa3E7714D62a2cA223acBeC1Eef095",
+            "name": "MORPHO_MARKET_ETHERFI"
+        },
+        {
+            "implementation": "0xB7CeFE4CB483Be80C2963D3D9Edb991e69ff39cf",
+            "name": "MORPHO_MARKET_LIDO"
+        },
+        {
+            "implementation": "0xa52cC5aDFE6C638cE31694eAFfD8F993A0324f22",
+            "name": "MORPHO_MARKET_LIDO_IMPL"
+        },
+        {
+            "implementation": "0x2a1b59870f7806E60dF58415B0C220C096f57658",
+            "name": "MORPHO_MARKET_ETHERFI_IMPL"
+        },
+        {
+            "implementation": "0x29c4Bb7B1eBcc53e8CBd16480B5bAe52C69806D3",
+            "name": "MORPHO_MARKET_MEVCAPITAL"
+        },
+        {
+            "implementation": "0x90c7ABC962f96de171ee395A242D2Ff794D0a04c",
+            "name": "MORPHO_MARKET_MEVCAPITAL_IMP"
+        },
+        {
+            "implementation": "0x0ad39D67404aE36Fe476eFDDE1306a5414383544",
+            "name": "MORPHO_MARKET_ORIGIN"
+        },
+        {
+            "implementation": "0x2ea9D1827973813D77aA8f35BD23cb1F1311A648",
+            "name": "MORPHO_MARKET_ORIGIN_IMPL"
+        },
+        {
+            "implementation": "0x6bac785889A4127dB0e0CeFEE88E0a9F1Aaf3cC7",
+            "name": "OETH_ARM"
+        },
+        {
+            "implementation": "0x9A2be51E45Eec98F75b3e6e1b334246c94663641",
+            "name": "OETH_ARM_IMPL"
+        },
+        {
+            "implementation": "0xbcae2Eb1cc47F137D8B2D351B0E0ea8DdA4C6184",
+            "name": "PENDLE_ORIGIN_ARM_SY"
+        },
+        {
+            "implementation": "0x1707b933037287eAf35A64ff1E89Cb00Db809aaB",
+            "name": "ETHENA_ARM_SUSDE_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0xE620aFB67223AE03C260112aE21A717Af94C90f0",
+            "name": "ETHENA_ARM_SUSDE_ADAPTER"
+        }
+    ],
+    "executions": [
+        {
+            "name": "001_CoreMainnet",
+            "proposalId": 1,
+            "tsDeployment": 1723685111,
+            "tsGovernance": 1
+        },
+        {
+            "name": "002_UpgradeMainnet",
+            "proposalId": 1,
+            "tsDeployment": 1726812322,
+            "tsGovernance": 1
+        },
+        {
+            "name": "003_UpgradeLidoARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1729073099,
+            "tsGovernance": 1
+        },
+        {
+            "name": "004_UpdateCrossPriceScript",
+            "proposalId": "35014690349432723957288190501753589450218643401938485181692293616657480917203",
+            "tsDeployment": 1739872607,
+            "tsGovernance": 1741006739
+        },
+        {
+            "name": "005_RegisterLidoWithdrawalsScript",
+            "proposalId": "64044440920440270085747261797126167860462634313138171523652997655161275965731",
+            "tsDeployment": 1743500783,
+            "tsGovernance": 1744160999
+        },
+        {
+            "name": "006_ChangeFeeCollector",
+            "proposalId": "109363689626229981205538511015089771588377155562499137759609037731650725632486",
+            "tsDeployment": 1751894483,
+            "tsGovernance": 1752344483
+        },
+        {
+            "name": "007_UpgradeLidoARMMorphoScript",
+            "proposalId": "59265604807181750059374521697037203647325806747129712398293966379088988710865",
+            "tsDeployment": 1754407535,
+            "tsGovernance": 1755065999
+        },
+        {
+            "name": "008_DeployPendleAdaptor",
+            "proposalId": 1,
+            "tsDeployment": 1755770303,
+            "tsGovernance": 1
+        },
+        {
+            "name": "009_UpgradeLidoARMSetBufferScript",
+            "proposalId": "102890619681967819838810828305071236237724717056692746223348120761300245862771",
+            "tsDeployment": 1755692387,
+            "tsGovernance": 1756300859
+        },
+        {
+            "name": "010_UpgradeLidoARMAssetScript",
+            "proposalId": "37708940508805836655115654926134468712278199739053834927259119548435770049054",
+            "tsDeployment": 1764755207,
+            "tsGovernance": 1765250063
+        },
+        {
+            "name": "011_DeployEtherFiARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1761812927,
+            "tsGovernance": 1
+        },
+        {
+            "name": "012_UpgradeEtherFiARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1763557643,
+            "tsGovernance": 1
+        },
+        {
+            "name": "013_UpgradeOETHARMScript",
+            "proposalId": "13037237308267442172275484225525115297039100275207017031248147012600338883646",
+            "tsDeployment": 1765353455,
+            "tsGovernance": 1765977443
+        },
+        {
+            "name": "014_DeployEthenaARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1764664655,
+            "tsGovernance": 1
+        },
+        {
+            "name": "015_UpgradeEthenaARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1766319523,
+            "tsGovernance": 1
+        },
+        {
+            "name": "016_UpgradeLidoARMCrossPriceScript",
+            "proposalId": "31708125563490321189508956336526281463837110092407433451282139238539907004461",
+            "tsDeployment": 1767616727,
+            "tsGovernance": 1768078823
+        },
+        {
+            "name": "017_DeployNewMorphoMarketForEtherFiARM",
+            "proposalId": 1,
+            "tsDeployment": 1770197063,
+            "tsGovernance": 1
+        },
+        {
+            "name": "018_DeployNewMorphoMarketForLidoARM",
+            "proposalId": "104193745767957728487777538680481562234753615557563590994770579038567345820296",
+            "tsDeployment": 1770716663,
+            "tsGovernance": 1771230167
+        },
+        {
+            "name": "019_DeployPendleAdaptor_EtherFi",
+            "proposalId": 1,
+            "tsDeployment": 1770793835,
+            "tsGovernance": 1
+        },
+        {
+            "name": "020_UpgradeEthenaARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1771799051,
+            "tsGovernance": 1
+        },
+        {
+            "name": "021_UpgradeEtherFiARMCrossPriceScript",
+            "proposalId": "114812379648161625831369461227769038450456221701260101122620166047089230034199",
+            "tsDeployment": 1774843907,
+            "tsGovernance": 1775301371
+        },
+        {
+            "name": "022_UpgradeEtherFiARMDepositScript",
+            "proposalId": 1,
+            "tsDeployment": 1763557667,
+            "tsGovernance": 1
+        },
+        {
+            "name": "023_UpgradeEthenaARMDepositScript",
+            "proposalId": 1,
+            "tsDeployment": 1771799087,
+            "tsGovernance": 1
+        },
+        {
+            "name": "026_UpgradeEthenaARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1775631059,
+            "tsGovernance": 1
+        },
+        {
+            "name": "027_UpgradeEthenaARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1777952339,
+            "tsGovernance": 1
+        },
+        {
+            "name": "028_UpgradeARMsPauseScript",
+            "proposalId": "107456588163205703004763727598618132346480115183205972270610010610877561869240",
+            "tsDeployment": 1780037867,
+            "tsGovernance": 1781164307
+        },
+        {
+            "name": "029_SetTalosKMSOperatorScript",
+            "proposalId": "12986865731251129814295460769943611973912941096599758191915201739619928664693",
+            "tsDeployment": 1781035763,
+            "tsGovernance": 1781594591
+        },
+        {
+            "name": "030_SetEthenaTalosKMSOperatorScript",
+            "proposalId": 1,
+            "tsDeployment": 1781035763,
+            "tsGovernance": 1
+        },
+        {
+            "name": "031_UpgradeEthenaARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1781612483,
+            "tsGovernance": 0
+        }
+    ]
 }

--- a/test/invariants/LidoARM/TargetFunction.t.sol
+++ b/test/invariants/LidoARM/TargetFunction.t.sol
@@ -385,10 +385,17 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         address picked = candidates[s % 3];
         if (picked == current) picked = candidates[(s + 1) % 3];
 
-        // Switching away from a market redeems ALL shares. Skip if the market can't cover the full redeem.
+        // Switching away from a market redeems ALL shares via balanceOf. Skip the call if that full
+        // redeem would revert: either the market can't cover it (maxRedeem < balanceOf), or the shares
+        // are dust worth 0 assets (convertToAssets == 0), which reverts with ZERO_ASSETS in ERC4626.redeem.
+        // Both are documented operational edge cases the operator handles off-chain (see setActiveMarket).
         if (current != address(0)) {
             uint256 shares = IERC4626(current).balanceOf(address(lidoARM));
-            vm.assume(shares == 0 || shares <= IERC4626(current).maxRedeem(address(lidoARM)));
+            vm.assume(
+                shares == 0
+                    || (shares <= IERC4626(current).maxRedeem(address(lidoARM))
+                        && IERC4626(current).convertToAssets(shares) > 0)
+            );
         }
 
         vm.prank(operator);

--- a/test/invariants/LidoARM/TargetFunction.t.sol
+++ b/test/invariants/LidoARM/TargetFunction.t.sol
@@ -476,6 +476,9 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         vm.assume(bal > 0);
 
         uint256 boundedAmount = _bound(amount, 1, bal);
+        // With a share price >= 1, a tiny deposit can round down to 0 shares, which reverts with
+        // ZERO_SHARES in ERC4626.deposit. Skip those amounts (a supplier would never deposit dust).
+        vm.assume(market.previewDeposit(boundedAmount) > 0);
         vm.prank(hanna);
         market.deposit(boundedAmount, hanna);
 

--- a/test/invariants/LidoARM/base/Setup.t.sol
+++ b/test/invariants/LidoARM/base/Setup.t.sol
@@ -213,9 +213,12 @@ abstract contract Invariant_LidoARM_Setup_Test is Base_Test_, Helpers {
         weth.approve(address(mockERC4626Market_B), type(uint256).max);
         mockERC4626Market_A.deposit(10_000 ether, address(this));
         mockERC4626Market_B.deposit(10_000 ether, address(this));
-        // Simulate yield in markets, ~10%
-        deal(address(weth), address(mockERC4626Market_A), 1_458 ether);
-        deal(address(weth), address(mockERC4626Market_B), 1_981 ether);
+        // Simulate accrued yield in the markets. `deal` overwrites the balance (it does not add), so
+        // the target is the 10_000 deposited + the yield. This keeps the share price above 1 (~1.15 /
+        // ~1.20) as in a real interest-bearing vault; a price below 1 would let dust shares convert to
+        // 0 assets and brick ERC4626.redeem with ZERO_ASSETS.
+        deal(address(weth), address(mockERC4626Market_A), 10_000 ether + 1_458 ether);
+        deal(address(weth), address(mockERC4626Market_B), 10_000 ether + 1_981 ether);
 
         // 6. Give LPs initial liquidity
         for (uint256 i; i < LP_COUNT; i++) {


### PR DESCRIPTION
# Description

Deploy a new implementation for EthenaARM together with the new `EthenaAssetAdapter`, which moves the sUSDe staking/unstaking logic out of the ARM and into a dedicated adapter backed by a rotating set of 42 `EthenaUnstaker` helpers (so multiple parallel sUSDe cooldowns can be in flight).

The following PRs are included in this deployment

### ARM

- https://github.com/OriginProtocol/arm-oeth/pull/208
- https://github.com/OriginProtocol/arm-oeth/pull/267

## Deployment

Script `script/deploy/mainnet/031_UpgradeEthenaARMScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| EthenaARM implementation | [0x028b9077f7E97E2F3E8AFC6eaaD310eB36A2bB39](https://etherscan.io/address/0x028b9077f7E97E2F3E8AFC6eaaD310eB36A2bB39) |
| EthenaAssetAdapter implementation | [0x1707b933037287eAf35A64ff1E89Cb00Db809aaB](https://etherscan.io/address/0x1707b933037287eAf35A64ff1E89Cb00Db809aaB) |
| EthenaAssetAdapter proxy | [0xE620aFB67223AE03C260112aE21A717Af94C90f0](https://etherscan.io/address/0xE620aFB67223AE03C260112aE21A717Af94C90f0) |

In addition, the adapter's `deployUnstakers()` call deployed 42 `EthenaUnstaker` helper contracts:

| # | Address |
| - | - |
| 1 | [0xB1b9cf49B16DECc1634AEa0675C3b976FfE2B4F4](https://etherscan.io/address/0xB1b9cf49B16DECc1634AEa0675C3b976FfE2B4F4) |
| 2 | [0x5B6623b6dbD06c060eBD4291879ca2A7086f3135](https://etherscan.io/address/0x5B6623b6dbD06c060eBD4291879ca2A7086f3135) |
| 3 | [0x8EFda3F217645382935380dD41af585d0d1862ad](https://etherscan.io/address/0x8EFda3F217645382935380dD41af585d0d1862ad) |
| 4 | [0xfF5D608DC7aC77cC7FFcb39BFAE7e92ca9fA9c8A](https://etherscan.io/address/0xfF5D608DC7aC77cC7FFcb39BFAE7e92ca9fA9c8A) |
| 5 | [0x6676EE61AfbCED8AFE3A3F29472fabCd69f9C30d](https://etherscan.io/address/0x6676EE61AfbCED8AFE3A3F29472fabCd69f9C30d) |
| 6 | [0x4fF37c10576B902ccDCaA8c95c9Af4D0F3Bd9EfA](https://etherscan.io/address/0x4fF37c10576B902ccDCaA8c95c9Af4D0F3Bd9EfA) |
| 7 | [0xF2188f57928e8e72A571A5a2a95D880705B76280](https://etherscan.io/address/0xF2188f57928e8e72A571A5a2a95D880705B76280) |
| 8 | [0x6C00f6c0Def50ac2CB2B8c871CFE76A0a8F37355](https://etherscan.io/address/0x6C00f6c0Def50ac2CB2B8c871CFE76A0a8F37355) |
| 9 | [0x8655EddC438AC291121f8DA1a10d634681c97309](https://etherscan.io/address/0x8655EddC438AC291121f8DA1a10d634681c97309) |
| 10 | [0x54c34361C2f70BfB2E671aF7e2d62D06B68BE4f6](https://etherscan.io/address/0x54c34361C2f70BfB2E671aF7e2d62D06B68BE4f6) |
| 11 | [0x0b136dcaDff857E5803e683E0EfC64CdC11e26E4](https://etherscan.io/address/0x0b136dcaDff857E5803e683E0EfC64CdC11e26E4) |
| 12 | [0x2335AFAE84Aa1F3Dd586F3e8C8187A6171aFA95A](https://etherscan.io/address/0x2335AFAE84Aa1F3Dd586F3e8C8187A6171aFA95A) |
| 13 | [0x37836B380b00bfD76D0E748091BA7a516B384760](https://etherscan.io/address/0x37836B380b00bfD76D0E748091BA7a516B384760) |
| 14 | [0xc34F829a7CD99A8C09aC2c58D174F05929CAbB05](https://etherscan.io/address/0xc34F829a7CD99A8C09aC2c58D174F05929CAbB05) |
| 15 | [0xfC1ff3D18055c662fa9E0a0A37000246DC91cC4d](https://etherscan.io/address/0xfC1ff3D18055c662fa9E0a0A37000246DC91cC4d) |
| 16 | [0xcb36fACf9fBd9F690497Ec6e81CdC660C47E21cd](https://etherscan.io/address/0xcb36fACf9fBd9F690497Ec6e81CdC660C47E21cd) |
| 17 | [0x014348AabFEBfF3FAb09F6C8C70cB4473b050871](https://etherscan.io/address/0x014348AabFEBfF3FAb09F6C8C70cB4473b050871) |
| 18 | [0x0d9F9Db8e68fA114a1659047cB287e5fF45BE101](https://etherscan.io/address/0x0d9F9Db8e68fA114a1659047cB287e5fF45BE101) |
| 19 | [0x29bBd09D4c53d57b8ce2F94B32980892eE823C0e](https://etherscan.io/address/0x29bBd09D4c53d57b8ce2F94B32980892eE823C0e) |
| 20 | [0x20395448d71AC13f401946d5c071157241a7de11](https://etherscan.io/address/0x20395448d71AC13f401946d5c071157241a7de11) |
| 21 | [0xDd91dA939f6BEe6fa3DA59a668464452251BFD38](https://etherscan.io/address/0xDd91dA939f6BEe6fa3DA59a668464452251BFD38) |
| 22 | [0xC9b9Cec6B92698646E02A75Ee850063470340e8B](https://etherscan.io/address/0xC9b9Cec6B92698646E02A75Ee850063470340e8B) |
| 23 | [0x8Ddef927b5d3aA0F2d04256590c140E013208Ed7](https://etherscan.io/address/0x8Ddef927b5d3aA0F2d04256590c140E013208Ed7) |
| 24 | [0xD23c5f39d9d46d72c14C082e4a57B79eFBD3c4D5](https://etherscan.io/address/0xD23c5f39d9d46d72c14C082e4a57B79eFBD3c4D5) |
| 25 | [0x2a698C7449dB7381244c7807073a865077d4b4b2](https://etherscan.io/address/0x2a698C7449dB7381244c7807073a865077d4b4b2) |
| 26 | [0xD9F27e0988566b13708CE3c5CeCF71F47207ccca](https://etherscan.io/address/0xD9F27e0988566b13708CE3c5CeCF71F47207ccca) |
| 27 | [0xAEaC6756F3dd48274828Db0825FDd5234BD05e19](https://etherscan.io/address/0xAEaC6756F3dd48274828Db0825FDd5234BD05e19) |
| 28 | [0x4CDf0dEd7ad6A2bE4fE3E9Ef36E7888Ebb56f744](https://etherscan.io/address/0x4CDf0dEd7ad6A2bE4fE3E9Ef36E7888Ebb56f744) |
| 29 | [0xb7Dd6bd11dD7AaB0272d2E98B1722651f2608BE9](https://etherscan.io/address/0xb7Dd6bd11dD7AaB0272d2E98B1722651f2608BE9) |
| 30 | [0xd033802F4c41Df8a4B2A867191e8AAD30dbf0Afa](https://etherscan.io/address/0xd033802F4c41Df8a4B2A867191e8AAD30dbf0Afa) |
| 31 | [0xB251Ebf01Ea5eB3030B79a809895eF8c2d0c2a78](https://etherscan.io/address/0xB251Ebf01Ea5eB3030B79a809895eF8c2d0c2a78) |
| 32 | [0xd58f624fc33c20e5EA0212373523e87694D365ac](https://etherscan.io/address/0xd58f624fc33c20e5EA0212373523e87694D365ac) |
| 33 | [0x659d886f12f68F0C8513D5aE0F08f830c6BA388a](https://etherscan.io/address/0x659d886f12f68F0C8513D5aE0F08f830c6BA388a) |
| 34 | [0xeC1f1bDdf266f7De8bc661bA6E550B2f275327aB](https://etherscan.io/address/0xeC1f1bDdf266f7De8bc661bA6E550B2f275327aB) |
| 35 | [0x6deDd77c9C85787923ed5E2a7AE6dF432063503A](https://etherscan.io/address/0x6deDd77c9C85787923ed5E2a7AE6dF432063503A) |
| 36 | [0x0aF356DF5410b5efDD2216d2fb1678e6aa7d93CB](https://etherscan.io/address/0x0aF356DF5410b5efDD2216d2fb1678e6aa7d93CB) |
| 37 | [0x2F31972667B81fD52DBc749919dbDb9ED115fc6f](https://etherscan.io/address/0x2F31972667B81fD52DBc749919dbDb9ED115fc6f) |
| 38 | [0xbDb40B3bDa7d314bC1C89B05c02f3E4400C6EAa7](https://etherscan.io/address/0xbDb40B3bDa7d314bC1C89B05c02f3E4400C6EAa7) |
| 39 | [0x986f349c0e8dE9DAC6228e55F0AFa62Ee715F255](https://etherscan.io/address/0x986f349c0e8dE9DAC6228e55F0AFa62Ee715F255) |
| 40 | [0x3001d34b0eA46356d8CF722018EE41D7C48b5e23](https://etherscan.io/address/0x3001d34b0eA46356d8CF722018EE41D7C48b5e23) |
| 41 | [0x72e74CF11FB8132935c9F2fDBE928B344BA82A40](https://etherscan.io/address/0x72e74CF11FB8132935c9F2fDBE928B344BA82A40) |
| 42 | [0x3fC64c268e5bD825fcDE2eB6574309a21928b4a9](https://etherscan.io/address/0x3fC64c268e5bD825fcDE2eB6574309a21928b4a9) |

## Contract diff
```python
make match file=src/contracts/EthenaARM.sol addr=0x028b9077f7E97E2F3E8AFC6eaaD310eB36A2bB39
make match file=src/contracts/adapters/EthenaAssetAdapter.sol addr=0x1707b933037287eAf35A64ff1E89Cb00Db809aaB
make match file=src/contracts/proxy.sol addr=0xE620aFB67223AE03C260112aE21A717Af94C90f0

# EthenaUnstaker helpers
make match file=src/contracts/EthenaUnstaker.sol addr=0xB1b9cf49B16DECc1634AEa0675C3b976FfE2B4F4
make match file=src/contracts/EthenaUnstaker.sol addr=0x5B6623b6dbD06c060eBD4291879ca2A7086f3135
make match file=src/contracts/EthenaUnstaker.sol addr=0x8EFda3F217645382935380dD41af585d0d1862ad
make match file=src/contracts/EthenaUnstaker.sol addr=0xfF5D608DC7aC77cC7FFcb39BFAE7e92ca9fA9c8A
make match file=src/contracts/EthenaUnstaker.sol addr=0x6676EE61AfbCED8AFE3A3F29472fabCd69f9C30d
make match file=src/contracts/EthenaUnstaker.sol addr=0x4fF37c10576B902ccDCaA8c95c9Af4D0F3Bd9EfA
make match file=src/contracts/EthenaUnstaker.sol addr=0xF2188f57928e8e72A571A5a2a95D880705B76280
make match file=src/contracts/EthenaUnstaker.sol addr=0x6C00f6c0Def50ac2CB2B8c871CFE76A0a8F37355
make match file=src/contracts/EthenaUnstaker.sol addr=0x8655EddC438AC291121f8DA1a10d634681c97309
make match file=src/contracts/EthenaUnstaker.sol addr=0x54c34361C2f70BfB2E671aF7e2d62D06B68BE4f6
make match file=src/contracts/EthenaUnstaker.sol addr=0x0b136dcaDff857E5803e683E0EfC64CdC11e26E4
make match file=src/contracts/EthenaUnstaker.sol addr=0x2335AFAE84Aa1F3Dd586F3e8C8187A6171aFA95A
make match file=src/contracts/EthenaUnstaker.sol addr=0x37836B380b00bfD76D0E748091BA7a516B384760
make match file=src/contracts/EthenaUnstaker.sol addr=0xc34F829a7CD99A8C09aC2c58D174F05929CAbB05
make match file=src/contracts/EthenaUnstaker.sol addr=0xfC1ff3D18055c662fa9E0a0A37000246DC91cC4d
make match file=src/contracts/EthenaUnstaker.sol addr=0xcb36fACf9fBd9F690497Ec6e81CdC660C47E21cd
make match file=src/contracts/EthenaUnstaker.sol addr=0x014348AabFEBfF3FAb09F6C8C70cB4473b050871
make match file=src/contracts/EthenaUnstaker.sol addr=0x0d9F9Db8e68fA114a1659047cB287e5fF45BE101
make match file=src/contracts/EthenaUnstaker.sol addr=0x29bBd09D4c53d57b8ce2F94B32980892eE823C0e
make match file=src/contracts/EthenaUnstaker.sol addr=0x20395448d71AC13f401946d5c071157241a7de11
make match file=src/contracts/EthenaUnstaker.sol addr=0xDd91dA939f6BEe6fa3DA59a668464452251BFD38
make match file=src/contracts/EthenaUnstaker.sol addr=0xC9b9Cec6B92698646E02A75Ee850063470340e8B
make match file=src/contracts/EthenaUnstaker.sol addr=0x8Ddef927b5d3aA0F2d04256590c140E013208Ed7
make match file=src/contracts/EthenaUnstaker.sol addr=0xD23c5f39d9d46d72c14C082e4a57B79eFBD3c4D5
make match file=src/contracts/EthenaUnstaker.sol addr=0x2a698C7449dB7381244c7807073a865077d4b4b2
make match file=src/contracts/EthenaUnstaker.sol addr=0xD9F27e0988566b13708CE3c5CeCF71F47207ccca
make match file=src/contracts/EthenaUnstaker.sol addr=0xAEaC6756F3dd48274828Db0825FDd5234BD05e19
make match file=src/contracts/EthenaUnstaker.sol addr=0x4CDf0dEd7ad6A2bE4fE3E9Ef36E7888Ebb56f744
make match file=src/contracts/EthenaUnstaker.sol addr=0xb7Dd6bd11dD7AaB0272d2E98B1722651f2608BE9
make match file=src/contracts/EthenaUnstaker.sol addr=0xd033802F4c41Df8a4B2A867191e8AAD30dbf0Afa
make match file=src/contracts/EthenaUnstaker.sol addr=0xB251Ebf01Ea5eB3030B79a809895eF8c2d0c2a78
make match file=src/contracts/EthenaUnstaker.sol addr=0xd58f624fc33c20e5EA0212373523e87694D365ac
make match file=src/contracts/EthenaUnstaker.sol addr=0x659d886f12f68F0C8513D5aE0F08f830c6BA388a
make match file=src/contracts/EthenaUnstaker.sol addr=0xeC1f1bDdf266f7De8bc661bA6E550B2f275327aB
make match file=src/contracts/EthenaUnstaker.sol addr=0x6deDd77c9C85787923ed5E2a7AE6dF432063503A
make match file=src/contracts/EthenaUnstaker.sol addr=0x0aF356DF5410b5efDD2216d2fb1678e6aa7d93CB
make match file=src/contracts/EthenaUnstaker.sol addr=0x2F31972667B81fD52DBc749919dbDb9ED115fc6f
make match file=src/contracts/EthenaUnstaker.sol addr=0xbDb40B3bDa7d314bC1C89B05c02f3E4400C6EAa7
make match file=src/contracts/EthenaUnstaker.sol addr=0x986f349c0e8dE9DAC6228e55F0AFa62Ee715F255
make match file=src/contracts/EthenaUnstaker.sol addr=0x3001d34b0eA46356d8CF722018EE41D7C48b5e23
make match file=src/contracts/EthenaUnstaker.sol addr=0x72e74CF11FB8132935c9F2fDBE928B344BA82A40
make match file=src/contracts/EthenaUnstaker.sol addr=0x3fC64c268e5bD825fcDE2eB6574309a21928b4a9
```

## Governance

EthenaARM is owned by the multisig directly (not by governance), so there is no governance proposal for this deployment. The upgrade (`upgradeToAndCall` running `checkNoLegacyWithdrawQueue`), the sUSDe base-asset registration via `addBaseAsset`, and the final `unpause()` are all executed by the multisig owner. The adapter proxy is initialized with the deployer as temporary owner so it can run `deployUnstakers()`, after which ownership is transferred to the multisig (`GOV_MULTISIG`).

## Governance action checklist

These are the actions governance must perform to complete the upgrade:

- [x] Deploy Ethena script
- [x] Ensure there is no more pending Ethena `requestRedeem` ([here](https://etherscan.io/address/0xCEDa2d856238aA0D12f6329de20B9115f07C366d#readProxyContract#F26)): calling it should return 0. RequestRedeem action is disabled, so we shouldn't have any.
- [x] Ensure contract is paused.
- [x] Ensure there are no unclaimed user pending requests, with [Dune query](https://dune.com/queries/7698846) and the [`check_pending_redeems.py`](script/check_pending_redeems.py) script:
  ```bash
  python3 script/check_pending_redeems.py --arm 0xCEDa2d856238aA0D12f6329de20B9115f07C366d
  ```
- [x] On 5/8 `addBaseAsset` for sUSDe + `unpause` + `upgrade` ([tx](https://app.blocksec.com/phalcon/explorer/tx/eth/0x83421e06661ea4182ba43ef105d2259f533485a9a300ce0d82a0a74ff4d3e62c))
- [x] Ensure all actions work well

### `addBaseAsset` parameters (sUSDe)

From `031_UpgradeEthenaARMScript.s.sol`, the call to make on the 5/8 multisig is:

| Param | Value | Note |
| - | - | - |
| `newBaseAsset` | `0x9D39A5DE30e57443BfF2A8307A4256c8797A3497` | sUSDe |
| `adapter` | `0xE620aFB67223AE03C260112aE21A717Af94C90f0` | EthenaAssetAdapter proxy |
| `buyPrice` | `998000000000000000000000000000000000` | `0.998e36` — 0.998 USDe per sUSDe |
| `sellPrice` | `1000000000000000000000000000000000000` | `1e36` — 1 USDe per sUSDe |
| `buyAmount` | `340282366920938463463374607431768211455` | `type(uint128).max` |
| `sellAmount` | `340282366920938463463374607431768211455` | `type(uint128).max` |
| `newCrossPrice` | `999960000000000000000000000000000000` | `0.99996e36` — totalAssets() valuation |
| `peggedToLiquidityAsset` | `false` | |

