### PR TITLE
[ARM] Deploy 034 EthenaARM upgrade exposing getBaseAssets()

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -17,7 +17,7 @@
             "name": "ETHENA_ARM_CAP_MAN"
         },
         {
-            "implementation": "0x028b9077f7E97E2F3E8AFC6eaaD310eB36A2bB39",
+            "implementation": "0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe",
             "name": "ETHENA_ARM_IMPL"
         },
         {
@@ -286,6 +286,12 @@
             "name": "031_UpgradeEthenaARMScript",
             "proposalId": 1,
             "tsDeployment": 1781612483,
+            "tsGovernance": 1
+        },
+        {
+            "name": "034_UpgradeEthenaARMGetBaseAssetsScript",
+            "proposalId": 1,
+            "tsDeployment": 1781855555,
             "tsGovernance": 0
         }
     ]


### PR DESCRIPTION
# Description

Deploy a new implementation for EthenaARM that exposes the `getBaseAssets()` getter added to `AbstractARM`. The currently deployed Ethena ARM runs the `031` implementation, which predates the getter. This is a **logic-only upgrade**: storage layout is unchanged, sUSDe stays registered from the `031` deployment, and no adapter redeployment or base-asset registration is needed.

The following PRs are included in this deployment

### ARM

- https://github.com/OriginProtocol/arm-oeth/pull/275

## Deployment

Script `script/deploy/mainnet/034_UpgradeEthenaARMGetBaseAssetsScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| EthenaARM implementation | [0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe](https://etherscan.io/address/0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe) |

## Contract diff
```python
make match file=src/contracts/EthenaARM.sol addr=0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe
```

## Governance

EthenaARM is owned by the multisig directly (not by governance), so there is no governance proposal for this deployment. The upgrade (`upgradeTo`) is executed by the multisig owner. `getBaseAssets()` is a pure view addition, so no re-initialization call is required.

## Governance action checklist

These are the actions governance must perform to complete the upgrade:

- [x] Deploy Ethena script
- [x] On 5/8 multisig, call `upgradeTo` on the Ethena ARM proxy ([0xCEDa2d856238aA0D12f6329de20B9115f07C366d](https://etherscan.io/address/0xCEDa2d856238aA0D12f6329de20B9115f07C366d)) with the new implementation `0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe`
- [x] Ensure `getBaseAssets()` returns sUSDe and all actions work well

### `upgradeTo` parameters

From `034_UpgradeEthenaARMGetBaseAssetsScript.s.sol`, the call to make on the 5/8 multisig is:

| Param | Value | Note |
| - | - | - |
| target (proxy) | `0xCEDa2d856238aA0D12f6329de20B9115f07C366d` | EthenaARM proxy |
| `newImplementation` | `0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe` | new EthenaARM implementation |
