### PR TITLE
chore: add .npmrc for GitHub package registry and update references t…

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: 'false'
   ssh-key:
     description: >-
-      SSH private key used to clone the private @talos/client dependency
+      SSH private key used to clone the private @oplabs/talos-client dependency
       (git@github.com:oplabs/talos.git) during `pnpm install`. Pass the
       TALOS_DEPLOY_KEY secret from jobs that set install-pnpm: true.
       Empty (e.g. fork PRs without secret access) skips the SSH agent.
@@ -64,10 +64,10 @@ runs:
         node-version: '22'
         cache: 'pnpm'
 
-    # The private @talos/client dependency is cloned over SSH during
+    # The private @oplabs/talos-client dependency is cloned over SSH during
     # `pnpm install`. Without the deploy key the clone fails with
     # "Permission denied (publickey)" and the whole install aborts.
-    - name: Set up SSH agent for private @talos/client dependency
+    - name: Set up SSH agent for private @oplabs/talos-client dependency
       if: inputs.install-pnpm == 'true' && inputs.ssh-key != ''
       uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd  # v0.9.1
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,14 +6,6 @@ inputs:
     description: 'Whether to install pnpm dependencies'
     required: false
     default: 'false'
-  ssh-key:
-    description: >-
-      SSH private key used to clone the private @oplabs/talos-client dependency
-      (git@github.com:oplabs/talos.git) during `pnpm install`. Pass the
-      TALOS_DEPLOY_KEY secret from jobs that set install-pnpm: true.
-      Empty (e.g. fork PRs without secret access) skips the SSH agent.
-    required: false
-    default: ''
 
 runs:
   using: 'composite'
@@ -63,15 +55,6 @@ runs:
       with:
         node-version: '22'
         cache: 'pnpm'
-
-    # The private @oplabs/talos-client dependency is cloned over SSH during
-    # `pnpm install`. Without the deploy key the clone fails with
-    # "Permission denied (publickey)" and the whole install aborts.
-    - name: Set up SSH agent for private @oplabs/talos-client dependency
-      if: inputs.install-pnpm == 'true' && inputs.ssh-key != ''
-      uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd  # v0.9.1
-      with:
-        ssh-private-key: ${{ inputs.ssh-key }}
 
     - name: Install pnpm dependencies
       if: inputs.install-pnpm == 'true'

--- a/.github/workflows/aws-deployment.yml
+++ b/.github/workflows/aws-deployment.yml
@@ -7,8 +7,9 @@ name: AWS — build runner image
 #
 # Triggers on `main`.
 #
-# Requires the TALOS_DEPLOY_KEY repo secret for the @oplabs/talos-client
-# git-install (SSH deploy key against oplabs/talos).
+# The image installs @oplabs/talos-client from the oplabs GitHub Packages
+# registry using the TALOS_PACKAGE_TOKEN secret. It must contain a PAT with
+# read:packages access to the oplabs package.
 
 on:
   push:
@@ -32,11 +33,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Set up SSH agent for @oplabs/talos-client deploy key
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.TALOS_DEPLOY_KEY }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
@@ -72,7 +68,8 @@ jobs:
           context: .
           file: ./dockerfile-actions
           push: true
-          ssh: default
+          secrets: |
+            talos_package_token=${{ secrets.TALOS_PACKAGE_TOKEN }}
           build-args: |
             GIT_COMMIT_SHA=${{ github.sha }}
           tags: |

--- a/.github/workflows/aws-deployment.yml
+++ b/.github/workflows/aws-deployment.yml
@@ -7,7 +7,7 @@ name: AWS — build runner image
 #
 # Triggers on `main`.
 #
-# Requires the TALOS_DEPLOY_KEY repo secret for the @talos/client
+# Requires the TALOS_DEPLOY_KEY repo secret for the @oplabs/talos-client
 # git-install (SSH deploy key against oplabs/talos).
 
 on:
@@ -29,23 +29,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Set up SSH agent for @talos/client deploy key
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd  # v0.9.1
+      - name: Set up SSH agent for @oplabs/talos-client deploy key
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.TALOS_DEPLOY_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df  # v4.2.1
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to ECR
-        uses: aws-actions/amazon-ecr-login@4625ce35226a7557230889aae2f52eb50ec3dcda  # v2.0.1
+        uses: aws-actions/amazon-ecr-login@4625ce35226a7557230889aae2f52eb50ec3dcda # v2.0.1
 
       - name: Check if image tag already exists (ECR is IMMUTABLE)
         id: tag_exists
