### PR TITLE
Add getBaseAssets getter + fix liquidity task queue accounting

### DIFF
--- a/script/deploy/mainnet/034_UpgradeEthenaARMGetBaseAssetsScript.s.sol
+++ b/script/deploy/mainnet/034_UpgradeEthenaARMGetBaseAssetsScript.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contract
+import {Proxy} from "contracts/Proxy.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+import {EthenaARM} from "contracts/EthenaARM.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+
+/// @title Upgrade Ethena ARM to expose getBaseAssets()
+/// @notice Upgrades the multisig-owned Ethena ARM to a fresh EthenaARM implementation that exposes
+///         the new `getBaseAssets()` getter added to AbstractARM. The 031 implementation predates the
+///         getter, so this is a logic-only upgrade: storage layout is unchanged, and no adapter
+///         redeployment or base-asset registration is needed (sUSDe stays registered from 031).
+contract $034_UpgradeEthenaARMGetBaseAssetsScript is AbstractDeployScript("034_UpgradeEthenaARMGetBaseAssetsScript") {
+    function _execute() internal override {
+        // Same constructor args as the 031 deployment; only the logic (the getBaseAssets getter) changes.
+        uint256 claimDelay = 10 minutes;
+        EthenaARM armImpl = new EthenaARM(
+            Mainnet.USDE,
+            claimDelay,
+            1e18, // minSharesToRedeem
+            100e18 // allocateThreshold
+        );
+
+        _recordDeployment("ETHENA_ARM_IMPL", address(armImpl));
+    }
+
+    function _fork() internal override {
+        Proxy proxy = Proxy(payable(resolver.resolve("ETHENA_ARM")));
+        address impl = resolver.resolve("ETHENA_ARM_IMPL");
+
+        // Idempotent: skip if the proxy already runs this implementation.
+        if (proxy.implementation() == impl) return;
+
+        // Ethena ARM is multisig-owned, so the upgrade is performed directly by the owner rather than
+        // through a governance proposal. getBaseAssets() is a pure view addition, so no
+        // re-initialization call is required.
+        vm.prank(proxy.owner());
+        proxy.upgradeTo(impl);
+    }
+}

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -1200,4 +1200,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         armBuffer = _armBuffer;
         emit ARMBufferUpdated(_armBuffer);
     }
+
+    /// @notice List of supported base assets iterated by totalAssets().
+    /// @return The supported base asset addresses.
+    function getBaseAssets() external view returns (address[] memory) {
+        return baseAssets;
+    }
 }

--- a/src/js/tasks/liquidity.js
+++ b/src/js/tasks/liquidity.js
@@ -323,11 +323,10 @@ const logLiquidity = async ({ block, arm, base }) => {
 };
 
 const logWithdrawalQueue = async (arm, blockTag, liquidityWeth) => {
-  const queue = await arm.withdrawsQueued({
-    blockTag,
-  });
-  const claimed = await arm.withdrawsClaimed({ blockTag });
-  const outstanding = queue - claimed;
+  // Since the withdrawal queue refactor (#208) the queue is tracked in shares.
+  // `reservedWithdrawLiquidity` exposes the outstanding obligation directly in
+  // liquidity-asset terms, replacing the old `withdrawsQueued - withdrawsClaimed`.
+  const outstanding = await arm.reservedWithdrawLiquidity({ blockTag });
   const available = liquidityWeth - outstanding;
 
   console.log(`\nARM Withdrawal Queue`);

--- a/test/smoke/AbstractSmokeTest.sol
+++ b/test/smoke/AbstractSmokeTest.sol
@@ -241,4 +241,18 @@ abstract contract AbstractSmokeTest is Test {
             );
         }
     }
+
+    /// @dev Assert `expected` appears in the ARM's `getBaseAssets()` list. A membership check
+    ///      rather than exact array equality keeps the assertion robust to registration order and
+    ///      to additional base assets being registered by future deployments.
+    function _assertBaseAssetListed(address[] memory baseAssets, address expected, string memory label) internal pure {
+        bool found = false;
+        for (uint256 i = 0; i < baseAssets.length; ++i) {
+            if (baseAssets[i] == expected) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, label);
+    }
 }

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -55,6 +55,8 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         (,,,, uint128 crossPrice,,,) = ethenaARM.baseAssetConfigs(Mainnet.SUSDE);
         assertEq(crossPrice, 0.99996e36, "cross price");
 
+        _assertBaseAssetListed(ethenaARM.getBaseAssets(), Mainnet.SUSDE, "sUSDe listed as base asset");
+
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
         assertEq(capManager.totalAssetsCap(), 100000 ether, "total assets cap");
         //assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 20000 ether, "liquidity provider cap");

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -22,6 +22,12 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
     CapManager capManager;
     address operator;
 
