### PR TITLE
Added Talos actions

### DIFF
--- a/migrations/seed_schedules.sql
+++ b/migrations/seed_schedules.sql
@@ -31,6 +31,13 @@ INSERT INTO schedules (product, name, command, cron_expr, timezone, enabled, not
 -- placeholders. For ids, use a comma-separated list, eg --ids 12,13,14.
 -- cron_expr is a placeholder that never fires while disabled.
 ('arm-oeth', 'mainnet_claim_redeem',                 'cd /app && pnpm hardhat claimRedeem --arm lido --ids 0 --network mainnet',         '0 0 * * *',             'UTC', false, NULL),
+-- ARM buffer changes: manual-only (enabled=false). Edit `--arm` and `--buffer`
+-- before using "Run now". 0.1 = 10% buffer, 1 = 100% buffer.
+('arm-oeth', 'Set ARM Buffer - Mainnet',             'cd /app && pnpm hardhat setARMBufferAction --arm lido --buffer 0.1 --network mainnet', '0 0 * * *',          'UTC', false, NULL),
+-- ARM cap changes: manual-only (enabled=false). Edit `--arm`, `--accounts`,
+-- and/or `--cap` before using "Run now".
+('arm-oeth', 'Set Liquidity Provider Caps - Mainnet','cd /app && pnpm hardhat setLiquidityProviderCapsAction --arm lido --accounts 0x0000000000000000000000000000000000000000 --cap 20000 --network mainnet', '0 0 * * *', 'UTC', false, NULL),
+('arm-oeth', 'Set Total Assets Cap - Mainnet',       'cd /app && pnpm hardhat setTotalAssetsCapAction --arm lido --cap 100000 --network mainnet', '0 0 * * *',         'UTC', false, NULL),
 ('arm-oeth', 'sonic_auto_request_withdraw',          'cd /app && pnpm hardhat autoRequestWithdrawSonic --network sonic',          '48,18 * * * *',         'UTC', false, NULL),
 ('arm-oeth', 'sonic_auto_claim_withdraw',            'cd /app && pnpm hardhat autoClaimWithdrawSonic --network sonic',            '10 * * * *',            'UTC', false, NULL),
 ('arm-oeth', 'sonic_collect_fees',                   'cd /app && pnpm hardhat collectFeesSonic --network sonic',                  '55 23 * * *',           'UTC', false, NULL),

--- a/src/js/tasks/actions/setARMBufferAction.ts
+++ b/src/js/tasks/actions/setARMBufferAction.ts
@@ -1,0 +1,33 @@
+import { types } from "hardhat/config";
+
+import { action } from "../lib/action";
+import { resolveMainnetARM } from "../lib/arm";
+import { setARMBuffer } from "../admin";
+
+action({
+  name: "setARMBufferAction",
+  description: "Set ARM Buffer - Mainnet",
+  chains: [1],
+  params: (t) =>
+    t
+      .addParam(
+        "arm",
+        "ARM to set buffer for: lido, etherfi, ethena, or oeth",
+        undefined,
+        types.string,
+      )
+      .addParam(
+        "buffer",
+        "The new buffer value, where 0.1 = 10% and 1 = 100%",
+        undefined,
+        types.float,
+      ),
+  run: async ({ signer, log, args }) => {
+    const arm = resolveMainnetARM({
+      arm: String(args.arm),
+      signer,
+    });
+    log.info(`Setting ${arm.name} ARM buffer to ${args.buffer}`);
+    await setARMBuffer({ signer, arm: arm.contract, buffer: args.buffer });
+  },
+});

--- a/src/js/tasks/actions/setLiquidityProviderCapsAction.ts
+++ b/src/js/tasks/actions/setLiquidityProviderCapsAction.ts
@@ -1,0 +1,47 @@
+import { types } from "hardhat/config";
+
+import { action } from "../lib/action";
+import { resolveMainnetARM } from "../lib/arm";
+import { setLiquidityProviderCaps } from "../admin";
+
+action({
+  name: "setLiquidityProviderCapsAction",
+  description: "Set Liquidity Provider Caps - Mainnet",
+  chains: [1],
+  params: (t) =>
+    t
+      .addParam(
+        "arm",
+        "ARM to set liquidity provider caps for: lido, etherfi, ethena, or oeth",
+        undefined,
+        types.string,
+      )
+      .addParam(
+        "accounts",
+        "Comma-separated list of liquidity provider addresses",
+        undefined,
+        types.string,
+      )
+      .addParam(
+        "cap",
+        "Deposit cap per account in liquidity asset units, where 20000 = 20,000 USDe",
+        undefined,
+        types.float,
+      ),
+  run: async ({ signer, log, args }) => {
+    const arm = resolveMainnetARM({
+      arm: String(args.arm),
+      signer,
+    });
+    log.info(
+      `Setting ${arm.name} ARM liquidity provider caps to ${args.cap}`,
+    );
+    await setLiquidityProviderCaps({
+      signer,
+      arm: arm.contract,
+      armName: arm.name,
+      accounts: args.accounts,
+      cap: args.cap,
+    });
+  },
+});

--- a/src/js/tasks/actions/setTotalAssetsCapAction.ts
+++ b/src/js/tasks/actions/setTotalAssetsCapAction.ts
@@ -2,38 +2,37 @@ import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { resolveMainnetARM } from "../lib/arm";
-import { claimArmRedeems } from "../armRedeemQueue";
+import { setTotalAssetsCap } from "../admin";
 
 action({
-  name: "claimRedeem",
-  description:
-    "Claim one or more matured LP redeem requests on behalf of users",
+  name: "setTotalAssetsCapAction",
+  description: "Set Total Assets Cap - Mainnet",
   chains: [1],
   params: (t) =>
     t
       .addParam(
         "arm",
-        "ARM to claim from: lido, etherfi, or ethena",
+        "ARM to set total assets cap for: lido, etherfi, ethena, or oeth",
         undefined,
         types.string,
       )
       .addParam(
-        "ids",
-        "Comma-separated LP withdrawal request ids to claim, eg 12,13,14",
+        "cap",
+        "Total assets cap in liquidity asset units, where 100000 = 100,000 USDe",
         undefined,
-        types.string,
+        types.float,
       ),
   run: async ({ signer, log, args }) => {
     const arm = resolveMainnetARM({
       arm: String(args.arm),
       signer,
-      supportedArms: ["lido", "etherfi", "ethena"],
     });
-    await claimArmRedeems({
+    log.info(`Setting ${arm.name} ARM total assets cap to ${args.cap}`);
+    await setTotalAssetsCap({
+      signer,
       arm: arm.contract,
       armName: arm.name,
-      ids: args.ids,
-      log,
+      cap: args.cap,
     });
   },
 });

--- a/src/js/tasks/lib/arm.ts
+++ b/src/js/tasks/lib/arm.ts
@@ -1,0 +1,66 @@
+import { ethers } from "ethers";
+import type { Signer } from "ethers";
+
+import { mainnet } from "../../utils/addresses";
+const ethenaARMAbi = require("../../../abis/EthenaARM.json");
+const etherFiARMAbi = require("../../../abis/EtherFiARM.json");
+const lidoARMAbi = require("../../../abis/LidoARM.json");
+const originARMAbi = require("../../../abis/OriginARM.json");
+
+const MAINNET_ARMS = {
+  ethena: {
+    abi: ethenaARMAbi,
+    address: mainnet.ethenaARM,
+    name: "Ethena",
+  },
+  etherfi: {
+    abi: etherFiARMAbi,
+    address: mainnet.etherfiARM,
+    name: "EtherFi",
+  },
+  lido: {
+    abi: lidoARMAbi,
+    address: mainnet.lidoARM,
+    name: "Lido",
+  },
+  oeth: {
+    abi: originARMAbi,
+    address: mainnet.OethARM,
+    name: "OETH",
+  },
+};
+
+type MainnetArmKey = keyof typeof MAINNET_ARMS;
+const MAINNET_ARM_KEYS: MainnetArmKey[] = ["lido", "etherfi", "ethena", "oeth"];
+
+function formatSupportedArms(supportedArms: MainnetArmKey[]) {
+  if (supportedArms.length <= 1) return supportedArms.join("");
+
+  return `${supportedArms.slice(0, -1).join(", ")}, or ${
+    supportedArms[supportedArms.length - 1]
+  }`;
+}
+
+export function resolveMainnetARM({
+  arm,
+  signer,
+  supportedArms = MAINNET_ARM_KEYS,
+}: {
+  arm: string;
+  signer: Signer;
+  supportedArms?: MainnetArmKey[];
+}) {
+  const armKey = arm.toLowerCase() as MainnetArmKey;
+  const armConfig = MAINNET_ARMS[armKey];
+
+  if (!armConfig || !supportedArms.includes(armKey)) {
+    throw new Error(
+      `Unsupported ARM "${arm}" (use ${formatSupportedArms(supportedArms)})`,
+    );
+  }
+
+  return {
+    ...armConfig,
+    contract: new ethers.Contract(armConfig.address, armConfig.abi, signer),
+  };
+}


### PR DESCRIPTION
## Summary

Adds manual Talos actions for ARM operations that need editable runtime params:

- `setARMBufferAction`
- `setLiquidityProviderCapsAction`
- `setTotalAssetsCapAction`

Also adds a shared mainnet ARM resolver for Talos actions and uses it in `claimRedeem` to remove duplicated ARM param handling.

## Changes

- Added shared `resolveMainnetARM` utility for `lido`, `etherfi`, `ethena`, and `oeth`.
- Added manual mainnet-only Talos actions for:
  - setting ARM buffer
  - setting liquidity provider caps
  - setting total assets cap
- Added disabled manual schedule rows for the new actions in `migrations/seed_schedules.sql`.
- Refactored `claimRedeem` to use the shared ARM resolver.

## Testing

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm hardhat help setARMBufferAction`
- `pnpm hardhat help setLiquidityProviderCapsAction`
- `pnpm hardhat help setTotalAssetsCapAction`
- Verified invalid `--arm bad` errors clearly.
- Verified Sonic network fails mainnet-only chain validation.