### PR TITLE
Improved ARM pricing

### DIFF
--- a/src/js/tasks/actions/setPricesEthena.ts
+++ b/src/js/tasks/actions/setPricesEthena.ts
@@ -4,6 +4,7 @@ import { types } from "hardhat/config";
 import { action } from "../lib/action";
 import { setPrices } from "../armPrices";
 import { setPricesForBases } from "../../utils/priceActionUtils";
+import { resolveEthenaAggregatorAmount } from "../../utils/ethenaPricing";
 import { mainnet } from "../../utils/addresses";
 const ethenaARMAbi = require("../../../abis/EthenaARM.json");
 
@@ -43,8 +44,8 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "Reference swap amount used when fetching aggregator quotes.",
-        2000,
+        "Override for the reference swap amount used when fetching aggregator quotes.",
+        undefined,
         types.float,
       )
       .addOptionalParam(
@@ -81,6 +82,14 @@ action({
     const arm = new ethers.Contract(mainnet.ethenaARM, ethenaARMAbi, signer);
 
     log.info("Setting prices for Ethena ARM");
+    const amount = await resolveEthenaAggregatorAmount({
+      arm,
+      amount: args.amount,
+      log,
+      blockTag: "latest",
+    });
+    if (amount === undefined) return;
+
     await setPricesForBases({
       setPrices,
       bases: ["SUSDE"],
@@ -94,7 +103,7 @@ action({
         minBuyPrice: args.minBuyPrice,
         kyber: args.kyber,
         inch: args.inch,
-        amount: args.amount,
+        amount,
         tolerance: args.tolerance,
         fee: args.fee,
         offset: args.offset,

--- a/src/js/tasks/actions/setPricesEthena.ts
+++ b/src/js/tasks/actions/setPricesEthena.ts
@@ -67,6 +67,18 @@ action({
         types.float,
       )
       .addOptionalParam(
+        "dynamicOffset",
+        "Use a dynamic offset that scales from zero at cross price to the DEX spread at the full-spread price.",
+        false,
+        types.boolean,
+      )
+      .addOptionalParam(
+        "dynamicOffsetFullSpreadPrice",
+        "DEX sell price where dynamic offset reaches 100% of the DEX spread.",
+        0.999,
+        types.float,
+      )
+      .addOptionalParam(
         "tolerance",
         "Tolerance used when comparing target and current prices.",
         0.09,
@@ -107,6 +119,8 @@ action({
         tolerance: args.tolerance,
         fee: args.fee,
         offset: args.offset,
+        dynamicOffset: args.dynamicOffset,
+        dynamicOffsetFullSpreadPrice: args.dynamicOffsetFullSpreadPrice,
         priceOffset: true,
         blockTag: "latest",
         wrapped: true,

--- a/src/js/tasks/actions/setPricesEtherFi.ts
+++ b/src/js/tasks/actions/setPricesEtherFi.ts
@@ -66,6 +66,18 @@ action({
         types.float,
       )
       .addOptionalParam(
+        "dynamicOffset",
+        "Use a dynamic offset that scales from zero at cross price to the DEX spread at the full-spread price.",
+        false,
+        types.boolean,
+      )
+      .addOptionalParam(
+        "dynamicOffsetFullSpreadPrice",
+        "DEX sell price where dynamic offset reaches 100% of the DEX spread.",
+        0.999,
+        types.float,
+      )
+      .addOptionalParam(
         "tolerance",
         "Tolerance used when comparing target and current prices.",
         0.09,
@@ -98,6 +110,8 @@ action({
         tolerance: args.tolerance,
         fee: args.fee,
         offset: args.offset,
+        dynamicOffset: args.dynamicOffset,
+        dynamicOffsetFullSpreadPrice: args.dynamicOffsetFullSpreadPrice,
         priceOffset: true,
         blockTag: "latest",
       },

--- a/src/js/tasks/actions/setPricesLido.ts
+++ b/src/js/tasks/actions/setPricesLido.ts
@@ -66,6 +66,18 @@ action({
         types.float,
       )
       .addOptionalParam(
+        "dynamicOffset",
+        "Use a dynamic offset that scales from zero at cross price to the DEX spread at the full-spread price.",
+        false,
+        types.boolean,
+      )
+      .addOptionalParam(
+        "dynamicOffsetFullSpreadPrice",
+        "DEX sell price where dynamic offset reaches 100% of the DEX spread.",
+        0.999,
+        types.float,
+      )
+      .addOptionalParam(
         "tolerance",
         "Tolerance used when comparing target and current prices.",
         0.1,
@@ -98,6 +110,8 @@ action({
         tolerance: args.tolerance,
         fee: args.fee,
         offset: args.offset,
+        dynamicOffset: args.dynamicOffset,
+        dynamicOffsetFullSpreadPrice: args.dynamicOffsetFullSpreadPrice,
         priceOffset: true,
         blockTag: "latest",
       },

--- a/src/js/tasks/actions/setPricesOETH.ts
+++ b/src/js/tasks/actions/setPricesOETH.ts
@@ -66,6 +66,18 @@ action({
         types.float,
       )
       .addOptionalParam(
+        "dynamicOffset",
+        "Use a dynamic offset that scales from zero at cross price to the DEX spread at the full-spread price.",
+        false,
+        types.boolean,
+      )
+      .addOptionalParam(
+        "dynamicOffsetFullSpreadPrice",
+        "DEX sell price where dynamic offset reaches 100% of the DEX spread.",
+        0.999,
+        types.float,
+      )
+      .addOptionalParam(
         "tolerance",
         "Tolerance used when comparing target and current prices.",
         0.3,
@@ -98,6 +110,8 @@ action({
         tolerance: args.tolerance,
         fee: args.fee,
         offset: args.offset,
+        dynamicOffset: args.dynamicOffset,
+        dynamicOffsetFullSpreadPrice: args.dynamicOffsetFullSpreadPrice,
         priceOffset: true,
         blockTag: "latest",
       },

--- a/src/js/tasks/armPrices.js
+++ b/src/js/tasks/armPrices.js
@@ -14,6 +14,7 @@ const { get1InchPrices } = require("../utils/1Inch");
 const { logTxDetails } = require("../utils/txLogger");
 const {
   convertToAsset,
+  calculatePriceOffset,
   rangeSellPrice,
   rangeBuyPrice,
 } = require("../utils/pricing");
@@ -33,6 +34,8 @@ const log = require("../utils/logger")("task:prices");
  * curve/inch/kyber - whether to use Curve/1Inch/Kyber for reference prices
  * market - Ethers contract of the ARM's active lending market. Only used for Morpho markets
  * offset - price offset in basis points to add to the reference buy price when calculating target prices
+ * dynamicOffset - if true, scale the offset from 0 to the DEX spread based on distance from cross price
+ * dynamicOffsetFullSpreadPrice - price where dynamic offset reaches 100% of the DEX spread
  * priceOffset - whether to use the offset-based approach for calculating target prices, or just calculate off the reference mid price and fee
  * dryrun - if true, will not actually call setPrices on the ARM, just log the target prices
  * base - base asset symbol. eg STETH, WSTETH, EETH, WEETH, SUSDE, OETH, WOETH, OS
@@ -63,6 +66,8 @@ const setPrices = async (options) => {
     wrapped,
     buyAmount,
     sellAmount,
+    dynamicOffset,
+    dynamicOffsetFullSpreadPrice,
   } = options;
 
   // 1. Get current ARM prices
@@ -174,8 +179,18 @@ const setPrices = async (options) => {
     );
 
     // 2.2 Calculate target prices
-    const offsetBN = parseUnits(offset.toString(), 14);
     if (priceOffset && referencePrices.sellPrice) {
+      const offsetBN = calculatePriceOffset({
+        offset,
+        dynamicOffset,
+        dynamicOffsetFullSpreadPrice,
+        referencePrices,
+        crossPrice: config.crossPrice,
+      });
+      const dexSpread =
+        referencePrices.buyPrice > referencePrices.sellPrice
+          ? referencePrices.buyPrice - referencePrices.sellPrice
+          : 0n;
       // If price offset is provided, adjust the target prices accordingly
       log(`\nCalculating target prices based on offset:`);
       // Target buy price is the reference sell price plus the offset
@@ -184,6 +199,12 @@ const setPrices = async (options) => {
       targetSellPrice =
         targetBuyPrice + parseUnits(fee.toString(), 32) * BigInt(2);
       log(`offset             : ${formatUnits(offsetBN, 14)} basis points`);
+      if (dynamicOffset) {
+        log(
+          `dynamic offset     : full spread at ${dynamicOffsetFullSpreadPrice}`,
+        );
+        log(`DEX spread         : ${formatUnits(dexSpread, 18)}`);
+      }
       log(
         `fee                : ${formatUnits(
           BigInt(fee * 1000000),
@@ -193,6 +214,7 @@ const setPrices = async (options) => {
       log(`target sell price  : ${formatUnits(targetSellPrice, 36)}`);
       log(`target buy price   : ${formatUnits(targetBuyPrice, 36)}`);
     } else {
+      const offsetBN = parseUnits(offset.toString(), 14);
       // If no price offset, calculate target prices based fee and offset
       log(`\nCalculating target prices based on fee:`);
       const FeeScale = BigInt(1e6);

--- a/src/js/utils/ethenaPricing.js
+++ b/src/js/utils/ethenaPricing.js
@@ -1,0 +1,61 @@
+const { formatUnits } = require("ethers");
+
+const { resolveArmBase } = require("./arm");
+
+const DEFAULT_ETHENA_AGGREGATOR_AMOUNT = 2000;
+
+const hasAmountOverride = (amount) => amount !== undefined && amount !== null;
+
+const readReserveLiquidity = (reserves) =>
+  reserves.liquidityAssets ?? reserves[0];
+
+const resolveEthenaAggregatorAmount = async ({
+  arm,
+  amount,
+  log,
+  blockTag = "latest",
+  resolveArmBaseFn = resolveArmBase,
+  defaultAmount = DEFAULT_ETHENA_AGGREGATOR_AMOUNT,
+}) => {
+  if (hasAmountOverride(amount)) {
+    log?.info?.(`Using configured aggregator quote amount: ${amount} USDe`);
+    return amount;
+  }
+
+  const baseContext = await resolveArmBaseFn({
+    arm,
+    armName: "Ethena",
+    base: "SUSDE",
+    blockTag,
+  });
+
+  if (baseContext.version !== "multiBase") {
+    log?.info?.(
+      `Using default aggregator quote amount for legacy Ethena ARM: ${defaultAmount} USDe`,
+    );
+    return defaultAmount;
+  }
+
+  const reserves = await arm.getReserves(baseContext.baseAddress, {
+    blockTag,
+  });
+  const liquidityAssets = readReserveLiquidity(reserves);
+
+  if (liquidityAssets === 0n) {
+    log?.info?.(
+      "Skipping Ethena price update: no withdrawable USDe available in ARM or lending market",
+    );
+    return undefined;
+  }
+
+  const resolvedAmount = formatUnits(liquidityAssets, 18);
+  log?.info?.(
+    `Using ${resolvedAmount} USDe available in ARM and lending market as aggregator quote amount`,
+  );
+  return resolvedAmount;
+};
+
+module.exports = {
+  DEFAULT_ETHENA_AGGREGATOR_AMOUNT,
+  resolveEthenaAggregatorAmount,
+};

--- a/src/js/utils/pricing.js
+++ b/src/js/utils/pricing.js
@@ -3,6 +3,8 @@ const { ethers } = require("ethers");
 
 const log = require("../utils/logger")("task:utils:pricing");
 
+const PRICE_SCALE = parseUnits("1", 18);
+
 const convertToAsset = async (vaultAddress, amount, signer) => {
   const vault = new ethers.Contract(
     vaultAddress,
@@ -15,6 +17,55 @@ const convertToAsset = async (vaultAddress, amount, signer) => {
   const assetPrice =
     (assetAmount * parseUnits("1")) / parseUnits(amount.toString(), 18);
   return assetPrice;
+};
+
+const calculateDynamicPriceOffset = ({
+  referencePrices,
+  crossPrice,
+  dynamicOffsetFullSpreadPrice,
+}) => {
+  const crossPriceScaled = crossPrice / PRICE_SCALE;
+  const fullSpreadPrice = parseUnits(
+    dynamicOffsetFullSpreadPrice.toString(),
+    18,
+  );
+
+  if (fullSpreadPrice >= crossPriceScaled) {
+    throw new Error(
+      `dynamicOffsetFullSpreadPrice ${dynamicOffsetFullSpreadPrice} must be below cross price ${formatUnits(
+        crossPriceScaled,
+        18,
+      )}`,
+    );
+  }
+
+  const dexSellPrice = referencePrices.sellPrice;
+  const dexBuyPrice = referencePrices.buyPrice;
+  const spread = dexBuyPrice > dexSellPrice ? dexBuyPrice - dexSellPrice : 0n;
+
+  if (dexSellPrice >= crossPriceScaled) return 0n;
+  if (dexSellPrice <= fullSpreadPrice) return spread;
+
+  return (
+    (spread * (crossPriceScaled - dexSellPrice)) /
+    (crossPriceScaled - fullSpreadPrice)
+  );
+};
+
+const calculatePriceOffset = ({
+  offset,
+  dynamicOffset,
+  dynamicOffsetFullSpreadPrice,
+  referencePrices,
+  crossPrice,
+}) => {
+  if (!dynamicOffset) return parseUnits(offset.toString(), 14);
+
+  return calculateDynamicPriceOffset({
+    referencePrices,
+    crossPrice,
+    dynamicOffsetFullSpreadPrice,
+  });
 };
 
 const rangeSellPrice = (targetSellPrice, minSellPrice, maxSellPrice) => {
@@ -102,6 +153,8 @@ const convertReth = async (rethAmount, signer) => {
 
 module.exports = {
   convertToAsset,
+  calculateDynamicPriceOffset,
+  calculatePriceOffset,
   rangeSellPrice,
   rangeBuyPrice,
   convertReth,

--- a/test/js/ethenaPricing.test.js
+++ b/test/js/ethenaPricing.test.js
@@ -1,0 +1,146 @@
+const assert = require("assert");
+
+const { parseUnits } = require("ethers");
+
+const {
+  DEFAULT_ETHENA_AGGREGATOR_AMOUNT,
+  resolveEthenaAggregatorAmount,
+} = require("../../src/js/utils/ethenaPricing");
+
+const sUSDe = "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497";
+
+const logger = () => {
+  const messages = [];
+  return {
+    messages,
+    info: (message) => messages.push(message),
+  };
+};
+
+const multiBaseResolver = async () => ({
+  version: "multiBase",
+  baseAddress: sUSDe,
+});
+
+const legacyResolver = async () => ({
+  version: "legacy",
+  baseAddress: sUSDe,
+});
+
+const run = async () => {
+  {
+    let getReservesCalled = false;
+    const log = logger();
+    const amount = await resolveEthenaAggregatorAmount({
+      amount: 123,
+      log,
+      arm: {
+        getReserves: async () => {
+          getReservesCalled = true;
+          return [parseUnits("456", 18), 0n];
+        },
+      },
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(amount, 123);
+    assert.strictEqual(getReservesCalled, false);
+    assert.deepStrictEqual(log.messages, [
+      "Using configured aggregator quote amount: 123 USDe",
+    ]);
+  }
+
+  {
+    let requestedBaseAddress;
+    const amount = await resolveEthenaAggregatorAmount({
+      arm: {
+        getReserves: async (baseAddress) => {
+          requestedBaseAddress = baseAddress;
+          return [parseUnits("789.123", 18), 0n];
+        },
+      },
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(requestedBaseAddress, sUSDe);
+    assert.strictEqual(amount, "789.123");
+  }
+
+  {
+    const amount = await resolveEthenaAggregatorAmount({
+      arm: {
+        getReserves: async () => ({
+          liquidityAssets: parseUnits("321", 18),
+          baseAssetReserve: 0n,
+        }),
+      },
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(amount, "321.0");
+  }
+
+  {
+    const log = logger();
+    const amount = await resolveEthenaAggregatorAmount({
+      arm: {
+        getReserves: async () => [0n, 0n],
+      },
+      log,
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(amount, undefined);
+    assert.deepStrictEqual(log.messages, [
+      "Skipping Ethena price update: no withdrawable USDe available in ARM or lending market",
+    ]);
+  }
+
+  {
+    let getReservesCalled = false;
+    const amount = await resolveEthenaAggregatorAmount({
+      arm: {
+        getReserves: async () => {
+          getReservesCalled = true;
+          return [parseUnits("456", 18), 0n];
+        },
+      },
+      resolveArmBaseFn: legacyResolver,
+    });
+
+    assert.strictEqual(amount, DEFAULT_ETHENA_AGGREGATOR_AMOUNT);
+    assert.strictEqual(getReservesCalled, false);
+  }
+
+  {
+    let commonPricingAmount;
+    const resolvedAmount = await resolveEthenaAggregatorAmount({
+      arm: {
+        getReserves: async () => [parseUnits("654", 18), 0n],
+      },
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    const setPricesForBases = async ({ options }) => {
+      commonPricingAmount = options.amount;
+    };
+    await setPricesForBases({
+      options: {
+        amount: resolvedAmount,
+        kyber: true,
+        inch: true,
+      },
+    });
+
+    assert.strictEqual(commonPricingAmount, "654.0");
+  }
+};
+
+run()
+  .then(() => {
+    console.log("ethenaPricing tests passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/test/js/pricing.test.js
+++ b/test/js/pricing.test.js
@@ -1,0 +1,110 @@
+const assert = require("assert");
+
+const { formatUnits, parseUnits } = require("ethers");
+
+const {
+  calculateDynamicPriceOffset,
+  calculatePriceOffset,
+} = require("../../src/js/utils/pricing");
+
+const prices = ({ sell = "0.9995", buy = "0.9998" } = {}) => ({
+  sellPrice: parseUnits(sell, 18),
+  buyPrice: parseUnits(buy, 18),
+});
+
+const crossPrice = parseUnits("1", 36);
+const fullSpreadPrice = 0.999;
+const spread = parseUnits("0.0003", 18);
+
+const assertOffset = (actual, expected, label) => {
+  assert.strictEqual(formatUnits(actual, 18), expected, label);
+};
+
+const run = () => {
+  assertOffset(
+    calculateDynamicPriceOffset({
+      referencePrices: prices({ sell: "1.0", buy: "1.0003" }),
+      crossPrice,
+      dynamicOffsetFullSpreadPrice: fullSpreadPrice,
+    }),
+    "0.0",
+    "zero at cross price",
+  );
+
+  assertOffset(
+    calculateDynamicPriceOffset({
+      referencePrices: prices({ sell: "0.999", buy: "0.9993" }),
+      crossPrice,
+      dynamicOffsetFullSpreadPrice: fullSpreadPrice,
+    }),
+    "0.0003",
+    "full spread at anchor",
+  );
+
+  assert.strictEqual(
+    calculateDynamicPriceOffset({
+      referencePrices: prices({ sell: "0.9995", buy: "0.9998" }),
+      crossPrice,
+      dynamicOffsetFullSpreadPrice: fullSpreadPrice,
+    }),
+    spread / 2n,
+    "half spread halfway between cross and anchor",
+  );
+
+  assertOffset(
+    calculateDynamicPriceOffset({
+      referencePrices: prices({ sell: "0.998", buy: "0.9983" }),
+      crossPrice,
+      dynamicOffsetFullSpreadPrice: fullSpreadPrice,
+    }),
+    "0.0003",
+    "clamps to full spread below anchor",
+  );
+
+  assertOffset(
+    calculateDynamicPriceOffset({
+      referencePrices: prices({ sell: "1.0001", buy: "1.0004" }),
+      crossPrice,
+      dynamicOffsetFullSpreadPrice: fullSpreadPrice,
+    }),
+    "0.0",
+    "clamps to zero above cross",
+  );
+
+  assert.throws(
+    () =>
+      calculateDynamicPriceOffset({
+        referencePrices: prices(),
+        crossPrice,
+        dynamicOffsetFullSpreadPrice: 1.0,
+      }),
+    /must be below cross price/,
+  );
+
+  assert.strictEqual(
+    calculatePriceOffset({
+      offset: 0.2,
+      dynamicOffset: false,
+      dynamicOffsetFullSpreadPrice: fullSpreadPrice,
+      referencePrices: prices(),
+      crossPrice,
+    }),
+    parseUnits("0.2", 14),
+    "fixed mode uses configured offset",
+  );
+
+  assert.strictEqual(
+    calculatePriceOffset({
+      offset: 0.2,
+      dynamicOffset: true,
+      dynamicOffsetFullSpreadPrice: fullSpreadPrice,
+      referencePrices: prices({ sell: "0.999", buy: "0.9993" }),
+      crossPrice,
+    }),
+    spread,
+    "dynamic mode uses calculated spread offset",
+  );
+};
+
+run();
+console.log("pricing tests passed");


### PR DESCRIPTION
## Summary

- Improve Ethena ARM pricing by sizing aggregator quotes from withdrawable USDe in both the ARM and active lending market.
- Add an opt-in dynamic offset mode for ARM pricing that scales from zero at cross price to the full DEX spread at a configurable price.
- Keep existing fixed `--offset` behavior as the default.

## Details

For Ethena, the pricing action now resolves the quote amount from `getReserves(sUSDe)` when `--amount` is not explicitly provided. This makes Kyber/1Inch pricing reflect USDe that swaps can pull from the upgraded ARM’s lending market, while still preserving manual override behavior.

For all shared `priceOffset` pricing actions, this adds:

- `--dynamic-offset`
- `--dynamic-offset-full-spread-price`

When enabled, dynamic offset uses the DEX sell price, DEX spread, cross price, and full-spread anchor to linearly calculate the offset. When disabled, the existing fixed `--offset` path is unchanged.

## Talos

This Talos PR is needed to make the new pricing options editable https://github.com/oplabs/talos/pull/13
