### PR TITLE
[ARM] Deploy 032 EtherFi ARM swap-fee upgrade with eETH and weETH asset adapters

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -21,7 +21,7 @@
             "name": "ETHENA_ARM_IMPL"
         },
         {
-            "implementation": "0x6DB596b66FED6a9994e09EeD70b6d210F01705E5",
+            "implementation": "0xac9759571bDFbdD7E9C5a45A313190c28a65184c",
             "name": "ETHERFI_ARM_IMPL"
         },
         {
@@ -111,6 +111,22 @@
         {
             "implementation": "0xE620aFB67223AE03C260112aE21A717Af94C90f0",
             "name": "ETHENA_ARM_SUSDE_ADAPTER"
+        },
+        {
+            "implementation": "0xa2c52459E2D1412d889ED94FBC6D1b806Ec2c481",
+            "name": "ETHER_FI_ARM_EETH_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0xaE45aF19EDb64E1D67185a648680A6dA468aB77E",
+            "name": "ETHER_FI_ARM_EETH_ADAPTER"
+        },
+        {
+            "implementation": "0x9c89A1e5DFeb7530ea0Aa429ac1c524D767ac003",
+            "name": "ETHER_FI_ARM_WEETH_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0x4576Ca992789B1B65574B631C635BE4adf176608",
+            "name": "ETHER_FI_ARM_WEETH_ADAPTER"
         }
     ],
     "executions": [
@@ -292,6 +308,12 @@
             "name": "034_UpgradeEthenaARMGetBaseAssetsScript",
             "proposalId": 1,
             "tsDeployment": 1781855555,
+            "tsGovernance": 1
+        },
+        {
+            "name": "032_UpgradeEtherFiARMSwapFeeScript",
+            "proposalId": 0,
+            "tsDeployment": 1782201503,
             "tsGovernance": 0
         }
     ]

--- a/script/GenEtherFiGovProposal.s.sol
+++ b/script/GenEtherFiGovProposal.s.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+// Foundry
+import {console2} from "forge-std/console2.sol";
+
+// Helpers
+import {GovHelper} from "script/deploy/helpers/GovHelper.sol";
+import {Root, State} from "script/deploy/helpers/DeploymentTypes.sol";
+
+// Addresses
+import {Mainnet} from "src/contracts/utils/Addresses.sol";
+
+// The deploy script whose governance proposal we want to encode
+import {$032_UpgradeEtherFiARMSwapFeeScript} from "script/deploy/mainnet/032_UpgradeEtherFiARMSwapFeeScript.s.sol";
+
+/// @title GenEtherFiGovProposal
+/// @notice Builds the EtherFi ARM (script 032) governance proposal in memory and prints the
+///         `propose(...)` calldata WITHOUT simulating / executing it.
+/// @dev One-off helper for the 032 deployment — safe to delete once the proposal is submitted.
+/// @dev The deploy framework's fork path runs `GovHelper.simulate()`, which actually *executes*
+///      the proposal on the fork. There, `upgradeToAndCall(impl, checkNoLegacyWithdrawQueue())`
+///      reverts while the legacy withdraw queue is still non-empty. This helper only *builds*
+///      the proposal — `getParams()` / `getProposeCalldata()` are pure, so it can never revert
+///      on that check. The legacy queue must still be cleared before the real on-chain upgrade.
+///
+///      No RPC is needed: the proposal only references resolver addresses + constants.
+///
+///      Usage:
+///        forge script script/GenEtherFiGovProposal.s.sol
+contract GenEtherFiGovProposal is $032_UpgradeEtherFiARMSwapFeeScript {
+    function run() external override {
+        // 1. Bootstrap the deterministic Resolver singleton so resolver.resolve() works.
+        vm.etch(address(resolver), vm.getDeployedCode("Resolver.sol:Resolver"));
+        resolver.setState(State.FORK_DEPLOYING);
+
+        // 2. Load the mainnet deployment history (the addresses the proposal references).
+        Root memory root =
+            abi.decode(vm.parseJson(vm.readFile(string.concat(projectRoot, "/build/deployments-1.json"))), (Root));
+        for (uint256 i; i < root.contracts.length; ++i) {
+            resolver.addContract(root.contracts[i].name, root.contracts[i].implementation);
+        }
+
+        // 3. Build the proposal in memory — no execution, so checkNoLegacyWithdrawQueue never runs.
+        _buildGovernanceProposal();
+
+        // 4. Print the full payload.
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            string[] memory sigs,
+            bytes[] memory data,
+            bytes[] memory calldatas
+        ) = GovHelper.getParams(govProposal);
+
+        console2.log("Governor (GOVERNOR_SIX):", Mainnet.GOVERNOR_SIX);
+        console2.log("Proposal id:", GovHelper.id(govProposal));
+        console2.log("Description:", govProposal.description);
+
+        for (uint256 i; i < targets.length; ++i) {
+            console2.log("");
+            console2.log("action", i);
+            console2.log("  target:", targets[i]);
+            console2.log("  value:", values[i]);
+            console2.log("  sig:", sigs[i]);
+            console2.log("  data (no selector):");
+            console2.logBytes(data[i]);
+            console2.log("  full calldata (selector + data):");
+            console2.logBytes(calldatas[i]);
+        }
+
+        console2.log("");
+        console2.log("=== propose() calldata to send to GOVERNOR_SIX ===");
+        console2.logBytes(GovHelper.getProposeCalldata(govProposal));
+    }
+}