@@ -63,11 +63,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.tag_exists.outputs.exists == 'false'
-        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca  # v3.9.0
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Build and push runner image
         if: steps.tag_exists.outputs.exists == 'false'
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5.4.0
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./dockerfile-actions
@@ -95,4 +95,3 @@ jobs:
           echo "    --container runner \\"
           echo "    --image \"${IMAGE_REF}\" \\"
           echo "    --version <semver>"
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           install-pnpm: 'true'
-          ssh-key: ${{ secrets.TALOS_DEPLOY_KEY }}
 
       - name: Compile all contracts
         run: forge build
@@ -84,7 +83,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           install-pnpm: 'true'
-          ssh-key: ${{ secrets.TALOS_DEPLOY_KEY }}
 
       - name: Run unit tests
         run: forge test --summary --fail-fast --show-progress --mp 'test/unit/**'
@@ -104,7 +102,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           install-pnpm: 'true'
-          ssh-key: ${{ secrets.TALOS_DEPLOY_KEY }}
 
       - name: Run fork tests
         run: forge test --summary --fail-fast --show-progress --mp 'test/fork/**'
@@ -124,7 +121,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           install-pnpm: 'true'
-          ssh-key: ${{ secrets.TALOS_DEPLOY_KEY }}
 
       - name: Run smoke tests
         run: forge build && forge test --summary --fail-fast --show-progress --mp 'test/smoke/**'

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ logs
 
 # npm
 node_modules
+.pnpm-store/
 *.log
 
 # hardhat

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@oplabs:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ yarn hardhat tenderlyUpload --network sonic --name ORIGIN_ARM
 
 ## Automated Actions (Talos)
 
-The `src/js/tasks/actions/*.ts` files are hardhat tasks that handle operational jobs (allocations, fee collection, withdrawal requests, etc.). In production they're driven by a container that imports [`@talos/client`](https://github.com/oplabs/talos):
+The `src/js/tasks/actions/*.ts` files are hardhat tasks that handle operational jobs (allocations, fee collection, withdrawal requests, etc.). In production they're driven by a container that imports [`@oplabs/talos-client`](https://github.com/oplabs/talos):
 
 - **`runner.ts`** at repo root calls `runContainer({ product: "arm-oeth", workdir: "/app" })`. The library reads enabled schedules from the shared Talos Postgres, fires them via croner, and spawns each schedule's command as `pnpm hardhat <name> --network <chain>`.
 - **`migrations/seed_schedules.sql`** is a one-time seed of the `schedules` table mirroring the old `cron/cron-jobs.ts`.

--- a/README.md
+++ b/README.md
@@ -319,6 +319,19 @@ The `src/js/tasks/actions/*.ts` files are hardhat tasks that handle operational 
 
 Every scheduled action — its cadence and one-line purpose — is catalogued in [`docs/ACTIONS.md`](docs/ACTIONS.md).
 
+`@oplabs/talos-client` is an optional peer dependency and is therefore not
+installed by the normal `pnpm install`. The runner image installs it explicitly
+from GitHub Packages. For a local image build, expose a token only through the
+BuildKit secret used by Compose:
+
+```bash
+TALOS_PACKAGE_TOKEN="<PAT>" docker compose build actions
+```
+
+Use a classic PAT with `read:packages` access to the oplabs package (and SSO
+authorization where required). The AWS image workflow reads it from the
+`TALOS_PACKAGE_TOKEN` repository secret.
+
 ### Running actions locally
 
 Every action remains directly executable as a hardhat task on your dev machine:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     build:
       context: .
       dockerfile: dockerfile-actions
+      secrets:
+        - talos_package_token
     depends_on:
       postgres:
         condition: service_healthy
@@ -34,3 +36,7 @@ services:
 
 volumes:
   pgdata:
+
+secrets:
+  talos_package_token:
+    environment: TALOS_PACKAGE_TOKEN

--- a/dockerfile-actions
+++ b/dockerfile-actions
@@ -19,7 +19,6 @@ RUN apt-get update \
   ca-certificates \
   curl \
   git \
-  openssh-client \
   build-essential \
   python3 \
   bsdutils \
