### PR TITLE
Document Talos scheduled actions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,6 +78,8 @@ All ARMs are deployed behind `Proxy.sol` (EIP-1967) for upgradeability.
 
 Actions are bundled via: `pnpm rollup -c src/js/actions/rollup.config.cjs`
 
+**Scheduled actions (Talos):** the runner's cron/manual actions live in `src/js/tasks/actions/*.ts`, are scheduled in `migrations/seed_schedules.sql`, and are catalogued in `docs/ACTIONS.md`. When you add, remove, or change the behaviour of a scheduled action, update `docs/ACTIONS.md` in the same change.
+
 ## Deployment
 
 Deployment scripts are in `script/deploy/` organized by chain (`mainnet/`, `sonic/`). Numbered scripts (e.g. `011_DeployEtherFiARMScript.s.sol`) are auto-discovered and ordered by `DeployManager.s.sol`. See `script/deploy/ARCHITECTURE.md` for the full deployment framework documentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ All ARMs are deployed behind `Proxy.sol` (EIP-1967) for upgradeability.
 
 Actions are bundled via: `pnpm rollup -c src/js/actions/rollup.config.cjs`
 
+**Scheduled actions (Talos):** the runner's cron/manual actions live in `src/js/tasks/actions/*.ts`, are scheduled in `migrations/seed_schedules.sql`, and are catalogued in `docs/ACTIONS.md`. When you add, remove, or change the behaviour of a scheduled action, update `docs/ACTIONS.md` in the same change.
+
 ## Deployment
 
 Deployment scripts are in `script/deploy/` organized by chain (`mainnet/`, `sonic/`). `DeployManager.sol` orchestrates execution based on chain ID.

--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ The `src/js/tasks/actions/*.ts` files are hardhat tasks that handle operational 
 - **`migrations/seed_schedules.sql`** is a one-time seed of the `schedules` table mirroring the old `cron/cron-jobs.ts`.
 - **`src/js/tasks/lib/action.ts`** wraps the hardhat signer with `wrapSignerWithNonceQueueV6` from the library when `DATABASE_URL` is set. That routes `signer.sendTransaction` through Postgres row-locked nonce coordination.
 