--- a/script/deploy/mainnet/032_UpgradeEtherFiARMSwapFeeScript.s.sol
+++ b/script/deploy/mainnet/032_UpgradeEtherFiARMSwapFeeScript.s.sol
@@ -13,7 +13,7 @@ import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";
 contract $032_UpgradeEtherFiARMSwapFeeScript is AbstractDeployScript("032_UpgradeEtherFiARMSwapFeeScript") {
     using GovHelper for GovProposal;
 
-    bool public constant override skip = true;
+    bool public constant override skip = false;
 
     // Prices are intentionally set wider than the current on-chain prices (buy ~0.9992, sell ~0.99998)
     // to discourage swaps right after the upgrade. The operator can tighten them later via setPrices().


### PR DESCRIPTION
# Description

Deploy a new implementation for EtherFiARM that migrates it to the multi-base model with swap-only fee accrual, together with two new asset adapters:

- **`EtherFiAssetAdapter`** (eETH) — moves the eETH staking/withdrawal logic into a dedicated adapter behind a proxy.
- **`WeETHAssetAdapter`** (weETH) — adds weETH as a second base asset, wrapping/unwrapping to eETH and routing withdrawals through the Ether.fi withdrawal queue.

Both adapters are deployed behind a proxy whose admin/owner is the Timelock, and are initialized through the proxy (`initialize()` sets the eETH approval to the Ether.fi withdrawal queue).

The following PRs are included in this deployment

### ARM

- https://github.com/OriginProtocol/arm-oeth/pull/208
- https://github.com/OriginProtocol/arm-oeth/pull/267

## Deployment

Script `script/deploy/mainnet/032_UpgradeEtherFiARMSwapFeeScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| EtherFiARM implementation | [0xac9759571bDFbdD7E9C5a45A313190c28a65184c](https://etherscan.io/address/0xac9759571bDFbdD7E9C5a45A313190c28a65184c) |
| EtherFiAssetAdapter (eETH) implementation | [0xa2c52459E2D1412d889ED94FBC6D1b806Ec2c481](https://etherscan.io/address/0xa2c52459E2D1412d889ED94FBC6D1b806Ec2c481) |
| EtherFiAssetAdapter (eETH) proxy | [0xaE45aF19EDb64E1D67185a648680A6dA468aB77E](https://etherscan.io/address/0xaE45aF19EDb64E1D67185a648680A6dA468aB77E) |
| WeETHAssetAdapter (weETH) implementation | [0x9c89A1e5DFeb7530ea0Aa429ac1c524D767ac003](https://etherscan.io/address/0x9c89A1e5DFeb7530ea0Aa429ac1c524D767ac003) |
| WeETHAssetAdapter (weETH) proxy | [0x4576Ca992789B1B65574B631C635BE4adf176608](https://etherscan.io/address/0x4576Ca992789B1B65574B631C635BE4adf176608) |

## Contract diff
```python
make match file=src/contracts/EtherFiARM.sol addr=0xac9759571bDFbdD7E9C5a45A313190c28a65184c
make match file=src/contracts/adapters/EtherFiAssetAdapter.sol addr=0xa2c52459E2D1412d889ED94FBC6D1b806Ec2c481
make match file=src/contracts/Proxy.sol addr=0xaE45aF19EDb64E1D67185a648680A6dA468aB77E
make match file=src/contracts/adapters/WeETHAssetAdapter.sol addr=0x9c89A1e5DFeb7530ea0Aa429ac1c524D767ac003
make match file=src/contracts/Proxy.sol addr=0x4576Ca992789B1B65574B631C635BE4adf176608
```

## Governance

Unlike EthenaARM (multisig-owned), **EtherFiARM is owned by the Timelock** (`0x35918cDE7233F2dD33fA41ae3Cb6aE0e42E0e69F`), which is the executor of the OZ Governor `GOVERNOR_SIX` (`0x1D3Fbd4d129Ddd2372EA85c5Fa00b2682081c9EC`). So this upgrade goes through a standard GovernorSix proposal: when the proposal executes, GovernorSix routes the calls through the Timelock, which holds both the `owner` and proxy-admin roles on the ARM.

Verified on-chain:

| Check | Value | Expected |
| - | - | - |
| EtherFiARM proxy `owner()` | `0x35918cDE…E0e69F` | TIMELOCK ✅ |
| EtherFiARM proxy admin (EIP-1967 slot) | `0x35918cDE…E0e69F` | TIMELOCK ✅ |
| `GovernorSix.timelock()` | `0x35918cDE…E0e69F` | TIMELOCK ✅ |

The proposal performs 5 actions, all on the EtherFiARM proxy `0xfB0A3CF9B019BFd8827443d131b235B3E0FC58d2` (value `0`), as built in `_buildGovernanceProposal()`:

| # | Signature | Args |
| - | - | - |
| 0 | `collectFees()` | — |
| 1 | `upgradeToAndCall(address,bytes)` | impl `0xac9759571bDFbdD7E9C5a45A313190c28a65184c`, data `0x227e4c21` (= `checkNoLegacyWithdrawQueue()`) |
| 2 | `addBaseAsset(address,address,uint256,uint256,uint256,uint256,uint256,bool)` | eETH — see params below |
| 3 | `addBaseAsset(address,address,uint256,uint256,uint256,uint256,uint256,bool)` | weETH — see params below |
| 4 | `unpause()` | — |

**Description:** `Collect legacy EtherFi ARM fees, upgrade to swap-only fee accrual, register eETH and weETH base assets with zero swap limits, and unpause the ARM`

**Proposal id:** `105654574937231003330392513643829003112386243262807514278502537561017349450193`

### `addBaseAsset` parameters (eETH)

| Param | Value | Note |
| - | - | - |
| `newBaseAsset` | `0x35fA164735182de50811E8e2E824cFb9B6118ac2` | eETH |
| `adapter` | `0xaE45aF19EDb64E1D67185a648680A6dA468aB77E` | EtherFiAssetAdapter (eETH) proxy |
| `buyPrice` | `998000000000000000000000000000000000` | `0.998e36` |
| `sellPrice` | `1000000000000000000000000000000000000` | `1e36` |
| `buyAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `sellAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `newCrossPrice` | `999960000000000000000000000000000000` | `0.99996e36` — totalAssets() valuation |
| `peggedToLiquidityAsset` | `true` | |

### `addBaseAsset` parameters (weETH)

| Param | Value | Note |
| - | - | - |
| `newBaseAsset` | `0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee` | weETH |
| `adapter` | `0x4576Ca992789B1B65574B631C635BE4adf176608` | WeETHAssetAdapter (weETH) proxy |
| `buyPrice` | `998000000000000000000000000000000000` | `0.998e36` |
| `sellPrice` | `1000000000000000000000000000000000000` | `1e36` |
| `buyAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `sellAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `newCrossPrice` | `999960000000000000000000000000000000` | `0.99996e36` — totalAssets() valuation |
| `peggedToLiquidityAsset` | `false` | |

### `propose()` calldata

Calldata for `propose(address[],uint256[],string[],bytes[],string)` to submit to GOVERNOR_SIX (`0x1D3Fbd4d129Ddd2372EA85c5Fa00b2682081c9EC`):

```
0xda95691a00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000000000004a000000000000000000000000000000000000000000000000000000000000008800000000000000000000000000000000000000000000000000000000000000005000000000000000000000000fb0a3cf9b019bfd8827443d131b235b3e0fc58d2000000000000000000000000fb0a3cf9b019bfd8827443d131b235b3e0fc58d2000000000000000000000000fb0a3cf9b019bfd8827443d131b235b3e0fc58d2000000000000000000000000fb0a3cf9b019bfd8827443d131b235b3e0fc58d2000000000000000000000000fb0a3cf9b019bfd8827443d131b235b3e0fc58d2000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000220000000000000000000000000000000000000000000000000000000000000000d636f6c6c65637446656573282900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001f75706772616465546f416e6443616c6c28616464726573732c62797465732900000000000000000000000000000000000000000000000000000000000000004a61646442617365417373657428616464726573732c616464726573732c75696e743235362c75696e743235362c75696e743235362c75696e743235362c75696e743235362c626f6f6c2900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004a61646442617365417373657428616464726573732c616464726573732c75696e743235362c75696e743235362c75696e743235362c75696e743235362c75696e743235362c626f6f6c29000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009756e706175736528290000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000003a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000ac9759571bdfbdd7e9c5a45a313190c28a65184c00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000004227e4c2100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000035fa164735182de50811e8e2e824cfb9b6118ac2000000000000000000000000ae45af19edb64e1d67185a648680a6da468ab77e0000000000000000000000000000000000c03532ef3febef41c8e8fc000000000000000000000000000000000000000000c097ce7bc90715b34b9f1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c095d59cd0868ab10672760000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000cd5fe23c85820f7b72d0926fc9b05b43e359b7ee0000000000000000000000004576ca992789b1b65574b631c635be4adf1766080000000000000000000000000000000000c03532ef3febef41c8e8fc000000000000000000000000000000000000000000c097ce7bc90715b34b9f1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c095d59cd0868ab106727600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000091436f6c6c656374206c656761637920457468657246692041524d20666565732c207570677261646520746f20737761702d6f6e6c7920666565206163637275616c2c207265676973746572206545544820616e642077654554482062617365206173736574732077697468207a65726f2073776170206c696d6974732c20616e6420756e7061757365207468652041524d000000000000000000000000000000
```

> ⚠️ The legacy withdraw queue must be emptied before this proposal is executed: action 1's `upgradeToAndCall` runs `checkNoLegacyWithdrawQueue()`, which reverts while the queue is still non-empty.

This calldata is generated **without** simulating/executing the proposal (so it can't revert on `checkNoLegacyWithdrawQueue` while the queue is non-empty) via the helper script:

```bash
forge script script/GenEtherFiGovProposal.s.sol
```


## ⚠️ Smoke tests are expected to fail (for now)

The smoke suite currently fails at `setUp()` with:

```
[FAIL: TimelockController: underlying transaction reverted] setUp()
```

This is **expected** and not a regression. The smoke tests fork mainnet and replay every deployment through `DeployManager`. Because script 032 is recorded with `proposalId: 0` (governance pending), the framework simulates the proposal end-to-end (propose → vote → queue → execute). Action 1 (`upgradeToAndCall`) runs `checkNoLegacyWithdrawQueue()`, which reverts with `Legacy EtherFi withdraw pending` because the legacy EtherFi withdraw queue (`_deprecatedEtherfiWithdrawalQueueAmount`) is not empty yet. The Timelock surfaces that inner revert as `TimelockController: underlying transaction reverted`.

The legacy queue will be emptied **just before** the real on-chain upgrade (it cannot be cleared earlier). Once it is empty — and the proposal is executed and recorded in `build/deployments-1.json` — the simulation passes and the smoke tests go green. No code change is needed here to "fix" them.