+    /// @dev EthenaAssetAdapter storage slots (see `forge inspect EthenaAssetAdapter storageLayout`):
+    ///      `totalRequests` is the public counter at slot 45, `nextPendingIndex` (internal FIFO claim
+    ///      cursor) immediately follows at slot 46.
+    uint256 internal constant ETHENA_ADAPTER_TOTAL_REQUESTS_SLOT = 45;
+    uint256 internal constant ETHENA_ADAPTER_NEXT_PENDING_INDEX_SLOT = 46;
+
     function setUp() public override {
         super.setUp();
         usde = IERC20(Mainnet.USDE);
@@ -232,6 +238,11 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         // trader sells sUSDe and buys USDE, the ARM buys sUSDe as a 20 bps discount
         _swapExactTokensForTokens(susde, usde, 0.998e36, 100 ether);
 
+        // On a `latest` fork the live adapter can already hold real, in-flight sUSDe cooldown
+        // requests at the head of its FIFO queue. Isolate the test's request so the claim succeeds
+        // regardless of that pre-existing on-chain state.
+        _isolateEthenaAdapterQueue();
+
         // Owner requests an Ethena withdrawal
         uint256 nextUnstakerIndex = ethenaAssetAdapter.nextUnstakerIndex();
         skip(DELAY_REQUEST + 1);
@@ -285,5 +296,26 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         uint256 balanceAfter = usde.balanceOf(address(ethenaARM));
 
         assertGt(balanceAfter, balanceBefore, "Allocated amount with yield");
+    }
+
+    /// @dev Advance the adapter's FIFO claim cursor (`nextPendingIndex`) past every pre-existing
+    ///      pending request so the test's own request becomes the head of the claimable queue.
+    ///      `EthenaAssetAdapter.redeem()` is strictly FIFO and requires the claimed shares to match
+    ///      the front request, so on a `latest` fork — where the live adapter can already hold real,
+    ///      in-flight sUSDe cooldown requests — claiming just the test's request would revert with
+    ///      "Adapter: invalid redeem amount". The adapter preserves the invariant
+    ///      `nextUnstakerIndex == totalRequests % MAX_UNSTAKERS`, so the next request lands on the free
+    ///      unstaker `unstakers[totalRequests % MAX_UNSTAKERS]` at request index `totalRequests` — which
+    ///      is exactly where the cursor is moved to here.
+    function _isolateEthenaAdapterQueue() internal {
+        uint256 totalRequests = ethenaAssetAdapter.totalRequests();
+        // nextPendingIndex is internal, so it is written by storage slot. Verify the layout
+        // assumption (totalRequests at slot 45) first so a future reordering fails loudly instead of
+        // silently corrupting adapter state.
+        require(
+            uint256(vm.load(address(ethenaAssetAdapter), bytes32(ETHENA_ADAPTER_TOTAL_REQUESTS_SLOT))) == totalRequests,
+            "Ethena adapter storage layout changed; update queue slots"
+        );
+        vm.store(address(ethenaAssetAdapter), bytes32(ETHENA_ADAPTER_NEXT_PENDING_INDEX_SLOT), bytes32(totalRequests));
     }
 }