@@ -32,9 +31,6 @@ RUN apt-get update \
 # chown /app and switch USER just before CMD.
 RUN groupadd -r runner && useradd -r -g runner -m -d /home/runner runner
 
-RUN mkdir -p /root/.ssh \
-  && ssh-keyscan -t ed25519,rsa github.com >> /root/.ssh/known_hosts
-
 # Foundry (forge/cast/anvil) — required at hardhat config load time
 # because hardhat.config.js loads @nomicfoundation/hardhat-foundry.
 # Pulled from the digest-pinned `foundry` builder stage at the top of
@@ -43,12 +39,19 @@ COPY --from=foundry /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvi
 
 WORKDIR /app
 
-# Install dependencies first for better caching. Requires BuildKit SSH
-# forwarding (e.g. Railway deploy key) to resolve @automaton/client.
-COPY package.json pnpm-lock.yaml ./
-RUN --mount=type=ssh \
+# Install the public dependencies first for better caching. The Talos client is
+# an optional peer dependency, so install it explicitly using a GitHub Packages
+# PAT supplied as a BuildKit secret. The PAT needs read:packages access to the
+# oplabs package.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN --mount=type=cache,id=arm-oeth-pnpm-store,target=/root/.local/share/pnpm/store \
+    npm install -g pnpm@10.33.2 && pnpm install --frozen-lockfile
+RUN --mount=type=secret,id=talos_package_token,required=true \
     --mount=type=cache,id=arm-oeth-pnpm-store,target=/root/.local/share/pnpm/store \
-    npm install -g pnpm@10.33.4 && pnpm install --frozen-lockfile
+    TOKEN="$(cat /run/secrets/talos_package_token)" \
+    && printf '@oplabs:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=%s\n' "$TOKEN" > /tmp/talos.npmrc \
+    && npm_config_userconfig=/tmp/talos.npmrc pnpm add --save-prod @oplabs/talos-client@0.0.1 \
+    && rm -f /tmp/talos.npmrc
 
 # Copy the rest of the workspace.
 COPY . .

--- a/dockerfile-actions
+++ b/dockerfile-actions
@@ -74,7 +74,7 @@ ENV MAINNET_URL="" \
   HOLESKY_URL=""
 
 # Git commit this image was built from. CI passes
-# --build-arg GIT_COMMIT_SHA=<github.sha>; empty for local builds. @talos/client's
+# --build-arg GIT_COMMIT_SHA=<github.sha>; empty for local builds. @oplabs/talos-client's
 # runContainer reports it as the runner's `version`, letting the admin announce
 # redeploys to Discord.
 ARG GIT_COMMIT_SHA=""

--- a/dockerfile-actions
+++ b/dockerfile-actions
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.10
 
 # Foundry binaries (forge/cast/anvil) — pulled from the official image
 # at a digest pin instead of curl-pipe-bash from foundry.paradigm.xyz.
@@ -40,17 +40,17 @@ COPY --from=foundry /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvi
 WORKDIR /app
 
 # Install the public dependencies first for better caching. The Talos client is
-# an optional peer dependency, so install it explicitly using a GitHub Packages
-# PAT supplied as a BuildKit secret. The PAT needs read:packages access to the
-# oplabs package.
+# an optional peer dependency, so install the version declared in package.json
+# using the TALOS_PACKAGE_TOKEN environment variable. The token needs
+# read:packages access to the oplabs package.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=arm-oeth-pnpm-store,target=/root/.local/share/pnpm/store \
     npm install -g pnpm@10.33.2 && pnpm install --frozen-lockfile
-RUN --mount=type=secret,id=talos_package_token,required=true \
+RUN --mount=type=secret,id=talos_package_token,env=TALOS_PACKAGE_TOKEN,required=true \
     --mount=type=cache,id=arm-oeth-pnpm-store,target=/root/.local/share/pnpm/store \
-    TOKEN="$(cat /run/secrets/talos_package_token)" \
-    && printf '@oplabs:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=%s\n' "$TOKEN" > /tmp/talos.npmrc \
-    && npm_config_userconfig=/tmp/talos.npmrc pnpm add --save-prod @oplabs/talos-client@0.0.1 \
+    TALOS_CLIENT_VERSION="$(node -p "require('./package.json').peerDependencies['@oplabs/talos-client']")" \
+    && printf '@oplabs:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=%s\n' "$TALOS_PACKAGE_TOKEN" > /tmp/talos.npmrc \
+    && npm_config_userconfig=/tmp/talos.npmrc pnpm add --save-prod "@oplabs/talos-client@$TALOS_CLIENT_VERSION" \
     && rm -f /tmp/talos.npmrc
 
 # Copy the rest of the workspace.

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -1,6 +1,6 @@
 # Talos scheduled actions
 
