### PR TITLE
[ARM] Deploy 037 Stables ARM (PYUSD/USDG) on mainnet

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -336,7 +336,7 @@
             "name": "037_DeployPaxosARMScript",
             "proposalId": 1,
             "tsDeployment": 1783421579,
-            "tsGovernance": 0
+            "tsGovernance": 1
         }
     ]
 }

--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -111,6 +111,38 @@
         {
             "implementation": "0xE620aFB67223AE03C260112aE21A717Af94C90f0",
             "name": "ETHENA_ARM_SUSDE_ADAPTER"
+        },
+        {
+            "implementation": "0x03D727Fc343FE42621DD28074350f99d005f0D18",
+            "name": "STABLES_ARM"
+        },
+        {
+            "implementation": "0x93D182bF55F9B320a731cEbD1c39916319241FFE",
+            "name": "STABLES_ARM_CAP_MAN"
+        },
+        {
+            "implementation": "0xE63730c6D1045A183E7153F6cB915b8a8f464525",
+            "name": "STABLES_ARM_CAP_IMPL"
+        },
+        {
+            "implementation": "0x16dd498828Ecd2835d113e838Af18A4b7f7B10F3",
+            "name": "STABLES_ARM_IMPL"
+        },
+        {
+            "implementation": "0x0CD57291231E4ba8788E13939eD9aA22825A0F11",
+            "name": "STABLES_ARM_PYUSD_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0x720395F299526b1EeD73D15cdFA8a9788084EBce",
+            "name": "STABLES_ARM_PYUSD_ADAPTER"
+        },
+        {
+            "implementation": "0xbf87518d0c366D0E0A5aF12720d85f10640f6fF6",
+            "name": "STABLES_ARM_USDG_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0xC905Cd9DC6d4032282494ca792b3e93Dac737554",
+            "name": "STABLES_ARM_USDG_ADAPTER"
         }
     ],
     "executions": [
@@ -296,9 +328,15 @@
         },
         {
             "name": "035_UnpauseEthenaARMScript",
-            "proposalId": 105952564920326880829480980653921695351704517467605619581569766325476268429476,
+            "proposalId": "105952564920326880829480980653921695351704517467605619581569766325476268429476",
             "tsDeployment": 1782206279,
             "tsGovernance": 1
+        },
+        {
+            "name": "037_DeployPaxosARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1783421579,
+            "tsGovernance": 0
         }
     ]
 }

