### PR TITLE
[ARM] Deploy 037 USD ARM (PYUSD/USDG) on mainnet

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -111,6 +111,38 @@
         {
             "implementation": "0xE620aFB67223AE03C260112aE21A717Af94C90f0",
             "name": "ETHENA_ARM_SUSDE_ADAPTER"
+        },
+        {
+            "implementation": "0x5c68a604d39A639C0b8CC115f0823C50272CF13a",
+            "name": "USD_ARM"
+        },
+        {
+            "implementation": "0xAAB4F9e842e5D34ec61B1DBAAE8EBa4559F0eEF6",
+            "name": "USD_ARM_CAP_MAN"
+        },
+        {
+            "implementation": "0x70A7Af16c180141839656d571ff4ef3be155c48e",
+            "name": "USD_ARM_CAP_IMPL"
+        },
+        {
+            "implementation": "0x1405CDB24f93A60d023400cb03787bB8576EE490",
+            "name": "USD_ARM_IMPL"
+        },
+        {
+            "implementation": "0x50223D4f7c027DF74939555E92584C6332c613B2",
+            "name": "USD_ARM_PYUSD_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465",
+            "name": "USD_ARM_PYUSD_ADAPTER"
+        },
+        {
+            "implementation": "0x7c4c0B599E17C3Ad4ae37Ba61Eef50980e13203B",
+            "name": "USD_ARM_USDG_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f",
+            "name": "USD_ARM_USDG_ADAPTER"
         }
     ],
     "executions": [
@@ -296,8 +328,14 @@
         },
         {
             "name": "035_UnpauseEthenaARMScript",
-            "proposalId": 105952564920326880829480980653921695351704517467605619581569766325476268429476,
+            "proposalId": "105952564920326880829480980653921695351704517467605619581569766325476268429476",
             "tsDeployment": 1782206279,
+            "tsGovernance": 1
+        },
+        {
+            "name": "037_DeployUSDARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1783493495,
             "tsGovernance": 1
         }
     ]

--- a/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
+++ b/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
@@ -26,7 +26,7 @@ import {State} from "script/deploy/helpers/DeploymentTypes.sol";
 ///      at deployment - the adapter owner replaces it with the real Paxos deposit address via
 ///      setPaxosRecipient() once Paxos provides it. No lending market is wired up here (idle USDC
 ///      stays in the ARM until a market is added in a follow-up script).
-contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMScript") {
+contract $037_DeployUSDARMScript is AbstractDeployScript("037_DeployUSDARMScript") {
     /// @dev Owner of the ARM, CapManager and both PaxosAssetAdapter proxies: the multi-chain 2/8 multisig.
     address internal constant OWNER_2_OF_8 = Mainnet.STRATEGIST;
     /// @dev Operational role (request/claim redemptions, submit Paxos redeems, set prices): the
@@ -54,15 +54,15 @@ contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMSc
     function _execute() internal override {
         // 1. Deploy the ARM proxy.
         Proxy armProxy = new Proxy();
-        _recordDeployment("STABLES_ARM", address(armProxy));
+        _recordDeployment("USD_ARM", address(armProxy));
 
         // 2. Deploy the CapManager (proxy + implementation), owned by the 2/8 multisig and
         //    operated by Talos.
         Proxy capManProxy = new Proxy();
-        _recordDeployment("STABLES_ARM_CAP_MAN", address(capManProxy));
+        _recordDeployment("USD_ARM_CAP_MAN", address(capManProxy));
 
         CapManager capManagerImpl = new CapManager(address(armProxy));
-        _recordDeployment("STABLES_ARM_CAP_IMPL", address(capManagerImpl));
+        _recordDeployment("USD_ARM_CAP_IMPL", address(capManagerImpl));
 
         // Initialize the CapManager with Talos as operator; keep the deployer as owner for now.
         bytes memory capManData = abi.encodeWithSignature("initialize(address)", OPERATOR_TALOS);
@@ -85,7 +85,7 @@ contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMSc
         MultiAssetARM armImpl = new MultiAssetARM({
             _liquidityAsset: Mainnet.USDC, _claimDelay: 10 minutes, _minSharesToRedeem: 1e6, _allocateThreshold: 100e6
         });
-        _recordDeployment("STABLES_ARM_IMPL", address(armImpl));
+        _recordDeployment("USD_ARM_IMPL", address(armImpl));
 
         // 6. Give the deployer the MIN_LIQUIDITY (1 atomic unit of USDC, i.e. 0.000001 USDC) that
         //    initialize() pulls to seed dead shares. 035 wraps ETH into WETH for this, but USDC
@@ -103,8 +103,8 @@ contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMSc
         // 7. Initialize the ARM proxy: deployer stays owner during setup, Talos is the operator.
         bytes memory armData = abi.encodeWithSignature(
             "initialize(string,string,address,uint256,address,address)",
-            "Stables ARM", // name
-            "ARM-USDC-Stables", // symbol
+            "USD ARM", // name
+            "ARM-USD", // symbol
             OPERATOR_TALOS, // operator
             2000, // 20% performance fee
             Mainnet.BUYBACK_OPERATOR, // fee collector
@@ -116,7 +116,7 @@ contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMSc
         // 8. Deploy the PYUSD Paxos adapter (pegged 1:1) and register PYUSD.
         {
             PaxosAssetAdapter adapterImpl = new PaxosAssetAdapter(address(armProxy), Mainnet.PYUSD, Mainnet.USDC);
-            _recordDeployment("STABLES_ARM_PYUSD_ADAPTER_IMPL", address(adapterImpl));
+            _recordDeployment("USD_ARM_PYUSD_ADAPTER_IMPL", address(adapterImpl));
             Proxy adapterProxy = new Proxy();
             // paxosRecipient is a placeholder - the 2/8 multisig owner replaces it via setPaxosRecipient().
             adapterProxy.initialize(
@@ -124,7 +124,7 @@ contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMSc
                 OWNER_2_OF_8,
                 abi.encodeWithSelector(PaxosAssetAdapter.initialize.selector, OPERATOR_TALOS, Mainnet.PAXOS_RECIPIENT)
             );
-            _recordDeployment("STABLES_ARM_PYUSD_ADAPTER", address(adapterProxy));
+            _recordDeployment("USD_ARM_PYUSD_ADAPTER", address(adapterProxy));
             arm.addBaseAsset(
                 Mainnet.PYUSD,
                 address(adapterProxy),
@@ -140,7 +140,7 @@ contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMSc
         // 9. Deploy the USDG Paxos adapter (pegged 1:1) and register USDG.
         {
             PaxosAssetAdapter adapterImpl = new PaxosAssetAdapter(address(armProxy), Mainnet.USDG, Mainnet.USDC);
-            _recordDeployment("STABLES_ARM_USDG_ADAPTER_IMPL", address(adapterImpl));
+            _recordDeployment("USD_ARM_USDG_ADAPTER_IMPL", address(adapterImpl));
             Proxy adapterProxy = new Proxy();
             // paxosRecipient is a placeholder - the 2/8 multisig owner replaces it via setPaxosRecipient().
             adapterProxy.initialize(
@@ -148,7 +148,7 @@ contract $037_DeployPaxosARMScript is AbstractDeployScript("037_DeployPaxosARMSc
                 OWNER_2_OF_8,
                 abi.encodeWithSelector(PaxosAssetAdapter.initialize.selector, OPERATOR_TALOS, Mainnet.PAXOS_RECIPIENT)
             );
-            _recordDeployment("STABLES_ARM_USDG_ADAPTER", address(adapterProxy));
+            _recordDeployment("USD_ARM_USDG_ADAPTER", address(adapterProxy));
             arm.addBaseAsset(
                 Mainnet.USDG,
                 address(adapterProxy),

--- a/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
+++ b/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
@@ -13,7 +13,7 @@ import {PaxosAssetAdapter} from "contracts/adapters/PaxosAssetAdapter.sol";
 import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
 import {State} from "script/deploy/helpers/DeploymentTypes.sol";
 
-/// @title Deploy the Stables ARM (USDC-quoted MultiAssetARM with Paxos base assets)
+/// @title Deploy the USD ARM (USDC-quoted MultiAssetARM with Paxos base assets)
 /// @notice Deploys a single MultiAssetARM with USDC as the liquidity asset and two Paxos-issued
 ///         base assets: PYUSD and USDG. Each base asset is wired to its own PaxosAssetAdapter,
 ///         whose redemption queue is fully off-chain: the operator submits queued base assets to a

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -15,7 +15,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
     IERC20 pyusd;
     IERC20 usdg;
     Proxy armProxy;
-    MultiAssetARM stablesARM;
+    MultiAssetARM usdARM;
     PaxosAssetAdapter pyusdAdapter;
     PaxosAssetAdapter usdgAdapter;
     CapManager capManager;
@@ -33,25 +33,25 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         vm.label(address(usdg), "USDG");
         vm.label(address(operator), "OPERATOR");
 
-        armProxy = Proxy(payable(resolver.resolve("STABLES_ARM")));
-        stablesARM = MultiAssetARM(payable(resolver.resolve("STABLES_ARM")));
-        pyusdAdapter = PaxosAssetAdapter(resolver.resolve("STABLES_ARM_PYUSD_ADAPTER"));
-        usdgAdapter = PaxosAssetAdapter(resolver.resolve("STABLES_ARM_USDG_ADAPTER"));
-        capManager = CapManager(resolver.resolve("STABLES_ARM_CAP_MAN"));
+        armProxy = Proxy(payable(resolver.resolve("USD_ARM")));
+        usdARM = MultiAssetARM(payable(resolver.resolve("USD_ARM")));
+        pyusdAdapter = PaxosAssetAdapter(resolver.resolve("USD_ARM_PYUSD_ADAPTER"));
+        usdgAdapter = PaxosAssetAdapter(resolver.resolve("USD_ARM_USDG_ADAPTER"));
+        capManager = CapManager(resolver.resolve("USD_ARM_CAP_MAN"));
     }
 
     function test_initialConfig() external view {
-        assertEq(stablesARM.name(), "Stables ARM", "Name");
-        assertEq(stablesARM.symbol(), "ARM-USDC-Stables", "Symbol");
-        assertEq(stablesARM.owner(), Mainnet.STRATEGIST, "Owner");
-        assertEq(stablesARM.operator(), operator, "Operator");
-        assertEq(stablesARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
-        assertEq(stablesARM.fee(), 2000, "Performance fee");
-        assertEq(stablesARM.liquidityAsset(), Mainnet.USDC, "liquidity asset");
-        assertEq(stablesARM.claimDelay(), 10 minutes, "claim delay");
+        assertEq(usdARM.name(), "USD ARM", "Name");
+        assertEq(usdARM.symbol(), "ARM-USD", "Symbol");
+        assertEq(usdARM.owner(), Mainnet.STRATEGIST, "Owner");
+        assertEq(usdARM.operator(), operator, "Operator");
+        assertEq(usdARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
+        assertEq(usdARM.fee(), 2000, "Performance fee");
+        assertEq(usdARM.liquidityAsset(), Mainnet.USDC, "liquidity asset");
+        assertEq(usdARM.claimDelay(), 10 minutes, "claim delay");
 
         // PYUSD adapter
-        assertEq(pyusdAdapter.arm(), address(stablesARM), "PYUSD adapter arm");
+        assertEq(pyusdAdapter.arm(), address(usdARM), "PYUSD adapter arm");
         assertEq(address(pyusdAdapter.baseAsset()), Mainnet.PYUSD, "PYUSD adapter base asset");
         assertEq(pyusdAdapter.asset(), Mainnet.USDC, "PYUSD adapter liquidity asset");
         assertEq(pyusdAdapter.owner(), Mainnet.STRATEGIST, "PYUSD adapter owner");
@@ -61,7 +61,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(pyusdAdapter.settlingShares(), 0, "PYUSD adapter settling shares");
 
         // USDG adapter
-        assertEq(usdgAdapter.arm(), address(stablesARM), "USDG adapter arm");
+        assertEq(usdgAdapter.arm(), address(usdARM), "USDG adapter arm");
         assertEq(address(usdgAdapter.baseAsset()), Mainnet.USDG, "USDG adapter base asset");
         assertEq(usdgAdapter.asset(), Mainnet.USDC, "USDG adapter liquidity asset");
         assertEq(usdgAdapter.owner(), Mainnet.STRATEGIST, "USDG adapter owner");
@@ -70,11 +70,11 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(usdgAdapter.pendingShares(), 0, "USDG adapter pending shares");
         assertEq(usdgAdapter.settlingShares(), 0, "USDG adapter settling shares");
 
-        address[] memory baseAssets = stablesARM.getBaseAssets();
+        address[] memory baseAssets = usdARM.getBaseAssets();
         _assertBaseAssetListed(baseAssets, Mainnet.PYUSD, "PYUSD listed as base asset");
         _assertBaseAssetListed(baseAssets, Mainnet.USDG, "USDG listed as base asset");
 
-        assertEq(capManager.arm(), address(stablesARM), "cap manager arm");
+        assertEq(capManager.arm(), address(usdARM), "cap manager arm");
         assertEq(capManager.totalAssetsCap(), 100_000e6, "total assets cap");
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
         assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 100_000e6, "liquidity provider cap");
@@ -98,7 +98,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
             bool peggedToLiquidityAsset,
             uint8 baseAssetDecimals,
             address adapter
-        ) = stablesARM.baseAssetConfigs(baseAsset);
+        ) = usdARM.baseAssetConfigs(baseAsset);
 
         assertEq(buyPrice, 0.998e36, string.concat(label, " buy price"));
         assertEq(sellPrice, 1e36, string.concat(label, " sell price"));
@@ -119,20 +119,20 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // Give the ARM USDC inventory and the trader PYUSD. Deal directly - deposits from
         // arbitrary accounts are blocked by the CapManager's account caps.
-        deal(address(usdc), address(stablesARM), 1_000_000e6);
+        deal(address(usdc), address(usdARM), 1_000_000e6);
         deal(address(pyusd), address(this), 1_000e6);
 
-        pyusd.approve(address(stablesARM), amountIn);
+        pyusd.approve(address(usdARM), amountIn);
 
         // The deployment registers base assets with zero swap liquidity, so the operator must set
         // the buy/sell amounts before any swap is possible.
         vm.prank(operator);
-        stablesARM.setPrices(address(pyusd), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
+        usdARM.setPrices(address(pyusd), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
 
         uint256 startIn = pyusd.balanceOf(address(this));
         uint256 startOut = usdc.balanceOf(address(this));
 
-        stablesARM.swapExactTokensForTokens(pyusd, usdc, amountIn, 0, address(this));
+        usdARM.swapExactTokensForTokens(pyusd, usdc, amountIn, 0, address(this));
 
         assertEq(pyusd.balanceOf(address(this)), startIn - amountIn, "PYUSD in actual");
         assertEq(usdc.balanceOf(address(this)), startOut + expectedOut, "USDC out actual");
@@ -146,20 +146,20 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // Give the ARM USDG inventory and the trader USDC. Deal directly - deposits from
         // arbitrary accounts are blocked by the CapManager's account caps.
-        deal(address(usdg), address(stablesARM), 1_000e6);
+        deal(address(usdg), address(usdARM), 1_000e6);
         deal(address(usdc), address(this), 1_000e6);
 
-        usdc.approve(address(stablesARM), amountIn);
+        usdc.approve(address(usdARM), amountIn);
 
         // The deployment registers base assets with zero swap liquidity, so the operator must set
         // the buy/sell amounts before any swap is possible.
         vm.prank(operator);
-        stablesARM.setPrices(address(usdg), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
+        usdARM.setPrices(address(usdg), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
 
         uint256 startIn = usdc.balanceOf(address(this));
         uint256 startOut = usdg.balanceOf(address(this));
 
-        stablesARM.swapExactTokensForTokens(usdc, usdg, amountIn, 0, address(this));
+        usdARM.swapExactTokensForTokens(usdc, usdg, amountIn, 0, address(this));
 
         assertEq(usdc.balanceOf(address(this)), startIn - amountIn, "USDC in actual");
         assertEq(usdg.balanceOf(address(this)), startOut + expectedOut, "USDG out actual");
@@ -180,14 +180,14 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         uint256 shares = 1_000e6;
 
         // Give the ARM base asset inventory (as if bought from traders).
-        deal(address(baseAsset), address(stablesARM), shares);
+        deal(address(baseAsset), address(usdARM), shares);
 
-        uint256 totalAssetsBefore = stablesARM.totalAssets();
-        uint256 armUsdcBefore = usdc.balanceOf(address(stablesARM));
+        uint256 totalAssetsBefore = usdARM.totalAssets();
+        uint256 armUsdcBefore = usdc.balanceOf(address(usdARM));
 
         // 1. Operator queues the base assets for Paxos redemption. The adapter pulls them from the ARM.
         vm.prank(operator);
-        stablesARM.requestBaseAssetRedeem(address(baseAsset), shares);
+        usdARM.requestBaseAssetRedeem(address(baseAsset), shares);
         assertEq(adapter.pendingShares(), shares, "pending shares after request");
         assertEq(baseAsset.balanceOf(address(adapter)), shares, "adapter base balance after request");
 
@@ -208,14 +208,14 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // 5. Operator claims the settled USDC back into the ARM.
         vm.prank(operator);
-        stablesARM.claimBaseAssetRedeem(address(baseAsset), shares);
+        usdARM.claimBaseAssetRedeem(address(baseAsset), shares);
 
         assertEq(adapter.pendingShares(), 0, "pending shares after claim");
         assertEq(adapter.settlingShares(), 0, "settling shares after claim");
-        assertEq(usdc.balanceOf(address(stablesARM)), armUsdcBefore + shares, "ARM USDC balance after claim");
-        (,,,,, uint128 pendingRedeemAssets,,,) = stablesARM.baseAssetConfigs(address(baseAsset));
+        assertEq(usdc.balanceOf(address(usdARM)), armUsdcBefore + shares, "ARM USDC balance after claim");
+        (,,,,, uint128 pendingRedeemAssets,,,) = usdARM.baseAssetConfigs(address(baseAsset));
         assertEq(pendingRedeemAssets, 0, "pending redeem assets after claim");
-        assertGe(stablesARM.totalAssets(), totalAssetsBefore, "total assets not decreased");
+        assertGe(usdARM.totalAssets(), totalAssetsBefore, "total assets not decreased");
     }
 
     function test_proxy_unauthorizedAccess() external {
@@ -241,7 +241,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // Implementation's restricted methods.
         vm.expectRevert(onlyOwnerError);
-        stablesARM.setOwner(RANDOM_ADDRESS);
+        usdARM.setOwner(RANDOM_ADDRESS);
     }
 
     /// @dev Assert `expected` appears in the ARM's `getBaseAssets()` list. A membership check


### PR DESCRIPTION
# Description

Record the mainnet deployment of the **USD ARM**: a USDC-quoted `MultiAssetARM` with two Paxos-issued base assets, each wired through its own `PaxosAssetAdapter` behind a proxy:

- **PYUSD** — pegged 1:1 to USDC, redeemed off-chain through Paxos Actions that settle USDC back to the adapter.
- **USDG** — pegged 1:1 to USDC, same off-chain Paxos redemption flow.

Ownership of the ARM, its `CapManager` and both adapter proxies is handed to the multi-chain 2/8 multisig (`STRATEGIST`); the operational role (request/claim redemptions, submit Paxos redeems, set prices) is the Talos KMS relayer (`ARM_TALOS_RELAYER`). No lending market is wired up — idle USDC stays in the ARM until a market is added in a follow-up script.

This is a rename of the former `037_DeployPaxosARMScript`: only the contract name, the recorded deployment names (`STABLES_ARM*` → `USD_ARM*`) and the ARM name/symbol (`Stables ARM` / `ARM-USDC-Stables` → `USD ARM` / `ARM-USD`) changed; the deployment logic is identical. It supersedes #290.

> The companion WETH-quoted **LST ARM** (`036_DeployMultiAssetARMScript`) deployed in the same round is recorded in a separate PR.

The following PRs are included in this deployment

### ARM

- https://github.com/OriginProtocol/arm-oeth/pull/289

## Deployment

Script `script/deploy/mainnet/037_DeployUSDARMScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| USD ARM (`MultiAssetARM`) proxy | [0x5c68a604d39A639C0b8CC115f0823C50272CF13a](https://etherscan.io/address/0x5c68a604d39A639C0b8CC115f0823C50272CF13a) |
| USD ARM implementation (`MultiAssetARM`) | [0x1405CDB24f93A60d023400cb03787bB8576EE490](https://etherscan.io/address/0x1405CDB24f93A60d023400cb03787bB8576EE490) |
| USD ARM `CapManager` proxy | [0xAAB4F9e842e5D34ec61B1DBAAE8EBa4559F0eEF6](https://etherscan.io/address/0xAAB4F9e842e5D34ec61B1DBAAE8EBa4559F0eEF6) |
| USD ARM `CapManager` implementation | [0x70A7Af16c180141839656d571ff4ef3be155c48e](https://etherscan.io/address/0x70A7Af16c180141839656d571ff4ef3be155c48e) |
| `PaxosAssetAdapter` (PYUSD) implementation | [0x50223D4f7c027DF74939555E92584C6332c613B2](https://etherscan.io/address/0x50223D4f7c027DF74939555E92584C6332c613B2) |
| `PaxosAssetAdapter` (PYUSD) proxy | [0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465](https://etherscan.io/address/0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465) |
| `PaxosAssetAdapter` (USDG) implementation | [0x7c4c0B599E17C3Ad4ae37Ba61Eef50980e13203B](https://etherscan.io/address/0x7c4c0B599E17C3Ad4ae37Ba61Eef50980e13203B) |
| `PaxosAssetAdapter` (USDG) proxy | [0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f](https://etherscan.io/address/0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f) |

## Contract diff
```python
make match file=src/contracts/Proxy.sol addr=0x5c68a604d39A639C0b8CC115f0823C50272CF13a
make match file=src/contracts/MultiAssetARM.sol addr=0x1405CDB24f93A60d023400cb03787bB8576EE490
make match file=src/contracts/Proxy.sol addr=0xAAB4F9e842e5D34ec61B1DBAAE8EBa4559F0eEF6
make match file=src/contracts/CapManager.sol addr=0x70A7Af16c180141839656d571ff4ef3be155c48e
make match file=src/contracts/adapters/PaxosAssetAdapter.sol addr=0x50223D4f7c027DF74939555E92584C6332c613B2
make match file=src/contracts/Proxy.sol addr=0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465
make match file=src/contracts/adapters/PaxosAssetAdapter.sol addr=0x7c4c0B599E17C3Ad4ae37Ba61Eef50980e13203B
make match file=src/contracts/Proxy.sol addr=0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f
```

## Configuration

The ARM implementation is deployed with USDC (6-decimal) parameters — the 6-decimal analogues of the 035/036 18-decimal WETH values:

| Param | Value | Note |
| - | - | - |
| `liquidityAsset` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` | USDC |
| `claimDelay` | `10 minutes` | |
| `minSharesToRedeem` | `1e6` | 1 USDC |
| `allocateThreshold` | `100e6` | 100 USDC |
| `name` / `symbol` | `USD ARM` / `ARM-USD` | |
| performance fee | `2000` | 20% |
| fee collector | `0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c` | `BUYBACK_OPERATOR` |
| `owner` (ARM / CapManager / adapter proxies) | `0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971` | `STRATEGIST` — multi-chain 2/8 multisig |
| `operator` | `0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b` | `ARM_TALOS_RELAYER` |

**CapManager:** total-assets cap `100,000e6` (100,000 USDC), account cap enabled, per-LP cap `100,000e6` for `TREASURY_LP` (`0x6E3fddab68Bf1EBaf9daCF9F7907c7Bc0951D1dc`).

### `addBaseAsset` parameters (PYUSD)

| Param | Value | Note |
| - | - | - |
| `newBaseAsset` | `0x6c3ea9036406852006290770BEdFcAbA0e23A0e8` | PYUSD |
| `adapter` | `0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465` | `PaxosAssetAdapter` (PYUSD) proxy |
| `buyPrice` | `998000000000000000000000000000000000` | `0.998e36` |
| `sellPrice` | `1000000000000000000000000000000000000` | `1e36` |
| `buyAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `sellAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `newCrossPrice` | `999970000000000000000000000000000000` | `0.99997e36` — totalAssets() valuation |
| `peggedToLiquidityAsset` | `true` | |

### `addBaseAsset` parameters (USDG)

| Param | Value | Note |
| - | - | - |
| `newBaseAsset` | `0xe343167631d89B6Ffc58B88d6b7fB0228795491D` | USDG |
| `adapter` | `0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f` | `PaxosAssetAdapter` (USDG) proxy |
| `buyPrice` | `998000000000000000000000000000000000` | `0.998e36` |
| `sellPrice` | `1000000000000000000000000000000000000` | `1e36` |
| `buyAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `sellAmount` | `0` | no swaps until the operator enables trading via `setPrices()` |
| `newCrossPrice` | `999970000000000000000000000000000000` | `0.99997e36` — totalAssets() valuation |
| `peggedToLiquidityAsset` | `true` | |

## Governance

Unlike EtherFiARM (Timelock-owned), the **USD ARM is owned by the multi-chain 2/8 multisig** (`STRATEGIST`, `0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971`). Ownership of the ARM, its `CapManager` and both adapter proxies is transferred to that multisig **directly inside `_execute()`** — there is no `GovernorSix` proposal and no `_buildGovernanceProposal()` for this script.

The deployment is therefore recorded in `build/deployments-1.json` with `proposalId: 1` (`NO_GOVERNANCE`), so the fork/smoke framework replays the deployment without simulating any governance action.

## Post-deployment follow-ups (owner / operator)

- **Set the real Paxos deposit address.** Both adapters are initialized with `PAXOS_RECIPIENT = 0x…dEaD` as a placeholder; the 2/8 multisig owner must call `setPaxosRecipient()` on each adapter with the real Paxos deposit address before enabling redemptions.
- **Enable trading.** `buyAmount` / `sellAmount` are both `0`, so no swaps are possible until the operator (Talos) sets the swap limits via `setPrices()`.