--- a/test/smoke/EtherFiARMSmokeTest.t.sol
+++ b/test/smoke/EtherFiARMSmokeTest.t.sol
@@ -59,6 +59,8 @@ contract Fork_EtherFiARM_Smoke_Test is AbstractSmokeTest {
         (,,,, uint128 crossPrice,,,) = etherFiARM.baseAssetConfigs(Mainnet.EETH);
         assertEq(crossPrice, 0.99996e36, "cross price");
 
+        _assertBaseAssetListed(etherFiARM.getBaseAssets(), Mainnet.EETH, "eETH listed as base asset");
+
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
         assertEq(capManager.totalAssetsCap(), 1000 ether, "total assets cap");
         assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 150 ether, "liquidity provider cap");

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -59,6 +59,10 @@ contract Fork_LidoARM_Smoke_Test is AbstractSmokeTest {
         (,,,, uint128 crossPrice,,,) = lidoARM.baseAssetConfigs(address(steth));
         assertEq(crossPrice, 0.99996e36, "cross price");
 
+        address[] memory baseAssets = lidoARM.getBaseAssets();
+        _assertBaseAssetListed(baseAssets, address(steth), "stETH listed as base asset");
+        _assertBaseAssetListed(baseAssets, Mainnet.WSTETH, "wstETH listed as base asset");
+
         assertEq(capManager.accountCapEnabled(), false, "account cap enabled");
         assertEq(capManager.operator(), Mainnet.ARM_RELAYER, "Operator");
         assertEq(capManager.arm(), address(lidoARM), "arm");

--- a/test/smoke/OethARMSmokeTest.t.sol
+++ b/test/smoke/OethARMSmokeTest.t.sol
@@ -91,6 +91,10 @@ contract Fork_OriginARM_Smoke_Test is AbstractSmokeTest {
         assertNotEq(buyPrice, 0, "woeth buy price");
         assertEq(wrappedOriginAssetAdapter.convertToAssets(1 ether), woeth.convertToAssets(1 ether), "woeth assets");
 
+        address[] memory baseAssets = originARM.getBaseAssets();
+        _assertBaseAssetListed(baseAssets, Mainnet.OETH, "OETH listed as base asset");
+        _assertBaseAssetListed(baseAssets, Mainnet.WOETH, "wOETH listed as base asset");
+
         // Redemption
         assertEq(address(originARM.vault()), Mainnet.OETH_VAULT, "OETH Vault");
         assertEq(originARM.claimDelay(), 10 minutes, "claim delay");

--- a/test/unit/LidoARM/concrete/Admin.t.sol
+++ b/test/unit/LidoARM/concrete/Admin.t.sol
@@ -289,6 +289,35 @@ contract Unit_LidoARM_Admin_Test is Unit_LidoARM_Shared_Test {
     }
 
     //////////////////////////////////////////////////////
+    /// --- getBaseAssets
+    //////////////////////////////////////////////////////
+
+    function test_GetBaseAssets_EmptyByDefault() public view {
+        // No base asset registered yet, so the list is empty.
+        address[] memory assets = lidoARM.getBaseAssets();
+        assertEq(assets.length, 0, "no base assets registered");
+    }
+
+    function test_GetBaseAssets_SingleAsset() public {
+        addBaseAsset(steth);
+
+        address[] memory assets = lidoARM.getBaseAssets();
+        assertEq(assets.length, 1, "one base asset registered");
+        assertEq(assets[0], address(steth), "first base asset is stETH");
+    }
+
+    function test_GetBaseAssets_MultipleAssets_PreservesInsertionOrder() public {
+        addBaseAsset(steth);
+        addBaseAsset(wsteth);
+
+        // The list mirrors the storage array, so it reflects registration order.
+        address[] memory assets = lidoARM.getBaseAssets();
+        assertEq(assets.length, 2, "two base assets registered");
+        assertEq(assets[0], address(steth), "first base asset is stETH");
+        assertEq(assets[1], address(wsteth), "second base asset is wstETH");
+    }
+
+    //////////////////////////////////////////////////////
     /// --- setPrices
     //////////////////////////////////////////////////////
 


### PR DESCRIPTION
## Summary

### 1. `getBaseAssets()` getter on `AbstractARM`
Exposes the internal `baseAssets` array via an `external view` getter so off-chain callers can enumerate the supported base assets without reading storage manually.
- NatSpec added, matching the existing getter style (e.g. `asset()`).
- Unit tests cover the empty list, single-asset, and multi-asset (insertion-order preserved) cases.
- Smoke tests: each ARM's `test_initialConfig` asserts `getBaseAssets()` lists the configured base assets (stETH/wstETH, OETH/wOETH, sUSDe, eETH), via a shared membership helper (containment, not exact equality — robust to registration order and future base assets).

### 2. Deploy script `034_UpgradeEthenaARMGetBaseAssetsScript`
The deployed Ethena ARM runs the `031` implementation, which predates `getBaseAssets()`. Unlike Lido/EtherFi/Origin, the smoke harness does not redeploy the Ethena logic when `031` is already live on the fork, so the getter reverted under CI (which forks at `latest`).
- Logic-only upgrade: deploys a fresh `EthenaARM` implementation and upgrades the multisig-owned proxy to it.
- Storage layout unchanged; sUSDe stays registered from `031` (no adapter redeploy / base-asset registration).
- The smoke harness now upgrades the Ethena ARM to this implementation, so `getBaseAssets()` is available and the assertion passes; on mainnet it brings the deployed ARM up to this version.

### 3. Ethena claim smoke test made fork-state independent
`EthenaAssetAdapter.redeem()` is strictly FIFO and requires the claimed shares to match the front request. On a `latest` fork the live adapter can already hold real, in-flight sUSDe cooldown requests at the head of its queue, so `test_claim_ethena_request_with_delay` reverted with `Adapter: invalid redeem amount`. The test now advances the adapter's claim cursor (`nextPendingIndex = totalRequests`) past any pre-existing requests before making its own, so it passes regardless of live on-chain queue state. A storage-layout guard fails loudly if the adapter's slots are ever reordered.

### 4. `liquidity.js` outstanding-queue fix
Since the withdrawal queue refactor (#208) the queue is tracked in **shares**, so the old `withdrawsQueued - withdrawsClaimed` no longer reflects the outstanding obligation in liquidity-asset terms. The task now reads `reservedWithdrawLiquidity` directly.

## Testing
- `forge build` — passes (pre-existing warnings only)
- `forge test --match-path "test/unit/**"` — 249 passed, 0 failed
- `make test-smoke` (pinned fork block) — 49 passed, 0 failed
- Full smoke suite at `latest` fork block (CI condition) — all ARMs green, incl. Ethena 12/12
- `forge fmt --check` — clean; `prettier`/`eslint` on `liquidity.js` — clean