### PR TITLE
Bump @talos/client to e0c53b2f06b8

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
-    "@talos/client": "github:oplabs/talos#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client"
+    "@talos/client": "github:oplabs/talos#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@talos/client':
-        specifier: github:oplabs/talos#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client
-        version: git+https://git@github.com:oplabs/talos.git#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client(typescript@5.9.3)(zod@3.25.76)
+        specifier: github:oplabs/talos#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client
+        version: git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client(typescript@5.9.3)(zod@3.25.76)
     devDependencies:
       '@apollo/client':
         specifier: ^3.11.4
@@ -1244,9 +1244,9 @@ packages:
   '@solidity-parser/parser@0.18.0':
     resolution: {integrity: sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==}
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client':
-    resolution: {commit: 0a6ecc9c273561dfad4dbe69c3708f3521a1670b, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
-    version: 0.0.21
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client':
+    resolution: {commit: e0c53b2f06b8aa627640a7cb3631140dcae14f41, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
+    version: 0.0.23
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -5207,7 +5207,7 @@ snapshots:
 
   '@solidity-parser/parser@0.18.0': {}
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client(typescript@5.9.3)(zod@3.25.76)':
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.16)
       croner: 10.0.1


### PR DESCRIPTION
The runtime didn't get bumped to the proper Talos client version so the attempted fix by Clement the other day is not live yet.