--- a/script/deploy/mainnet/036_DeployMultiAssetARMScript.s.sol
+++ b/script/deploy/mainnet/036_DeployMultiAssetARMScript.s.sol
@@ -39,6 +39,8 @@ contract $036_DeployMultiAssetARMScript is AbstractDeployScript("036_DeployMulti
     /// 1e36 = ARM charges 1 WETH per base asset sold to traders (must stay at/above cross)
     uint256 internal constant SELL_PRICE = 1e36;
 
+    bool public constant override skip = true;
+
     function _execute() internal override {
         // 1. Deploy the ARM proxy.
         Proxy armProxy = new Proxy();


### PR DESCRIPTION
# Description

Record the mainnet deployment of the **Stables ARM**: a USDC-quoted `MultiAssetARM` with two Paxos-issued base assets, each wired through its own `PaxosAssetAdapter` behind a proxy:

- **PYUSD** — pegged 1:1 to USDC, redeemed off-chain through Paxos Actions that settle USDC back to the adapter.
- **USDG** — pegged 1:1 to USDC, same off-chain Paxos redemption flow.

Ownership of the ARM, its `CapManager` and both adapter proxies is handed to the multi-chain 2/8 multisig (`STRATEGIST`); the operational role (request/claim redemptions, submit Paxos redeems, set prices) is the Talos KMS relayer (`ARM_TALOS_RELAYER`). No lending market is wired up — idle USDC stays in the ARM until a market is added in a follow-up script.

This PR also marks `036_DeployMultiAssetARMScript` (the WETH-quoted LST ARM) as **skipped** — it is not being deployed in this round.

The following PRs are included in this deployment

### ARM

- https://github.com/OriginProtocol/arm-oeth/pull/289

## Deployment

Script `script/deploy/mainnet/037_DeployPaxosARMScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| Stables ARM (`MultiAssetARM`) proxy | [0x03D727Fc343FE42621DD28074350f99d005f0D18](https://etherscan.io/address/0x03D727Fc343FE42621DD28074350f99d005f0D18) |
| Stables ARM implementation (`MultiAssetARM`) | [0x16dd498828Ecd2835d113e838Af18A4b7f7B10F3](https://etherscan.io/address/0x16dd498828Ecd2835d113e838Af18A4b7f7B10F3) |
| Stables ARM `CapManager` proxy | [0x93D182bF55F9B320a731cEbD1c39916319241FFE](https://etherscan.io/address/0x93D182bF55F9B320a731cEbD1c39916319241FFE) |
| Stables ARM `CapManager` implementation | [0xE63730c6D1045A183E7153F6cB915b8a8f464525](https://etherscan.io/address/0xE63730c6D1045A183E7153F6cB915b8a8f464525) |
| `PaxosAssetAdapter` (PYUSD) implementation | [0x0CD57291231E4ba8788E13939eD9aA22825A0F11](https://etherscan.io/address/0x0CD57291231E4ba8788E13939eD9aA22825A0F11) |
| `PaxosAssetAdapter` (PYUSD) proxy | [0x720395F299526b1EeD73D15cdFA8a9788084EBce](https://etherscan.io/address/0x720395F299526b1EeD73D15cdFA8a9788084EBce) |
| `PaxosAssetAdapter` (USDG) implementation | [0xbf87518d0c366D0E0A5aF12720d85f10640f6fF6](https://etherscan.io/address/0xbf87518d0c366D0E0A5aF12720d85f10640f6fF6) |
| `PaxosAssetAdapter` (USDG) proxy | [0xC905Cd9DC6d4032282494ca792b3e93Dac737554](https://etherscan.io/address/0xC905Cd9DC6d4032282494ca792b3e93Dac737554) |

## Contract diff
```python
make match file=src/contracts/Proxy.sol addr=0x03D727Fc343FE42621DD28074350f99d005f0D18
make match file=src/contracts/MultiAssetARM.sol addr=0x16dd498828Ecd2835d113e838Af18A4b7f7B10F3
make match file=src/contracts/Proxy.sol addr=0x93D182bF55F9B320a731cEbD1c39916319241FFE
make match file=src/contracts/CapManager.sol addr=0xE63730c6D1045A183E7153F6cB915b8a8f464525
make match file=src/contracts/adapters/PaxosAssetAdapter.sol addr=0x0CD57291231E4ba8788E13939eD9aA22825A0F11
make match file=src/contracts/Proxy.sol addr=0x720395F299526b1EeD73D15cdFA8a9788084EBce
make match file=src/contracts/adapters/PaxosAssetAdapter.sol addr=0xbf87518d0c366D0E0A5aF12720d85f10640f6fF6
make match file=src/contracts/Proxy.sol addr=0xC905Cd9DC6d4032282494ca792b3e93Dac737554
```

## Configuration

The ARM implementation is deployed with USDC (6-decimal) parameters — the 6-decimal analogues of the 035/036 18-decimal WETH values:

| Param | Value | Note |
| - | - | - |
| `liquidityAsset` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` | USDC |
| `claimDelay` | `10 minutes` | |
| `minSharesToRedeem` | `1e6` | 1 USDC |
| `allocateThreshold` | `100e6` | 100 USDC |
| `name` / `symbol` | `Stables ARM` / `ARM-USDC-Stables` | |
| performance fee | `2000` | 20% |
| fee collector | `0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c` | `BUYBACK_OPERATOR` |
| `owner` (ARM / CapManager / adapter proxies) | `0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971` | `STRATEGIST` — multi-chain 2/8 multisig |
| `operator` | `0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b` | `ARM_TALOS_RELAYER` |

**CapManager:** total-assets cap `100,000e6` (100,000 USDC), account cap enabled, per-LP cap `100,000e6` for `TREASURY_LP` (`0x6E3fddab68Bf1EBaf9daCF9F7907c7Bc0951D1dc`).

### `addBaseAsset` parameters (PYUSD)

| Param | Value | Note |
| - | - | - |
| `newBaseAsset` | `0x6c3ea9036406852006290770BEdFcAbA0e23A0e8` | PYUSD |
| `adapter` | `0x720395F299526b1EeD73D15cdFA8a9788084EBce` | `PaxosAssetAdapter` (PYUSD) proxy |
| `buyPrice` | `998000000000000000000000000000000000` | `0.998e36` |
| `sellPrice` | `1000000000000000000000000000000000000` | `1e36` |
| `buyAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `sellAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `newCrossPrice` | `999970000000000000000000000000000000` | `0.99997e36` — totalAssets() valuation |
| `peggedToLiquidityAsset` | `true` | |

### `addBaseAsset` parameters (USDG)

| Param | Value | Note |
| - | - | - |
| `newBaseAsset` | `0xe343167631d89B6Ffc58B88d6b7fB0228795491D` | USDG |
| `adapter` | `0xC905Cd9DC6d4032282494ca792b3e93Dac737554` | `PaxosAssetAdapter` (USDG) proxy |
| `buyPrice` | `998000000000000000000000000000000000` | `0.998e36` |
| `sellPrice` | `1000000000000000000000000000000000000` | `1e36` |
| `buyAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `sellAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `newCrossPrice` | `999970000000000000000000000000000000` | `0.99997e36` — totalAssets() valuation |
| `peggedToLiquidityAsset` | `true` | |

## Governance

Unlike EtherFiARM (Timelock-owned), the **Stables ARM is owned by the multi-chain 2/8 multisig** (`STRATEGIST`, `0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971`). Ownership of the ARM, its `CapManager` and both adapter proxies is transferred to that multisig **directly inside `_execute()`** — there is no `GovernorSix` proposal and no `_buildGovernanceProposal()` for this script.

The deployment is therefore recorded in `build/deployments-1.json` with `proposalId: 1` (`NO_GOVERNANCE`), so the fork/smoke framework replays the deployment without simulating any governance action.

## Skipped script

`036_DeployMultiAssetARMScript` (the WETH-quoted LST ARM: stETH / wstETH / eETH / weETH) is marked `skip = true`. It is not deployed in this round and is left in place for a future deployment.

## Post-deployment follow-ups (owner / operator)

- **Set the real Paxos deposit address.** Both adapters are initialized with `PAXOS_RECIPIENT = 0x…dEaD` as a placeholder; the 2/8 multisig owner must call `setPaxosRecipient()` on each adapter with the real Paxos deposit address before enabling redemptions.
- **Enable trading.** `buyAmount` / `sellAmount` are both `0`, so no swaps are possible until the operator (Talos) sets the swap limits via `setPrices()`.
