### PR TITLE
Fix Lido and EtherFi Actions

### DIFF
--- a/src/js/utils/arm.js
+++ b/src/js/utils/arm.js
@@ -141,6 +141,15 @@ const isMissingSelectorError = (err) =>
   err?.data === "0x" ||
   err?.info?.error?.data === "0x";
 
+const isMissingSelectorOrBareRevertError = (err) =>
+  isMissingSelectorError(err) ||
+  (err?.name === "ProviderError" && err?.message === "execution reverted");
+
+const errorSummary = (err) =>
+  [err?.name, err?.code, err?.message, err?.data || err?.info?.error?.data]
+    .filter(Boolean)
+    .join(": ");
+
 const legacyArmContract = async (arm, signerOrProvider) =>
   new Contract(
     await arm.getAddress(),
@@ -414,6 +423,8 @@ const getArmBuffer = async (arm, blockTag) => {
 
 const getOutstandingWithdrawals = async (arm, blockTag) => {
   const opts = blockTag === undefined ? [] : [{ blockTag }];
+  let reservedWithdrawLiquidityError;
+  let currentAbiWithdrawalsError;
   // Liquidity reserved for outstanding LP withdrawal requests (asset-denominated).
   // Newer ARMs track the asset-denominated amount directly in
   // reservedWithdrawLiquidity(). Legacy ARMs expose
@@ -424,7 +435,13 @@ const getOutstandingWithdrawals = async (arm, blockTag) => {
     try {
       return await arm.reservedWithdrawLiquidity(...opts);
     } catch (err) {
-      if (!isMissingSelectorError(err)) throw err;
+      reservedWithdrawLiquidityError = err;
+      if (!isMissingSelectorOrBareRevertError(err)) {
+        throw new Error(
+          `Failed to read outstanding withdrawals via reservedWithdrawLiquidity(): ${errorSummary(err)}`,
+          { cause: err },
+        );
+      }
     }
   }
 
@@ -435,7 +452,13 @@ const getOutstandingWithdrawals = async (arm, blockTag) => {
     ]);
     return queued - claimed;
   } catch (err) {
-    if (!isMissingSelectorError(err)) throw err;
+    currentAbiWithdrawalsError = err;
+    if (!isMissingSelectorError(err)) {
+      throw new Error(
+        `Failed to read outstanding withdrawals via withdrawsQueued()/withdrawsClaimed(): ${errorSummary(err)}`,
+        { cause: err },
+      );
+    }
   }
   try {
     const legacyArm = await legacyArmContract(arm);
@@ -445,8 +468,27 @@ const getOutstandingWithdrawals = async (arm, blockTag) => {
     ]);
     return queued - claimed;
   } catch (err) {
-    if (!isMissingSelectorError(err)) throw err;
-    return arm.reservedWithdrawLiquidity(...opts);
+    if (!isMissingSelectorError(err)) {
+      throw new Error(
+        `Failed to read outstanding withdrawals via legacy withdrawsQueued()/withdrawsClaimed(): ${errorSummary(err)}`,
+        { cause: err },
+      );
+    }
+
+    const armAddress = await arm.getAddress();
+    const reservedResult = reservedWithdrawLiquidityError
+      ? `failed (${errorSummary(reservedWithdrawLiquidityError)})`
+      : "was not available in the current ABI";
+    const currentAbiResult = currentAbiWithdrawalsError
+      ? `failed (${errorSummary(currentAbiWithdrawalsError)})`
+      : "was not attempted";
+    throw new Error(
+      `Unable to read outstanding withdrawals for ARM ${armAddress}: ` +
+        `reservedWithdrawLiquidity() ${reservedResult}; ` +
+        `current ABI withdrawsQueued()/withdrawsClaimed() ${currentAbiResult}; ` +
+        `legacy ABI withdrawsQueued()/withdrawsClaimed() failed (${errorSummary(err)})`,
+      { cause: err },
+    );
   }
 };
 

