### PR TITLE
Bake GIT_COMMIT_SHA into runner image

### DIFF
--- a/.github/workflows/aws-deployment.yml
+++ b/.github/workflows/aws-deployment.yml
@@ -73,6 +73,8 @@ jobs:
           file: ./dockerfile-actions
           push: true
           ssh: default
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
 

--- a/dockerfile-actions
+++ b/dockerfile-actions
@@ -73,5 +73,12 @@ ENV MAINNET_URL="" \
   SONIC_URL="" \
   HOLESKY_URL=""
 
+# Git commit this image was built from. CI passes
+# --build-arg GIT_COMMIT_SHA=<github.sha>; empty for local builds. @talos/client's
+# runContainer reports it as the runner's `version`, letting the admin announce
+# redeploys to Discord.
+ARG GIT_COMMIT_SHA=""
+ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA
+
 USER runner
 CMD ["bun", "run", "runner.ts"]


### PR DESCRIPTION
Bakes the build commit into the runner image so `@talos/client`'s `runContainer` reports it as the runner's `version` (it reads `GIT_COMMIT_SHA`). This populates `runners.version` in the shared Talos Postgres — null today — which the Talos admin uses to announce runner redeploys to Discord.

Mirrors how the admin already bakes `TALOS_ADMIN_COMMIT`:
- `dockerfile-actions`: `ARG GIT_COMMIT_SHA=""` + `ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA` (empty default keeps local builds working).
- `aws-deployment.yml`: CI passes `--build-arg GIT_COMMIT_SHA=${{ github.sha }}`.

No `@talos/client` bump — the library already reads this env. Pairs with oplabs/talos#14.