### PR TITLE
[ARM] Ether ARM

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -13,8 +13,8 @@ import {IAssetAdapter, IERC20, ICapManager} from "./Interfaces.sol";
  * @title Generic Automated Redemption Manager (ARM)
  * @notice Coordinates liquidity-provider shares, two-token swaps, active market allocation, and
  * protocol-specific redemption adapters for one liquidity asset and one or more supported base assets.
- * @dev Existing ARM proxies depend on the original storage prefix. New multi-base state is appended after
- * legacy single-base storage so Lido, EtherFi, Ethena, and Origin ARMs can share this implementation.
+ * @dev Fresh-deploy ARM implementation. It intentionally omits the legacy single-base storage slots
+ * retained by AbstractARM for existing proxy upgrades.
  * @author Origin Protocol Inc
  */
 abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGuardUpgradeable {
@@ -50,22 +50,8 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     uint256 public immutable claimDelay;
 
     ////////////////////////////////////////////////////
-    ///                 Storage
+    ///                 Structs
     ////////////////////////////////////////////////////
-
-    /// @dev Legacy single-base storage. Keep this prefix unchanged for existing proxy upgrades.
-    /// These fields are retained for storage/ABI compatibility and are not the source of truth for
-    /// multi-base swap pricing.
-    uint256 internal _deprecatedTraderate0;
-    uint256 internal _deprecatedTraderate1;
-    uint256 internal _deprecatedCrossPrice;
-
-    /// @dev Legacy asset-denominated queue counters retained for storage layout compatibility.
-    uint128 internal _deprecatedWithdrawsQueued;
-    uint128 internal _deprecatedWithdrawsClaimed;
-    /// @notice Index of the next LP withdrawal request.
-    uint256 public nextWithdrawalIndex;
-
     /// @notice LP withdrawal request for liquidity assets.
     struct WithdrawalRequest {
         address withdrawer;
@@ -76,39 +62,10 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         uint128 assets;
         /// @notice Cumulative queued LP shares including this request.
         uint128 queued;
-        /// @notice LP shares escrowed when this request was made.
-        uint128 shares;
     }
 
-    /// @notice Mapping of LP withdrawal request ids to request data.
-    mapping(uint256 requestId => WithdrawalRequest) public withdrawalRequests;
-
-    /// @notice Swap fee share collected on discounted base-asset buy swaps, in basis points.
-    /// 10,000 = 100% fee
-    /// 500 = 5% fee
-    uint16 public fee;
-    /// @dev Deprecated storage retained for layout compatibility.
-    int128 internal _deprecatedLastAvailableAssets;
-    /// @notice Account or contract that can collect accrued swap fees.
-    address public feeCollector;
-    /// @notice Optional CapManager contract used to enforce LP and total asset caps.
-    address public capManager;
-
-    /// @notice Active ERC-4626 lending market used for excess liquidity.
-    address public activeMarket;
-    /// @notice Lending markets that can be used by the ARM.
-    mapping(address market => bool supported) public supportedMarkets;
-    /// @notice Percentage of available liquid assets to keep in the ARM. 100% = 1e18.
-    uint256 public armBuffer;
-
-    /// @notice True when user-facing ARM actions are paused.
-    bool public paused;
-
-    /// @notice Accrued swap fees denominated in the liquidity asset.
-    uint128 public feesAccrued;
-
     /// @notice Per-base-asset swap, valuation, and adapter configuration.
-    /// @dev Packed into three storage slots. `adapter != address(0)` is the supported-asset flag.
+    /// @dev Packed into four storage slots. `adapter != address(0)` is the supported-asset flag.
     struct BaseAssetConfig {
         /// @notice Price the ARM pays in liquidity-asset terms when buying this base asset from traders.
         uint128 buyPrice;
@@ -128,19 +85,47 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         address adapter;
     }
 
+    ////////////////////////////////////////////////////
+    ///                 Storage
+    ////////////////////////////////////////////////////
+    /// @notice Index of the next LP withdrawal request.
+    uint256 public nextWithdrawalIndex;
+    /// @notice Mapping of LP withdrawal request ids to request data.
+    mapping(uint256 requestId => WithdrawalRequest) public withdrawalRequests;
+
+    /// @notice Optional CapManager contract used to enforce LP and total asset caps.
+    address public capManager;
+
+    /// @notice Active ERC-4626 lending market used for excess liquidity.
+    address public activeMarket;
+    /// @notice Lending markets that can be used by the ARM.
+    mapping(address market => bool supported) public supportedMarkets;
+    /// @notice Percentage of available liquid assets to keep in the ARM. 100% = 1e18.
+    uint256 public armBuffer;
+
     /// @notice Supported base assets for totalAssets() iteration.
     address[] internal baseAssets;
     /// @notice Base asset configuration. A zero adapter means unsupported.
     mapping(address asset => BaseAssetConfig) public baseAssetConfigs;
 
+    /// @notice True when user-facing ARM actions are paused.
+    bool public paused;
+    /// @notice Swap fee share collected on discounted base-asset buy swaps, in basis points.
+    /// 10,000 = 100% fee
+    /// 500 = 5% fee
+    uint16 public fee;
+    /// @notice Account or contract that can collect accrued swap fees.
+    address public feeCollector;
+    /// @notice Accrued swap fees denominated in the liquidity asset.
+    uint128 public feesAccrued;
     /// @notice Cumulative LP shares queued for redemption, used by the FIFO gate.
     uint128 public withdrawsQueuedShares;
     /// @notice Cumulative LP shares claimed and burned.
     uint128 public withdrawsClaimedShares;
     /// @notice Maximum liquidity assets reserved for outstanding LP withdrawal requests.
-    uint256 public reservedWithdrawLiquidity;
+    uint128 public reservedWithdrawLiquidity;
 
-    uint256[33] private _gap;
+    uint256[50] private _gap;
 
     ////////////////////////////////////////////////////
     ///                 Errors
@@ -172,6 +157,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     error QueuePendingLiquidity(); // 0xa5e8d7ac
     error NotRequesterOrOperator(); // 0x40e6afe4
     error AlreadyClaimed(); // 0x646cf558
+    error InvalidWithdrawalRequest(); // 0xa0fc0d03
 
     ////////////////////////////////////////////////////
     ///                 Events
@@ -794,7 +780,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         uint128 queued = SafeCast.toUint128(withdrawsQueuedShares + shares);
         withdrawsQueuedShares = queued;
         // Reserve the request-time maximum liquidity payout.
-        reservedWithdrawLiquidity += assets;
+        reservedWithdrawLiquidity = SafeCast.toUint128(uint256(reservedWithdrawLiquidity) + assets);
 
         uint40 claimTimestamp = uint40(block.timestamp + claimDelay);
         withdrawalRequests[requestId] = WithdrawalRequest({
@@ -802,8 +788,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
             claimed: false,
             claimTimestamp: claimTimestamp,
             assets: SafeCast.toUint128(assets),
-            queued: queued,
-            shares: SafeCast.toUint128(shares)
+            queued: queued
         });
 
         // Escrow the redeemer's shares so they stay in totalSupply() and share losses/gains pro-rata.
@@ -828,21 +813,23 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         if (request.withdrawer != msg.sender && msg.sender != operator) revert NotRequesterOrOperator();
         if (request.claimed) revert AlreadyClaimed();
 
+        uint256 shares = withdrawalRequestShares(requestId);
+
         // In the scenario where the ARM has made a loss after the redeem request, the asset value of
         // the redeemed shares at the time of the claim is used.
         // This can happen if there was a significant slashing event on the base asset, eg stETH,
         // after the redeem request was made.
-        uint256 assetsAtClaim = convertToAssets(request.shares);
+        uint256 assetsAtClaim = convertToAssets(shares);
         // Use the minimum of the asset value of the redeemed shares at request or claim.
         assets = request.assets < assetsAtClaim ? request.assets : assetsAtClaim;
 
         // Release the full request-time reservation, even when a loss-adjusted payout is lower.
         reservedWithdrawLiquidity -= request.assets;
         // Cumulative claimed amount in shares, used by the FIFO gate above.
-        withdrawsClaimedShares += request.shares;
+        withdrawsClaimedShares += SafeCast.toUint128(shares);
 
         // Burn the escrowed shares after `assets` was computed so conversion uses the pre-claim supply.
-        _burn(address(this), request.shares);
+        _burn(address(this), shares);
 
         // Store the request as claimed.
         withdrawalRequests[requestId].claimed = true;
@@ -851,6 +838,17 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         // Transfer the liquidity asset to the withdrawer.
         IERC20(liquidityAsset).transfer(request.withdrawer, assets);
         emit RedeemClaimed(request.withdrawer, requestId, assets);
+    }
+
+    /// @notice Get the LP shares escrowed for a withdrawal request.
+    /// @param requestId LP withdrawal request id.
+    /// @return shares LP shares represented by the request.
+    function withdrawalRequestShares(uint256 requestId) public view returns (uint256 shares) {
+        if (requestId >= nextWithdrawalIndex) revert InvalidWithdrawalRequest();
+
+        WithdrawalRequest memory request = withdrawalRequests[requestId];
+        uint256 previousQueued = requestId == 0 ? 0 : withdrawalRequests[requestId - 1].queued;
+        shares = request.queued - previousQueued;
     }
 
     /// @dev Pull liquidity from the active market if the ARM does not hold enough to pay a redeem claim.