--- a/src/js/utils/arm.js
+++ b/src/js/utils/arm.js
@@ -427,7 +427,7 @@ const getOutstandingWithdrawals = async (arm, blockTag) => {
   let currentAbiWithdrawalsError;
   // Liquidity reserved for outstanding LP withdrawal requests (asset-denominated).
   // Newer ARMs track the asset-denominated amount directly in
-  // reservedWithdrawLiquidity(). Legacy ARMs expose
+  // reservedWithdrawLiquidity(). Legacy Lido and EtherFi ARMs expose
   // withdrawsQueued()/withdrawsClaimed(); several new ABIs dropped these getters
   // even though the deployed legacy contracts still implement them on-chain, so
   // fall back to the legacy ABI.

--- a/test/js/arm.test.js
+++ b/test/js/arm.test.js
@@ -1,0 +1,80 @@
+const assert = require("assert");
+
+const { AbiCoder, Contract, id } = require("ethers");
+
+const { getOutstandingWithdrawals } = require("../../src/js/utils/arm");
+
+const coder = AbiCoder.defaultAbiCoder();
+
+const selector = (signature) => id(signature).slice(0, 10);
+
+const providerRevert = () => {
+  const err = new Error("execution reverted");
+  err.name = "ProviderError";
+  return err;
+};
+
+const run = async () => {
+  const selectors = {
+    reservedWithdrawLiquidity: selector("reservedWithdrawLiquidity()"),
+    withdrawsQueued: selector("withdrawsQueued()"),
+    withdrawsClaimed: selector("withdrawsClaimed()"),
+  };
+
+  {
+    const runner = {
+      call: async (tx) => {
+        if (tx.data === selectors.reservedWithdrawLiquidity) {
+          throw providerRevert();
+        }
+        if (tx.data === selectors.withdrawsQueued) {
+          return coder.encode(["uint256"], [123n]);
+        }
+        if (tx.data === selectors.withdrawsClaimed) {
+          return coder.encode(["uint256"], [23n]);
+        }
+        throw new Error(`unexpected selector ${tx.data}`);
+      },
+    };
+
+    const arm = new Contract(
+      "0x0000000000000000000000000000000000000001",
+      ["function reservedWithdrawLiquidity() view returns (uint256)"],
+      runner,
+    );
+
+    assert.strictEqual(await getOutstandingWithdrawals(arm), 100n);
+  }
+
+  {
+    const runner = {
+      call: async (tx) => {
+        if (tx.data === selectors.reservedWithdrawLiquidity) {
+          throw providerRevert();
+        }
+        if (
+          tx.data === selectors.withdrawsQueued ||
+          tx.data === selectors.withdrawsClaimed
+        ) {
+          const err = providerRevert();
+          err.code = "CALL_EXCEPTION";
+          throw err;
+        }
+        throw new Error(`unexpected selector ${tx.data}`);
+      },
+    };
+
+    const arm = new Contract(
+      "0x0000000000000000000000000000000000000001",
+      ["function reservedWithdrawLiquidity() view returns (uint256)"],
+      runner,
+    );
+
+    await assert.rejects(
+      () => getOutstandingWithdrawals(arm),
+      /Unable to read outstanding withdrawals for ARM .*reservedWithdrawLiquidity\(\).*legacy ABI withdrawsQueued\(\)\/withdrawsClaimed\(\) failed/,
+    );
+  }
+};
+
+run().then(() => console.log("arm tests passed"));


### PR DESCRIPTION
## Summary

Fixes Talos action failures for intentionally legacy Lido and EtherFi ARMs by making `getOutstandingWithdrawals()` fall back from `reservedWithdrawLiquidity()` to legacy `withdrawsQueued() - withdrawsClaimed()` when RPC/Hardhat reports the missing selector as a bare `ProviderError: execution reverted`.

Also improves diagnostics so future failures identify which outstanding-withdrawal read path failed.

## Details

- Treats bare `ProviderError: execution reverted` as a legacy fallback signal only for the optional `reservedWithdrawLiquidity()` probe.
- Preserves upgraded ARM behavior, including Ethena’s `reservedWithdrawLiquidity()` path.
- Adds contextual errors for failed reads via:
  - `reservedWithdrawLiquidity()`
  - current ABI `withdrawsQueued()/withdrawsClaimed()`
  - legacy ABI `withdrawsQueued()/withdrawsClaimed()`
- Clarifies comments that Lido and EtherFi are intentionally legacy deployments.
- Adds JS regression coverage for successful legacy fallback and useful all-paths-failed diagnostics.

## Testing

- `NODE_PATH=node_modules/.pnpm/node_modules node test/js/arm.test.js`
- `NODE_PATH=node_modules/.pnpm/node_modules node test/js/pricing.test.js`
- `NODE_PATH=node_modules/.pnpm/node_modules node test/js/ethenaPricing.test.js`
- `npx prettier --check src/js/utils/arm.js test/js/arm.test.js`