-Hardhat tasks the Talos runner (`runner.ts` → `@talos/client`) runs on a cron
+Hardhat tasks the Talos runner (`runner.ts` → `@oplabs/talos-client`) runs on a cron
 schedule, or on demand via the "Run now" button in the Talos admin UI. Each
 action is defined in [`src/js/tasks/actions/<name>.ts`](../src/js/tasks/actions);
 the canonical schedule — cron, enabled state, and per-row operational notes —

--- a/dump-actions-catalog.cjs
+++ b/dump-actions-catalog.cjs
@@ -9,8 +9,8 @@
  * stays in Node-land here; the bundled JSON is shipped into the image
  * and read by `runner.ts` at boot.
  *
- * Output shape matches `ActionParam[]` from `@talos/client/actions-catalog`.
- * Self-contained on purpose — no @talos/client import (the bundle is ESM
+ * Output shape matches `ActionParam[]` from `@oplabs/talos-client/actions-catalog`.
+ * Self-contained on purpose — no @oplabs/talos-client import (the bundle is ESM
  * and this script runs under Node CJS).
  */
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
-    "@talos/client": "github:oplabs/talos#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client"
+    "@oplabs/talos-client": "0.0.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -38,8 +38,13 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.7.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@oplabs/talos-client": "0.0.1"
+  },
+  "peerDependenciesMeta": {
+    "@oplabs/talos-client": {
+      "optional": true
+    }
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.7.0"
   },
   "peerDependencies": {
-    "@oplabs/talos-client": "0.0.1"
+    "@oplabs/talos-client": "0.0.28"
   },
   "peerDependenciesMeta": {
     "@oplabs/talos-client": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,12 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
 
   .:
-    dependencies:
-      '@talos/client':
-        specifier: github:oplabs/talos#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client
-        version: git+https://git@github.com:oplabs/talos.git#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client(typescript@5.9.3)(zod@3.25.76)
     devDependencies:
       '@apollo/client':
         specifier: ^3.11.4
@@ -77,9 +73,6 @@ packages:
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
-
-  '@adraffy/ens-normalize@1.11.1':
-    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@apollo/client@3.14.1':
     resolution: {integrity: sha512-SgGX6E23JsZhUdG2anxiyHvEvvN6CUaI4ZfMsndZFeuHPXL3H0IsaiNAhLITSISbeyeYd+CBd9oERXQDdjXWZw==}
@@ -286,17 +279,8 @@ packages:
   '@ethersproject/constants@5.8.0':
     resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
 
-  '@ethersproject/contracts@5.8.0':
-    resolution: {integrity: sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==}
-
   '@ethersproject/hash@5.8.0':
     resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
-
-  '@ethersproject/hdnode@5.8.0':
-    resolution: {integrity: sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==}
-
-  '@ethersproject/json-wallets@5.8.0':
-    resolution: {integrity: sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==}
 
   '@ethersproject/keccak256@5.8.0':
     resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
@@ -306,9 +290,6 @@ packages:
 
   '@ethersproject/networks@5.8.0':
     resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
-
-  '@ethersproject/pbkdf2@5.8.0':
-    resolution: {integrity: sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==}
 
   '@ethersproject/properties@5.8.0':
     resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
@@ -328,26 +309,14 @@ packages:
   '@ethersproject/signing-key@5.8.0':
     resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
 
-  '@ethersproject/solidity@5.8.0':
-    resolution: {integrity: sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==}
-
   '@ethersproject/strings@5.8.0':
     resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
 
   '@ethersproject/transactions@5.8.0':
     resolution: {integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==}
 
-  '@ethersproject/units@5.8.0':
-    resolution: {integrity: sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==}
-
-  '@ethersproject/wallet@5.8.0':
-    resolution: {integrity: sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==}
-
   '@ethersproject/web@5.8.0':
     resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
-
-  '@ethersproject/wordlists@5.8.0':
-    resolution: {integrity: sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==}
 
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
@@ -357,12 +326,6 @@ packages:
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -394,10 +357,6 @@ packages:
     peerDependencies:
       ethers: ^6.13.0
 
-  '@noble/ciphers@1.3.0':
-    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
-    engines: {node: ^14.21.3 || >=16}
-
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -406,10 +365,6 @@ packages:
 
   '@noble/curves@1.8.2':
     resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
-    engines: {node: ^14.21.3 || >=16}
-
-  '@noble/curves@1.9.1':
-    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.2.0':
@@ -425,10 +380,6 @@ packages:
 
   '@noble/hashes@1.7.2':
     resolution: {integrity: sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==}
-    engines: {node: ^14.21.3 || >=16}
-
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/secp256k1@1.7.1':
@@ -541,17 +492,11 @@ packages:
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
-  '@scure/bip32@1.7.0':
-    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
-
   '@scure/bip39@1.1.1':
     resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
 
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
-
-  '@scure/bip39@1.6.0':
-    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sentry/core@5.30.0':
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
@@ -732,6 +677,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
@@ -755,10 +701,6 @@ packages:
 
   '@solidity-parser/parser@0.18.0':
     resolution: {integrity: sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==}
-
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client':
-    resolution: {commit: 8f15dbbdc96a4d3cabf932d41e016779c0946266, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
-    version: 0.0.25
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -806,17 +748,6 @@ packages:
     resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
     engines: {node: '>=8'}
 
-  abitype@1.2.3:
-    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3.22.0 || ^4.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -834,9 +765,6 @@ packages:
   adm-zip@0.4.16:
     resolution: {integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==}
     engines: {node: '>=0.3.0'}
-
-  aes-js@3.0.0:
-    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
 
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
@@ -1056,10 +984,6 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  croner@10.0.1:
-    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
-    engines: {node: '>=18.0'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1114,98 +1038,6 @@ packages:
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
-
-  drizzle-orm@0.45.2:
-    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
-    peerDependencies:
-      '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=4'
-      '@electric-sql/pglite': '>=0.2.0'
-      '@libsql/client': '>=0.10.0'
-      '@libsql/client-wasm': '>=0.10.0'
-      '@neondatabase/serverless': '>=0.10.0'
-      '@op-engineering/op-sqlite': '>=2'
-      '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1.13'
-      '@prisma/client': '*'
-      '@tidbcloud/serverless': '*'
-      '@types/better-sqlite3': '*'
-      '@types/pg': '*'
-      '@types/sql.js': '*'
-      '@upstash/redis': '>=1.34.7'
-      '@vercel/postgres': '>=0.8.0'
-      '@xata.io/client': '*'
-      better-sqlite3: '>=7'
-      bun-types: '*'
-      expo-sqlite: '>=14.0.0'
-      gel: '>=2'
-      knex: '*'
-      kysely: '*'
-      mysql2: '>=2'
-      pg: '>=8'
-      postgres: '>=3'
-      prisma: '*'
-      sql.js: '>=1'
-      sqlite3: '>=5'
-    peerDependenciesMeta:
-      '@aws-sdk/client-rds-data':
-        optional: true
-      '@cloudflare/workers-types':
-        optional: true
-      '@electric-sql/pglite':
-        optional: true
-      '@libsql/client':
-        optional: true
-      '@libsql/client-wasm':
-        optional: true
-      '@neondatabase/serverless':
-        optional: true
-      '@op-engineering/op-sqlite':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@prisma/client':
-        optional: true
-      '@tidbcloud/serverless':
-        optional: true
-      '@types/better-sqlite3':
-        optional: true
-      '@types/pg':
-        optional: true
-      '@types/sql.js':
-        optional: true
-      '@upstash/redis':
-        optional: true
-      '@vercel/postgres':
-        optional: true
-      '@xata.io/client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      bun-types:
-        optional: true
-      expo-sqlite:
-        optional: true
-      gel:
-        optional: true
-      knex:
-        optional: true
-      kysely:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      postgres:
-        optional: true
-      prisma:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1296,15 +1128,9 @@ packages:
     resolution: {integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==}
     engines: {node: '>=10.0.0'}
 
-  ethers@5.8.0:
-    resolution: {integrity: sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==}
-
   ethers@6.13.2:
     resolution: {integrity: sha512-9VkriTTed+/27BGuY1s0hf441kqwHJ1wtN2edksEtiRvXx+soxRX3iSXTfFqq2+YwrOqbDoTHjIhQnjJRlzKmg==}
     engines: {node: '>=14.0.0'}
-
-  eventemitter3@5.0.1:
-    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
@@ -1499,10 +1325,6 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.16:
-    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
-    engines: {node: '>=16.9.0'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -1592,11 +1414,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isows@1.0.7:
-    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
-    peerDependencies:
-      ws: '*'
 
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
@@ -1762,14 +1579,6 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
-  ox@0.14.20:
-    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1812,40 +1621,6 @@ packages:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
     engines: {node: '>= 0.10'}
 
-  pg-cloudflare@1.3.0:
-    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
-
-  pg-connection-string@2.12.0:
-    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
-
-  pg-int8@1.0.1:
-    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
-    engines: {node: '>=4.0.0'}
-
-  pg-pool@3.13.0:
-    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
-    peerDependencies:
-      pg: '>=8.0'
-
-  pg-protocol@1.13.0:
-    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
-
-  pg-types@2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
-
-  pg@8.20.0:
-    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
-
-  pgpass@1.0.5:
-    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1860,22 +1635,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postgres-array@2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
-
-  postgres-bytea@1.0.1:
-    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-date@1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-interval@1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2032,10 +1791,6 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
-
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
@@ -2190,14 +1945,6 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
-  viem@2.48.4:
-    resolution: {integrity: sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2267,22 +2014,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2313,14 +2044,9 @@ packages:
   zen-observable@0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
 snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
-
-  '@adraffy/ens-normalize@1.11.1': {}
 
   '@apollo/client@3.14.1(graphql@16.13.2)':
     dependencies:
@@ -2800,19 +2526,6 @@ snapshots:
     dependencies:
       '@ethersproject/bignumber': 5.8.0
 
-  '@ethersproject/contracts@5.8.0':
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-
   '@ethersproject/hash@5.8.0':
     dependencies:
       '@ethersproject/abstract-signer': 5.8.0
@@ -2825,37 +2538,6 @@ snapshots:
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
 
-  '@ethersproject/hdnode@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/basex': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-
-  '@ethersproject/json-wallets@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      aes-js: 3.0.0
-      scrypt-js: 3.0.1
-
   '@ethersproject/keccak256@5.8.0':
     dependencies:
       '@ethersproject/bytes': 5.8.0
@@ -2866,11 +2548,6 @@ snapshots:
   '@ethersproject/networks@5.8.0':
     dependencies:
       '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/pbkdf2@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/sha2': 5.8.0
 
   '@ethersproject/properties@5.8.0':
     dependencies:
@@ -2927,15 +2604,6 @@ snapshots:
       elliptic: 6.6.1
       hash.js: 1.1.7
 
-  '@ethersproject/solidity@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
   '@ethersproject/strings@5.8.0':
     dependencies:
       '@ethersproject/bytes': 5.8.0
@@ -2954,42 +2622,10 @@ snapshots:
       '@ethersproject/rlp': 5.8.0
       '@ethersproject/signing-key': 5.8.0
 
-  '@ethersproject/units@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/wallet@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/json-wallets': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-
   '@ethersproject/web@5.8.0':
     dependencies:
       '@ethersproject/base64': 5.8.0
       '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/wordlists@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hash': 5.8.0
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
@@ -2999,10 +2635,6 @@ snapshots:
   '@graphql-typed-document-node/core@3.2.0(graphql@16.13.2)':
     dependencies:
       graphql: 16.13.2
-
-  '@hono/node-server@1.19.14(hono@4.12.16)':
-    dependencies:
-      hono: 4.12.16
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -3033,8 +2665,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@noble/ciphers@1.3.0': {}
-
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -3047,10 +2677,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.7.2
 
-  '@noble/curves@1.9.1':
-    dependencies:
-      '@noble/hashes': 1.8.0
-
   '@noble/hashes@1.2.0': {}
 
   '@noble/hashes@1.3.2': {}
@@ -3058,8 +2684,6 @@ snapshots:
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@1.7.2': {}
-
-  '@noble/hashes@1.8.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -3167,12 +2791,6 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
 
-  '@scure/bip32@1.7.0':
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-
   '@scure/bip39@1.1.1':
     dependencies:
       '@noble/hashes': 1.2.0
@@ -3182,11 +2800,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
-
-  '@scure/bip39@1.6.0':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
 
   '@sentry/core@5.30.0':
     dependencies:
@@ -3513,51 +3126,6 @@ snapshots:
 
   '@solidity-parser/parser@0.18.0': {}
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client(typescript@5.9.3)(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.16)
-      croner: 10.0.1
-      drizzle-orm: 0.45.2(pg@8.20.0)
-      ethers-v5: ethers@5.8.0
-      ethers-v6: ethers@6.13.2
-      hono: 4.12.16
-      pg: 8.20.0
-      viem: 2.48.4(typescript@5.9.3)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bufferutil
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - pg-native
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
-      - typescript
-      - utf-8-validate
-      - zod
-
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -3602,11 +3170,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
-    optionalDependencies:
-      typescript: 5.9.3
-      zod: 3.25.76
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3618,8 +3181,6 @@ snapshots:
   acorn@8.16.0: {}
 
   adm-zip@0.4.16: {}
-
-  aes-js@3.0.0: {}
 
   aes-js@4.0.0-beta.5: {}
 
@@ -3868,8 +3429,6 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  croner@10.0.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3911,10 +3470,6 @@ snapshots:
       esutils: 2.0.3
 
   dotenv@16.6.1: {}
-
-  drizzle-orm@0.45.2(pg@8.20.0):
-    optionalDependencies:
-      pg: 8.20.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4068,42 +3623,6 @@ snapshots:
       ethereum-cryptography: 0.1.3
       rlp: 2.2.7
 
-  ethers@5.8.0:
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/basex': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/contracts': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/json-wallets': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/providers': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/solidity': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/units': 5.8.0
-      '@ethersproject/wallet': 5.8.0
-      '@ethersproject/web': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   ethers@6.13.2:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
@@ -4116,8 +3635,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  eventemitter3@5.0.1: {}
 
   evp_bytestokey@1.0.3:
     dependencies:
@@ -4356,8 +3873,6 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.16: {}
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -4432,10 +3947,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isows@1.0.7(ws@8.18.3):
-    dependencies:
-      ws: 8.18.3
 
   js-sha3@0.8.0: {}
 
@@ -4606,21 +4117,6 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
-  ox@0.14.20(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -4658,41 +4154,6 @@ snapshots:
       sha.js: 2.4.12
       to-buffer: 1.2.2
 
-  pg-cloudflare@1.3.0:
-    optional: true
-
-  pg-connection-string@2.12.0: {}
-
-  pg-int8@1.0.1: {}
-
-  pg-pool@3.13.0(pg@8.20.0):
-    dependencies:
-      pg: 8.20.0
-
-  pg-protocol@1.13.0: {}
-
-  pg-types@2.2.0:
-    dependencies:
-      pg-int8: 1.0.1
-      postgres-array: 2.0.0
-      postgres-bytea: 1.0.1
-      postgres-date: 1.0.7
-      postgres-interval: 1.2.0
-
-  pg@8.20.0:
-    dependencies:
-      pg-connection-string: 2.12.0
-      pg-pool: 3.13.0(pg@8.20.0)
-      pg-protocol: 1.13.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    optionalDependencies:
-      pg-cloudflare: 1.3.0
-
-  pgpass@1.0.5:
-    dependencies:
-      split2: 4.2.0
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4700,16 +4161,6 @@ snapshots:
   picomatch@4.0.4: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postgres-array@2.0.0: {}
-
-  postgres-bytea@1.0.1: {}
-
-  postgres-date@1.0.7: {}
-
-  postgres-interval@1.2.0:
-    dependencies:
-      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -4859,8 +4310,6 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  split2@4.2.0: {}
-
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
@@ -4994,23 +4443,6 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  viem@2.48.4(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.20(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.18.3
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -5054,10 +4486,6 @@ snapshots:
 
   ws@8.18.0: {}
 
-  ws@8.18.3: {}
-
-  xtend@4.0.2: {}
-
   y18n@5.0.8: {}
 
   yargs-parser@20.2.9: {}
@@ -5088,6 +4516,3 @@ snapshots:
       zen-observable: 0.8.15
 
   zen-observable@0.8.15: {}
-
-  zod@3.25.76:
-    optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
+autoInstallPeers: false
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@oplabs/talos-client'

--- a/runner.ts
+++ b/runner.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 
-import { type ActionsCatalog, runContainer } from "@talos/client";
+import { type ActionsCatalog, runContainer } from "@oplabs/talos-client";
 
 // The catalog is dumped at image build time by docker/dump-actions-catalog.cjs
 // (Node, where hardhat works). Reading it here keeps the runner's bun parent

--- a/src/js/types/talos-client.d.ts
+++ b/src/js/types/talos-client.d.ts
@@ -1,8 +1,8 @@
-// Ambient declaration for @talos/client.
+// Ambient declaration for @oplabs/talos-client.
 //
 // The package ships a bundled dist/index.js without .d.ts. A proper fix
 // would be emitting a bundled declaration (tsup --dts or similar) from
 // the talos repo. Until then, treat imports as `any` so consumer tsc
 // resolves the module without following the source graph (which pulls
 // in the private @talos/schema workspace dep).
-declare module "@talos/client";
+declare module "@oplabs/talos-client";

--- a/src/js/utils/signers.ts
+++ b/src/js/utils/signers.ts
@@ -1,10 +1,5 @@
 import { JsonRpcProvider, Signer, Wallet } from "ethers";
 import * as hhHelpers from "@nomicfoundation/hardhat-network-helpers";
-import {
-  createDb,
-  createPool,
-  wrapSignerWithNonceQueueV6,
-} from "@oplabs/talos-client";
 
 import { ethereumAddress, privateKey } from "./regex";
 
@@ -18,6 +13,9 @@ let dbInstance: unknown = null;
 function getNonceDb(): unknown {
   if (!process.env.DATABASE_URL) return null;
   if (!dbInstance) {
+    // Optional peer: only production/DB-backed runs need the Talos client.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { createDb, createPool } = require("@oplabs/talos-client");
     const pool = createPool({ connectionString: process.env.DATABASE_URL });
     dbInstance = createDb(pool);
   }
@@ -30,6 +28,8 @@ function getNonceDb(): unknown {
 function maybeWrap<S extends Signer>(rawSigner: S): S {
   const db = getNonceDb();
   if (!db) return rawSigner;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { wrapSignerWithNonceQueueV6 } = require("@oplabs/talos-client");
   return wrapSignerWithNonceQueueV6(rawSigner, { db });
 }
 

--- a/src/js/utils/signers.ts
+++ b/src/js/utils/signers.ts
@@ -4,14 +4,14 @@ import {
   createDb,
   createPool,
   wrapSignerWithNonceQueueV6,
-} from "@talos/client";
+} from "@oplabs/talos-client";
 
 import { ethereumAddress, privateKey } from "./regex";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const log = require("./logger")("utils:signers");
 
-// `@talos/client` ships without .d.ts so the ambient decl in
+// `@oplabs/talos-client` ships without .d.ts so the ambient decl in
 // src/js/types/talos-client.d.ts types imports as `any`; the Db handle
 // is therefore typed loosely here but used opaquely.
 let dbInstance: unknown = null;


### PR DESCRIPTION
## What

Migrates the arm-oeth runner off git-installing `@talos/client` from the private `oplabs/talos` repo (SSH deploy key) to the **published `@oplabs/talos-client` GitHub Package**. Companion to `oplabs/talos#19` (which publishes it) and `OriginProtocol/origin-dollar#2946`.

## Changes

- **`@talos/client` → `@oplabs/talos-client`**, declared as an **optional peer dependency**; the runner Dockerfile installs the pinned version with a `read:packages` PAT (`TALOS_PACKAGE_TOKEN` secret). No more SSH deploy key / git install.
- **`autoInstallPeers: false`** (`pnpm-workspace.yaml`) so token-less `pnpm install` passes without trying to resolve the optional peer. The client `require` in `src/js/utils/signers.ts` is lazy (behind the `DATABASE_URL` gate) so hardhat boots when the package is absent.
- **`.npmrc`** points the `@oplabs` scope at GitHub Packages; Dockerfile installs via `pnpm add --save-prod` with `# syntax=docker/dockerfile:1.10`.
- Pin `@oplabs/talos-client@0.0.28`.

(No `@lodestar` in arm-oeth's tree, so none of origin-dollar's dependency work applies here.)

## Validation

- **ARM CI green.**
- Runner image builds locally end-to-end (frozen install + token-authed `pnpm add @oplabs/talos-client@0.0.28`).

> `TALOS_PACKAGE_TOKEN` (a `read:packages` PAT) must stay set on the repo. The image build runs on `main`; the actual runner roll is a separate signed release.