--- a/src/contracts/EtherARM.sol
+++ b/src/contracts/EtherARM.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import {AbstractARM} from "./AbstractARM.sol";
+
+/**
+ * @title Ether Automated Redemption Manager (ARM)
+ * @dev This implementation supports multiple Liquidity Providers (LPs) with single buy and sell prices.
+ * It also integrates to a CapManager contract that caps the amount of assets a liquidity provider
+ * can deposit and caps the ARM's total assets.
+ * A fee is accrued on discounted base-asset buy swaps.
+ * @author Origin Protocol Inc
+ */
+contract EtherARM is AbstractARM {
+    /// @param _weth The address of the WETH token
+    /// @param _claimDelay The delay in seconds before a user can claim a redeem from the request
+    /// @param _minSharesToRedeem The minimum amount of shares to redeem from the active lending market
+    /// @param _allocateThreshold The minimum amount of liquidity assets in excess of the ARM buffer before
+    /// the ARM can allocate to a active lending market.
+    constructor(address _weth, uint256 _claimDelay, uint256 _minSharesToRedeem, int256 _allocateThreshold)
+        AbstractARM(_weth, _claimDelay, _minSharesToRedeem, _allocateThreshold)
+    {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize the storage variables stored in the proxy contract.
+    /// The deployer that calls initialize has to approve the ARM's proxy contract to transfer 1e12 WETH.
+    /// @param _name The name of the liquidity provider (LP) token.
+    /// @param _symbol The symbol of the liquidity provider (LP) token.
+    /// @param _operator The address of the account that can request and claim base-asset redemptions.
+    /// @param _fee The fee accrued on discounted base-asset buy swaps measured in basis points (1/100th of a percent).
+    /// 10,000 = 100% fee
+    /// 500 = 5% fee
+    /// @param _feeCollector The account that can collect the accrued swap fee
+    /// @param _capManager The address of the CapManager contract
+    function initialize(
+        string calldata _name,
+        string calldata _symbol,
+        address _operator,
+        uint256 _fee,
+        address _feeCollector,
+        address _capManager
+    ) external initializer {
+        _initARM(_operator, _name, _symbol, _fee, _feeCollector, _capManager);
+    }
+}

--- a/test/fork/LidoARM/ClaimRedeem.t.sol
+++ b/test/fork/LidoARM/ClaimRedeem.t.sol
@@ -275,7 +275,7 @@ contract Fork_Concrete_LidoARM_ClaimRedeem_Test_ is Fork_Shared_Test_ {
         weth.transfer(address(0), DEFAULT_AMOUNT / 10); // burn some WETH
 
         // Withdrawal request
-        (,,, uint128 assets,,) = lidoARM.withdrawalRequests(0);
+        (,,, uint128 assets,) = lidoARM.withdrawalRequests(0);
 
         // Main call
         uint256 claimed = lidoARM.claimRedeem(0);

--- a/test/fork/OriginARM/ClaimRedeem.sol
+++ b/test/fork/OriginARM/ClaimRedeem.sol
@@ -76,7 +76,7 @@ contract Fork_Concrete_OriginARM_ClaimRedeem_Test_ is Fork_Shared_Test {
         setActiveMarket(address(siloMarket))
         requestRedeemAll(alice)
     {
-        (,,, uint128 requestAssets,,) = originARM.withdrawalRequests(0);
+        (,,, uint128 requestAssets,) = originARM.withdrawalRequests(0);
 
         // Assertions before claim
         assertApproxEqAbs(originARM.totalAssets(), uint256(requestAssets) + MIN_TOTAL_SUPPLY, 1, "totalAssets before");

--- a/test/fork/utils/Helpers.sol
+++ b/test/fork/utils/Helpers.sol
@@ -59,9 +59,9 @@ abstract contract Helpers is Base_Test_ {
             bool _claimed,
             uint40 _claimTimestamp,
             uint128 _assets,
-            uint128 _queued,
-            uint128 _shares
+            uint128 _queued
         ) = lidoARM.withdrawalRequests(requestId);
+        uint256 _shares = lidoARM.withdrawalRequestShares(requestId);
         assertEq(_withdrawer, withdrawer, "Wrong withdrawer");
         assertEq(_claimed, claimed, "Wrong claimed");
         assertEq(_claimTimestamp, claimTimestamp, "Wrong claimTimestamp");

--- a/test/invariants/EthenaARM/Properties.sol
+++ b/test/invariants/EthenaARM/Properties.sol
@@ -149,7 +149,7 @@ abstract contract Properties is TargetFunctions {
     function sumOfUnclaimedRequestAssets() public view returns (uint256 sum) {
         uint256 len = arm.nextWithdrawalIndex();
         for (uint256 i; i < len; i++) {
-            (, bool claimed,, uint128 amount,,) = arm.withdrawalRequests(i);
+            (, bool claimed,, uint128 amount,) = arm.withdrawalRequests(i);
             if (!claimed) sum += amount;
         }
     }

--- a/test/invariants/EthenaARM/TargetFunctions.sol
+++ b/test/invariants/EthenaARM/TargetFunctions.sol
@@ -196,7 +196,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
 
         // Claim redeem as user
         uint256 balanceBefore = usde.balanceOf(address(arm));
-        (,,,,, uint128 requestShares) = arm.withdrawalRequests(requestId);
+        uint256 requestShares = arm.withdrawalRequestShares(requestId);
         vm.prank(user);
         uint256 amount = arm.claimRedeem(requestId);
 
@@ -928,7 +928,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         vm.warp(block.timestamp + DEFAULT_CLAIM_DELAY);
         uint256 nextWithdrawalIndex = arm.nextWithdrawalIndex();
         for (uint256 i; i < nextWithdrawalIndex; i++) {
-            (address user, bool claimed,,,,) = arm.withdrawalRequests(i);
+            (address user, bool claimed,,,) = arm.withdrawalRequests(i);
             if (claimed) continue;
             vm.prank(user);
             arm.claimRedeem(i);

--- a/test/invariants/EthenaARM/helpers/Find.sol
+++ b/test/invariants/EthenaARM/helpers/Find.sol
@@ -27,7 +27,7 @@ library Find {
                 // Take a random request from that user
                 uint256 _requestId = pendingRequests[_user][($.randomArrayIndex + j) % pendingRequests[_user].length];
                 // Check request data
-                (,, uint40 _claimTimestamp, uint128 _amount, uint128 _queued,) =
+                (,, uint40 _claimTimestamp, uint128 _amount, uint128 _queued) =
                     AbstractARM($.arm).withdrawalRequests(_requestId);
                 // Check if this is claimable
                 if (_queued <= $.claimable && _amount <= $.availableLiquidity) {

--- a/test/invariants/LidoARM/TargetFunction.t.sol
+++ b/test/invariants/LidoARM/TargetFunction.t.sol
@@ -236,7 +236,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         (address user, uint256 requestId, uint256 positionInList) = selectUserWithPendingRequest();
         vm.assume(user != address(0));
 
-        (,,, uint128 reqAssets,, uint128 reqShares) = lidoARM.withdrawalRequests(requestId);
+        uint256 reqShares = lidoARM.withdrawalRequestShares(requestId);
 
         // claimable() passing does not guarantee claimRedeem succeeds (known limitation, see PR#247).
         // The share-based FIFO gate can pass while the market lacks liquidity for this specific request.

--- a/test/invariants/LidoARM/helpers/Helpers.t.sol
+++ b/test/invariants/LidoARM/helpers/Helpers.t.sol
@@ -99,8 +99,7 @@ abstract contract Helpers is Base_Test_ {
 
         for (uint256 i; i < pendingRequestCount; i++) {
             uint256 requestId = _pendingRequestIds[i];
-            (address user, bool claimed, uint40 claimTimestamp,, uint128 queued,) =
-                lidoARM.withdrawalRequests(requestId);
+            (address user, bool claimed, uint40 claimTimestamp,, uint128 queued) = lidoARM.withdrawalRequests(requestId);
             if (claimTimestamp > block.timestamp) continue; // Claim delay not elapsed
             if (queued > claimable) continue; // FIFO gate: not enough backed liquidity
 
@@ -153,7 +152,7 @@ abstract contract Helpers is Base_Test_ {
     function sumOfUnclaimedRequestAssets() public view returns (uint256 total) {
         uint256 nextIdx = lidoARM.nextWithdrawalIndex();
         for (uint256 i; i < nextIdx; i++) {
-            (, bool claimed,, uint128 assets,,) = lidoARM.withdrawalRequests(i);
+            (, bool claimed,, uint128 assets,) = lidoARM.withdrawalRequests(i);
             if (!claimed) total += assets;
         }
     }
@@ -162,7 +161,7 @@ abstract contract Helpers is Base_Test_ {
     function sumOfUserPendingAssets(address user) public view returns (uint256 total) {
         uint256 nextIdx = lidoARM.nextWithdrawalIndex();
         for (uint256 i; i < nextIdx; i++) {
-            (address withdrawer, bool claimed,, uint128 assets,,) = lidoARM.withdrawalRequests(i);
+            (address withdrawer, bool claimed,, uint128 assets,) = lidoARM.withdrawalRequests(i);
             if (withdrawer == user && !claimed) total += assets;
         }
     }

--- a/test/invariants/OriginARM/Helpers.sol
+++ b/test/invariants/OriginARM/Helpers.sol
@@ -179,7 +179,7 @@ abstract contract Helpers is Setup, Logger {
 
             // Access the element at the shuffled position
             uint256 id = requests_[indices[j]];
-            (,, uint40 ts, uint256 asset, uint256 queued,) = originARM.withdrawalRequests(id);
+            (,, uint40 ts, uint256 asset, uint256 queued) = originARM.withdrawalRequests(id);
 
             // Return if it satisfies the condition
             if (queued <= claimable) return (id, asset, ts);

--- a/test/invariants/OriginARM/Properties.sol
+++ b/test/invariants/OriginARM/Properties.sol
@@ -121,7 +121,7 @@ abstract contract Properties is Setup, Helpers {
     function sumOfUnclaimedRequestRedeemAmount() public view returns (uint256 sum) {
         uint256 len = originARM.nextWithdrawalIndex();
         for (uint256 i; i < len; i++) {
-            (, bool claimed,, uint128 amount,,) = originARM.withdrawalRequests(i);
+            (, bool claimed,, uint128 amount,) = originARM.withdrawalRequests(i);
             if (!claimed) sum += amount;
         }
     }

--- a/test/invariants/OriginARM/TargetFunction.sol
+++ b/test/invariants/OriginARM/TargetFunction.sol
@@ -144,7 +144,7 @@ abstract contract TargetFunction is Properties {
         // Remove the request from the list
         removeRequest(user, id);
         sum_ws_user_claimed += assets;
-        (,,,,, uint128 requestShares) = originARM.withdrawalRequests(id);
+        uint256 requestShares = originARM.withdrawalRequestShares(id);
         sum_shares_claimed += requestShares;
     }
 
@@ -573,7 +573,7 @@ abstract contract TargetFunction is Properties {
         // No unclaimed requests
         uint256 len = originARM.nextWithdrawalIndex();
         for (uint256 i; i < len; i++) {
-            (, bool claimed,,,,) = originARM.withdrawalRequests(i);
+            (, bool claimed,,,) = originARM.withdrawalRequests(i);
             require(claimed, "All withdrawals should be claimed");
         }
         // No users with shares

--- a/test/unit/LidoARM/Shared.t.sol
+++ b/test/unit/LidoARM/Shared.t.sol
@@ -361,9 +361,9 @@ abstract contract Unit_LidoARM_Shared_Test is Base_Test_ {
             bool claimed,
             uint40 claimTimestamp,
             uint128 storedAssets,
-            uint128 storedQueued,
-            uint128 storedShares
+            uint128 storedQueued
         ) = lidoARM.withdrawalRequests(requestId);
+        uint256 storedShares = lidoARM.withdrawalRequestShares(requestId);
         assertEq(withdrawer, expectedWithdrawer, "req.withdrawer");
         assertEq(claimed, false, "req.claimed");
         assertEq(claimTimestamp, expectedClaimTimestamp, "req.claimTimestamp");

--- a/test/unit/LidoARM/fuzz/ClaimRedeem.fuzz.t.sol
+++ b/test/unit/LidoARM/fuzz/ClaimRedeem.fuzz.t.sol
@@ -66,7 +66,7 @@ contract Unit_Fuzz_LidoARM_ClaimRedeem_Test is Unit_LidoARM_Shared_Test {
         assertEq(lidoARM.reservedWithdrawLiquidity(), reservedBefore - requestAssets, "reserved released");
         assertEq(lidoARM.withdrawsClaimedShares(), claimedSharesBefore + shares, "withdrawsClaimedShares");
 
-        (, bool claimed,,,,) = lidoARM.withdrawalRequests(requestId);
+        (, bool claimed,,,) = lidoARM.withdrawalRequests(requestId);
         assertTrue(claimed, "request marked claimed");
     }
 
@@ -115,7 +115,7 @@ contract Unit_Fuzz_LidoARM_ClaimRedeem_Test is Unit_LidoARM_Shared_Test {
         // The yield stays with the remaining LPs: share price strictly above 1 after the claim.
         assertGt(lidoARM.convertToAssets(1 ether), 1 ether, "share price > 1 after claim");
 
-        (, bool claimed,,,,) = lidoARM.withdrawalRequests(requestId);
+        (, bool claimed,,,) = lidoARM.withdrawalRequests(requestId);
         assertTrue(claimed, "request marked claimed");
     }
 
@@ -171,7 +171,7 @@ contract Unit_Fuzz_LidoARM_ClaimRedeem_Test is Unit_LidoARM_Shared_Test {
         assertEq(lidoARM.balanceOf(alice), 0, "alice shares");
         assertEq(lidoARM.balanceOf(address(lidoARM)), 0, "escrow burned");
 
-        (, bool claimed,,,,) = lidoARM.withdrawalRequests(requestId);
+        (, bool claimed,,,) = lidoARM.withdrawalRequests(requestId);
         assertTrue(claimed, "request marked claimed");
     }
 
@@ -204,7 +204,7 @@ contract Unit_Fuzz_LidoARM_ClaimRedeem_Test is Unit_LidoARM_Shared_Test {
         assertEq(lidoARM.reservedWithdrawLiquidity(), 0, "reserved released");
         assertEq(lidoARM.withdrawsClaimedShares(), 50 ether, "withdrawsClaimedShares");
 
-        (, bool claimed,,,,) = lidoARM.withdrawalRequests(requestId);
+        (, bool claimed,,,) = lidoARM.withdrawalRequests(requestId);
         assertTrue(claimed, "request marked claimed");
     }
 }


### PR DESCRIPTION
Summary:
- Add fresh-deploy EtherARM.
- Remove legacy upgrade storage from AbstractARM and pack withdrawal requests by deriving shares from cumulative queued shares.
- Expose withdrawalRequestShares() and update tests/helpers for the new withdrawalRequests() shape.

Reason:
- The ETH ARM will be deployed from scratch, so legacy upgrade storage is no longer needed.
- Deriving request shares saves one storage slot per withdrawal request while keeping loss socialization through escrowed shares.