+Every scheduled action — its cadence and one-line purpose — is catalogued in [`docs/ACTIONS.md`](docs/ACTIONS.md).
+
 ### Running actions locally
 
 Every action remains directly executable as a hardhat task on your dev machine:

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -1,0 +1,87 @@
+# Talos scheduled actions
+
+Hardhat tasks the Talos runner (`runner.ts` → `@talos/client`) runs on a cron
+schedule, or on demand via the "Run now" button in the Talos admin UI. Each
+action is defined in [`src/js/tasks/actions/<name>.ts`](../src/js/tasks/actions);
+the canonical schedule — cron, enabled state, and per-row operational notes —
+lives in [`migrations/seed_schedules.sql`](../migrations/seed_schedules.sql). See
+[Automated Actions (Talos)](../README.md#automated-actions-talos) for how the
+runner works.
+
+> **Keep in sync** (see [`CLAUDE.md`](../CLAUDE.md)): update this file whenever a
+> scheduled action is added, removed, or its behaviour changes.
+
+Cron times are UTC. Enable state is managed in the database, not here.
+
+## Lido ARM — mainnet
+
+| Action                    | Cron                    | Description                            |
+| ------------------------- | ----------------------- | -------------------------------------- |
+| `autoRequestLidoWithdraw` | `29,58 12-23,0-8 * * *` | Request Lido withdrawals from Lido ARM |
+| `autoClaimLidoWithdraw`   | `32 0,12 * * *`         | Claim Lido withdrawals from Lido ARM   |
+| `collectLidoFees`         | `30 12 * * *`           | Collect fees from Lido ARM             |
+| `allocateLido`            | `38,08 * * * *`         | Allocate liquidity for Lido ARM        |
+| `setPricesLido`           | `*/30 * * * *`          | Set prices for Lido ARM                |
+
+## EtherFi ARM — mainnet
+
+| Action                       | Cron            | Description                                  |
+| ---------------------------- | --------------- | -------------------------------------------- |
+| `autoRequestEtherFiWithdraw` | `10,40 * * * *` | Request EtherFi withdrawals from EtherFi ARM |
+| `autoClaimEtherFiWithdraw`   | `40 * * * *`    | Claim EtherFi withdrawals from EtherFi ARM   |
+| `collectEtherFiFees`         | `45 23 * * *`   | Collect fees from EtherFi ARM                |
+| `allocateEtherFi`            | `52 * * * *`    | Allocate liquidity for EtherFi ARM           |
+| `setPricesEtherFi`           | `2,32 * * * *`  | Set prices for EtherFi ARM                   |
+
+## Ethena ARM — mainnet
+
+| Action                      | Cron          | Description                                |
+| --------------------------- | ------------- | ------------------------------------------ |
+| `autoRequestEthenaWithdraw` | `12 * * * *`  | Request Ethena withdrawals from Ethena ARM |
+| `autoClaimEthenaWithdraw`   | `40 * * * *`  | Claim Ethena withdrawals from Ethena ARM   |
+| `collectEthenaFees`         | `45 23 * * *` | Collect fees from Ethena ARM               |
+| `allocateEthena`            | `28 * * * *`  | Allocate liquidity for Ethena ARM          |
+| `setPricesEthena`           | `4 * * * *`   | Set prices for Ethena ARM                  |
+
+## USD ARM — mainnet
+
+| Action                   | Cron          | Description                                                         |
+| ------------------------ | ------------- | ------------------------------------------------------------------- |
+| `autoRequestUSDWithdraw` | `14 * * * *`  | Request and submit Paxos redemptions of PYUSD/USDG from the USD ARM |
+| `autoClaimUSDWithdraw`   | `44 * * * *`  | Claim USDC settled by Paxos redemptions for the USD ARM             |
+| `collectUSDFees`         | `50 23 * * *` | Collect fees from USD ARM                                           |
+| `allocateUSD`            | `26 * * * *`  | Allocate liquidity for USD ARM                                      |
+| `setPricesUSD`           | `6 * * * *`   | Set prices for USD ARM                                              |
+
+## Origin ARM — Sonic
+
+| Action                     | Cron            | Description                                             |
+| -------------------------- | --------------- | ------------------------------------------------------- |
+| `autoRequestWithdrawSonic` | `48,18 * * * *` | Request withdrawals from Origin ARM on Sonic            |
+| `autoClaimWithdrawSonic`   | `10 * * * *`    | Claim withdrawals from Origin ARM on Sonic and allocate |
+| `collectFeesSonic`         | `55 23 * * *`   | Collect fees from Origin ARM on Sonic                   |
+| `allocateSonic`            | `1,31 * * * *`  | Allocate liquidity for Origin ARM on Sonic              |
+| `setOSSiloPriceAction`     | `*/30 * * * *`  | Set prices on Sonic ARM                                 |
+| `collectRewardsSonic`      | `45 23 * * *`   | Collect rewards from the Sonic harvester                |
+
+## System
+
+| Action        | Cron          | Description                                           |
+| ------------- | ------------- | ----------------------------------------------------- |
+| `healthcheck` | `*/5 * * * *` | Simple health check to verify the action system works |
+
+## Manual-only — mainnet
+
+Dispatched via "Run now"; the required flags are edited into the schedule's
+command before each run (see notes in `seed_schedules.sql`).
+
+| Action                           | Description                                                            |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| `pauseLido`                      | Pause the Lido ARM                                                     |
+| `pauseEtherFi`                   | Pause the EtherFi ARM                                                  |
+| `pauseEthena`                    | Pause the Ethena ARM                                                   |
+| `pauseUSD`                       | Pause the USD ARM                                                      |
+| `claimRedeem`                    | Claim matured LP redeem requests on behalf of users (`--arm`, `--ids`) |
+| `setARMBufferAction`             | Set the ARM buffer (`--arm`, `--buffer`)                               |
+| `setLiquidityProviderCapsAction` | Set liquidity-provider caps (`--arm`, `--accounts`, `--cap`)           |
+| `setTotalAssetsCapAction`        | Set the total-assets cap (`--arm`, `--cap`)                            |


### PR DESCRIPTION
## What

Adds a concise, human-readable reference for the **Talos scheduled actions** this repo runs, and a CLAUDE.md rule to keep it current.

### New: `docs/ACTIONS.md`
One row per scheduled action — **35 total** — grouped for scanability:

- **Lido / EtherFi / Ethena / USD ARM (mainnet)** — request/claim withdrawals, collect fees, allocate, set prices (5 each).
- **Origin ARM (Sonic)** — request/claim withdrawals, collect fees, allocate, set prices, collect rewards (6).
- **System** — `healthcheck`.
- **Manual-only (mainnet)** — `pause*`, `claimRedeem`, `setARMBufferAction`, `setLiquidityProviderCapsAction`, `setTotalAssetsCapAction` (dispatched via the admin "Run now" button).

Each row is `action | cron | description`, with the description sourced verbatim from the action's own `description` field in `src/js/tasks/actions/<name>.ts`. Cron/network come from `migrations/seed_schedules.sql` (the canonical schedule). Enable state and per-row operational notes stay in the SQL — the doc links to it rather than duplicating them.

### CLAUDE.md keep-in-sync rule
Added to **both** `CLAUDE.md` and `.claude/CLAUDE.md` (in the *Off-Chain Automation* section), stating that when a scheduled action is added, removed, or its behaviour changes, `docs/ACTIONS.md` must be updated in the same change. The note also fills a gap — those sections previously described only the legacy Defender actions and didn't point at the Talos `src/js/tasks/actions/` set.