### PR TITLE
Fix Ethena unstaker FIFO ordering after rotation

### DIFF
--- a/src/js/tasks/ethenaQueue.js
+++ b/src/js/tasks/ethenaQueue.js
@@ -8,6 +8,10 @@ const {
   requestBaseAssetWithdrawal,
   resolveArmBase,
 } = require("../utils/arm");
+const {
+  orderPendingUnstakerStates,
+  selectClaimableFifoPrefix,
+} = require("../utils/ethenaQueue");
 const { logTxDetails } = require("../utils/txLogger");
 const log = require("../utils/logger")("task:ethenaQueue");
 
@@ -74,14 +78,21 @@ const fetchUnstakerStates = async (signer, adapter, addresses) => {
   const contract = new ethers.Contract(SUSDE_ADDRESS, SUSDE_ABI, signer);
   const { timestamp: currentTimestamp } =
     await signer.provider.getBlock("latest");
+  let requestCount;
+  let maxUnstakers;
 
   if (!addresses) {
-    const requestCount = await adapter.totalRequests();
+    [requestCount, maxUnstakers] = await Promise.all([
+      adapter.totalRequests(),
+      adapter.MAX_UNSTAKERS(),
+    ]);
+    const unstakerCount = Number(
+      requestCount < maxUnstakers ? requestCount : maxUnstakers,
+    );
     addresses = await Promise.all(
-      Array.from({ length: Number(requestCount) }, async (_, requestIndex) => {
-        const index = await adapter.unstakerIndexAt(requestIndex);
+      Array.from({ length: unstakerCount }, async (_, index) => {
         const address = await adapter.unstakers(index);
-        return { address, index: Number(index) };
+        return { address, index };
       }),
     );
   } else {
@@ -96,7 +107,7 @@ const fetchUnstakerStates = async (signer, adapter, addresses) => {
   }
 
   // Promise.all executes all RPC calls simultaneously
-  return Promise.all(
+  const states = await Promise.all(
     addresses.map(async ({ address, index }) => {
       const [cooldownEnd, underlyingAmount] = await contract.cooldowns(address);
       const shares = adapter
@@ -135,6 +146,10 @@ const fetchUnstakerStates = async (signer, adapter, addresses) => {
       };
     }),
   );
+
+  if (!adapter) return states;
+
+  return orderPendingUnstakerStates(states, requestCount, maxUnstakers);
 };
 
 // --- MAIN FUNCTIONS ---
@@ -249,12 +264,6 @@ const claimEthenaWithdrawals = async (options) => {
   }
 };
 
-const selectClaimableFifoPrefix = (states) => {
-  const firstUnreadyIndex = states.findIndex((s) => !s.isReady);
-  if (firstUnreadyIndex === -1) return states;
-  return states.slice(0, firstUnreadyIndex);
-};
-
 // --- UTILS ---
 function getTimeDifference(date1, date2) {
   const diff = Math.abs(new Date(date2) - new Date(date1));
@@ -269,5 +278,6 @@ module.exports = {
   requestEthenaWithdrawals,
   claimEthenaWithdrawals,
   ethenaWithdrawStatus,
+  orderPendingUnstakerStates,
   selectClaimableFifoPrefix,
 };

--- a/src/js/utils/arm.js
+++ b/src/js/utils/arm.js
@@ -533,6 +533,7 @@ const adapterContract = async (adapterAddress, signerOrProvider) =>
       "function claimableRedeem() view returns (uint256,uint256)",
       "function lastRequestTimestamp() view returns (uint32)",
       "function DELAY_REQUEST() view returns (uint256)",
+      "function MAX_UNSTAKERS() view returns (uint8)",
       "function totalRequests() view returns (uint256)",
       "function unstakerIndexAt(uint256) view returns (uint8)",
       "function unstakers(uint256) view returns (address)",

--- a/src/js/utils/ethenaQueue.js
+++ b/src/js/utils/ethenaQueue.js
@@ -1,0 +1,39 @@
+const orderPendingUnstakerStates = (states, totalRequests, maxUnstakers) => {
+  const activeStates = states.filter((state) => state.shares > 0n);
+  if (activeStates.length === 0) return [];
+
+  const pendingCount = BigInt(activeStates.length);
+  if (pendingCount > totalRequests) {
+    throw new Error("Ethena pending request count exceeds total requests");
+  }
+
+  const statesByIndex = new Map(
+    activeStates.map((state) => [state.index, state]),
+  );
+  // The adapter clears requests only from the FIFO head, so the active request
+  // ids are the final `pendingCount` ids and map to unstakers circularly.
+  const firstPendingRequest = totalRequests - pendingCount;
+
+  return Array.from({ length: activeStates.length }, (_, offset) => {
+    const requestIndex = firstPendingRequest + BigInt(offset);
+    const unstakerIndex = Number(requestIndex % maxUnstakers);
+    const state = statesByIndex.get(unstakerIndex);
+    if (!state) {
+      throw new Error(
+        `Missing Ethena unstaker ${unstakerIndex} for pending request ${requestIndex}`,
+      );
+    }
+    return state;
+  });
+};
+
+const selectClaimableFifoPrefix = (states) => {
+  const firstUnreadyIndex = states.findIndex((state) => !state.isReady);
+  if (firstUnreadyIndex === -1) return states;
+  return states.slice(0, firstUnreadyIndex);
+};
+
+module.exports = {
+  orderPendingUnstakerStates,
+  selectClaimableFifoPrefix,
+};

--- a/test/js/ethenaQueue.test.js
+++ b/test/js/ethenaQueue.test.js
@@ -1,0 +1,74 @@
+const assert = require("assert");
+
+const {
+  orderPendingUnstakerStates,
+  selectClaimableFifoPrefix,
+} = require("../../src/js/utils/ethenaQueue");
+
+const state = (index, isReady = false) => ({
+  index,
+  shares: BigInt(index + 1),
+  isReady,
+});
+
+const run = async () => {
+  {
+    const states = [state(39, true), state(40, false)];
+    const ordered = orderPendingUnstakerStates(states, 41n, 42n);
+
+    assert.deepStrictEqual(
+      ordered.map(({ index }) => index),
+      [39, 40],
+    );
+    assert.deepStrictEqual(
+      selectClaimableFifoPrefix(ordered).map(({ index }) => index),
+      [39],
+    );
+  }
+
+  {
+    // Requests 41-44 are pending after the first rotation. Reading the current
+    // slots by index returns 0, 1, 2 before 41, but the FIFO starts at 41.
+    const states = [
+      state(0, false),
+      state(1, false),
+      state(2, false),
+      state(41, true),
+    ];
+    const ordered = orderPendingUnstakerStates(states, 45n, 42n);
+
+    assert.deepStrictEqual(
+      ordered.map(({ index }) => index),
+      [41, 0, 1, 2],
+    );
+    assert.deepStrictEqual(
+      selectClaimableFifoPrefix(ordered).map(({ index }) => index),
+      [41],
+    );
+  }
+
+  {
+    const states = [state(0, true), state(1, true), state(2, true)];
+    const ordered = orderPendingUnstakerStates(states, 45n, 42n);
+
+    assert.strictEqual(ordered.length, 3);
+    assert.strictEqual(
+      ordered.reduce((shares, item) => shares + item.shares, 0n),
+      6n,
+    );
+  }
+
+  {
+    assert.throws(
+      () => orderPendingUnstakerStates([state(0)], 45n, 42n),
+      /Missing Ethena unstaker 2 for pending request 44/,
+    );
+  }
+};
+
+run()
+  .then(() => console.log("ethenaQueue tests passed"))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary

- query each current Ethena unstaker slot once instead of expanding every historical request
- reconstruct the pending FIFO from `totalRequests`, the active request count, and `MAX_UNSTAKERS`
- add regression coverage for the first 42-slot wrap and duplicate-share prevention

## Root cause

After `totalRequests` exceeded 42, the action expanded every historical request id and resolved each id modulo 42. At 45 requests this produced `0, 1, 2, ..., 41, 0, 1, 2`, while the actual pending FIFO was `41, 0, 1, 2`. Since slots 0-2 were not ready, the off-chain FIFO prefix stopped before ready slot 41 and submitted no claim.

## Mainnet validation

Against the current Ethena adapter state:

- `totalRequests = 45`
- reconstructed pending order: `[41, 0, 1, 2]`
- reconstructed claimable prefix: `[41]`
- claim shares: `6063070730252694374950`

A read-only simulation from the Talos operator returns `7509122412196736546883` USDe for that claim.

## Tests

- `node test/js/ethenaQueue.test.js`
- `pnpm lint`
- `forge test --match-path test/unit/adapters/concrete/EthenaAssetAdapter.t.sol` (21 passed)
- focused Prettier check on changed JS files

`pnpm typecheck` remains blocked by the existing repository setup: `tsconfig.json` requests the Node type library, but `@types/node` is not declared as a root dependency.