### PR TITLE
[yAudit-03] Fix swap fee accrual on realized gain

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -428,7 +428,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
             amountOut = convertedAmountIn * config.buyPrice / PRICE_SCALE;
         }
 
-        _validateAndConsumeSwapLiquidity(config, isBuySide, outToken, amountOut);
+        _validateAndConsumeSwapLiquidity(config, isBuySide, outToken, amountIn, amountOut);
 
         // Transfer the input tokens from the caller to this ARM contract
         inToken.transferFrom(msg.sender, address(this), amountIn);
@@ -468,7 +468,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
             amountIn = convertedAmountOut * PRICE_SCALE / config.buyPrice + 3;
         }
 
-        _validateAndConsumeSwapLiquidity(config, isBuySide, outToken, amountOut);
+        _validateAndConsumeSwapLiquidity(config, isBuySide, outToken, amountIn, amountOut);
 
         // Transfer the input tokens from the caller to this ARM contract
         inToken.transferFrom(msg.sender, address(this), amountIn);
@@ -518,16 +518,18 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
     /// @dev Validate swap reserves and consume the per-base liquidity limit.
     /// @param isBuySide True when the ARM buys base asset and pays out liquidity asset.
     /// @param outToken Swap output token address.
+    /// @param amountIn Swap input token amount.
     /// @param amountOut Swap output token amount.
     function _validateAndConsumeSwapLiquidity(
         BaseAssetConfig storage config,
         bool isBuySide,
         IERC20 outToken,
+        uint256 amountIn,
         uint256 amountOut
     ) private {
         uint256 remaining;
         if (isBuySide) {
-            _accrueSwapFee(config.buyPrice, config.crossPrice, amountOut);
+            _accrueSwapFee(config, amountIn, amountOut);
             remaining = config.buyLiquidityRemaining;
             if (amountOut > remaining) revert InsufficientLiquidity();
             unchecked {
@@ -581,13 +583,14 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         return baseDecimals > liquidityAssetDecimals ? amount * 1e12 : amount / 1e12;
     }
 
-    /// @dev Accrue fees on discounted buy-side swaps using the recognized NAV gain.
-    /// @param buyPrice Price the ARM paid for the base asset.
-    /// @param crossPrice Price used to value the base asset in totalAssets().
+    /// @dev Accrue fees on buy-side swaps using the gain realized from the settled input and output amounts.
+    /// @param config Base asset configuration used to value the input received by the ARM.
+    /// @param amountIn Base asset amount received by the ARM.
     /// @param amountOut Liquidity asset amount paid out by the ARM.
-    function _accrueSwapFee(uint256 buyPrice, uint256 crossPrice, uint256 amountOut) internal {
-        uint256 feeMultiplier = (crossPrice - buyPrice) * uint256(fee) * PRICE_SCALE / (buyPrice * FEE_SCALE);
-        feesAccrued = SafeCast.toUint128(feesAccrued + amountOut * feeMultiplier / PRICE_SCALE);
+    function _accrueSwapFee(BaseAssetConfig storage config, uint256 amountIn, uint256 amountOut) internal {
+        uint256 realizedAssets = _convertToAssets(config, amountIn) * config.crossPrice / PRICE_SCALE;
+        uint256 gain = realizedAssets > amountOut ? realizedAssets - amountOut : 0;
+        feesAccrued = SafeCast.toUint128(feesAccrued + gain * uint256(fee) / FEE_SCALE);
     }
 
     ////////////////////////////////////////////////////

--- a/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
@@ -90,8 +90,7 @@ contract Fork_Concrete_EthenaARM_swapExactTokensForTokens_Test_ is Fork_Shared_T
         // Precompute expected amount out
         uint256 traderate = _buyPrice();
         uint256 expectedAmountOut = (susde.convertToAssets(AMOUNT_IN) * traderate) / 1e36;
-        uint256 expectedFee =
-            expectedAmountOut * _swapFeeMultiplier(_buyPrice(), _crossPrice(), ethenaARM.fee()) / PRICE_SCALE;
+        uint256 expectedFee = _expectedBuySideFee(AMOUNT_IN, expectedAmountOut);
 
         // Expected events
         vm.expectEmit({emitter: address(susde)});
@@ -112,9 +111,7 @@ contract Fork_Concrete_EthenaARM_swapExactTokensForTokens_Test_ is Fork_Shared_T
         assertEq(obtained[1], expectedAmountOut, "Obtained USDe amount should match expected output");
         assertEq(usdeBalanceAfter, usdeBalanceBefore + expectedAmountOut, "USDe balance should have increased");
         assertEq(susdeBalanceBefore, susdeBalanceAfter + AMOUNT_IN, "SUSDe balance should have decreased");
-        assertEq(
-            ethenaARM.feesAccrued() - feesAccruedBefore, expectedFee, "Fees accrued should match output multiplier"
-        );
+        assertEq(ethenaARM.feesAccrued() - feesAccruedBefore, expectedFee, "Fees accrued should match realized gain");
     }
 
     function test_swapExactTokensForTokens_SUSDE_To_USDE_WithOutstandingWithdrawals_Sig1() public {

--- a/test/fork/EthenaARM/shared/Shared.sol
+++ b/test/fork/EthenaARM/shared/Shared.sol
@@ -120,10 +120,10 @@ abstract contract Fork_Shared_Test is Base_Test_ {
         crossPrice = crossPriceMem;
     }
 
-    function _swapFeeMultiplier(uint256 buyPrice, uint256 crossPrice, uint256 fee) internal view returns (uint256) {
-        uint256 priceScale = PRICE_SCALE;
-        if (buyPrice == 0 || fee == 0) return 0;
-        return (crossPrice - buyPrice) * fee * priceScale / (buyPrice * FEE_SCALE);
+    function _expectedBuySideFee(uint256 amountIn, uint256 amountOut) internal view returns (uint256) {
+        uint256 realizedAssets = susde.convertToAssets(amountIn) * _crossPrice() / PRICE_SCALE;
+        uint256 gain = realizedAssets > amountOut ? realizedAssets - amountOut : 0;
+        return gain * ethenaARM.fee() / FEE_SCALE;
     }
 
     function _ignite() internal virtual {

--- a/test/fork/MultiAssetARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/MultiAssetARM/SwapExactTokensForTokens.t.sol
@@ -162,8 +162,7 @@ contract Fork_Concrete_MultiAssetARM_swapExactTokensForTokens_Test_ is Fork_Shar
     function _swapBuy(IERC20 token) internal {
         uint256 buyPrice = _buyPrice(token);
         uint256 expectedAmountOut = _convertToAssets(token, AMOUNT_IN) * buyPrice / PRICE_SCALE;
-        uint256 expectedFee =
-            expectedAmountOut * _swapFeeMultiplier(buyPrice, _crossPrice(token), arm.fee()) / PRICE_SCALE;
+        uint256 expectedFee = _expectedBuySideFee(token, AMOUNT_IN, expectedAmountOut);
 
         uint256 wethBefore = weth.balanceOf(address(this));
         uint256 baseBefore = token.balanceOf(address(this));

--- a/test/fork/MultiAssetARM/SwapTokensForExactTokens.t.sol
+++ b/test/fork/MultiAssetARM/SwapTokensForExactTokens.t.sol
@@ -153,7 +153,7 @@ contract Fork_Concrete_MultiAssetARM_swapTokensForExactTokens_Test_ is Fork_Shar
     function _swapBuyExact(IERC20 token) internal {
         uint256 buyPrice = _buyPrice(token);
         uint256 expectedAmountIn = _convertToShares(token, AMOUNT_OUT) * PRICE_SCALE / buyPrice + 3;
-        uint256 expectedFee = AMOUNT_OUT * _swapFeeMultiplier(buyPrice, _crossPrice(token), arm.fee()) / PRICE_SCALE;
+        uint256 expectedFee = _expectedBuySideFee(token, expectedAmountIn, AMOUNT_OUT);
 
         uint256 wethBefore = weth.balanceOf(address(this));
         uint256 baseBefore = token.balanceOf(address(this));

--- a/test/fork/MultiAssetARM/shared/Shared.sol
+++ b/test/fork/MultiAssetARM/shared/Shared.sol
@@ -313,9 +313,10 @@ abstract contract Fork_Shared_Test is Base_Test_ {
         return _adapter(token).convertToShares(assets);
     }
 
-    function _swapFeeMultiplier(uint256 buyPrice, uint256 crossPrice, uint256 fee) internal pure returns (uint256) {
-        if (buyPrice == 0 || fee == 0) return 0;
-        return (crossPrice - buyPrice) * fee * PRICE_SCALE / (buyPrice * FEE_SCALE);
+    function _expectedBuySideFee(IERC20 token, uint256 amountIn, uint256 amountOut) internal view returns (uint256) {
+        uint256 realizedAssets = _convertToAssets(token, amountIn) * _crossPrice(token) / PRICE_SCALE;
+        uint256 gain = realizedAssets > amountOut ? realizedAssets - amountOut : 0;
+        return gain * arm.fee() / FEE_SCALE;
     }
 
     //////////////////////////////////////////////////////

--- a/test/fork/PaxosARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/PaxosARM/SwapExactTokensForTokens.t.sol
@@ -69,8 +69,7 @@ contract Fork_Concrete_PaxosARM_swapExactTokensForTokens_Test_ is Fork_Shared_Te
     function _swapBuy(IERC20 token) internal {
         uint256 buyPrice = _buyPrice(token);
         uint256 expectedAmountOut = AMOUNT_IN * buyPrice / PRICE_SCALE;
-        uint256 expectedFee =
-            expectedAmountOut * _swapFeeMultiplier(buyPrice, _crossPrice(token), arm.fee()) / PRICE_SCALE;
+        uint256 expectedFee = _expectedBuySideFee(token, AMOUNT_IN, expectedAmountOut);
 
         uint256 usdcBefore = usdc.balanceOf(address(this));
         uint256 baseBefore = token.balanceOf(address(this));

--- a/test/fork/PaxosARM/SwapTokensForExactTokens.t.sol
+++ b/test/fork/PaxosARM/SwapTokensForExactTokens.t.sol
@@ -22,7 +22,7 @@ contract Fork_Concrete_PaxosARM_swapTokensForExactTokens_Test_ is Fork_Shared_Te
     function test_swapTokensForExactTokens_Pyusd_To_Usdc() public {
         uint256 buyPrice = _buyPrice(pyusd);
         uint256 expectedAmountIn = AMOUNT_OUT * PRICE_SCALE / buyPrice + 3;
-        uint256 expectedFee = AMOUNT_OUT * _swapFeeMultiplier(buyPrice, _crossPrice(pyusd), arm.fee()) / PRICE_SCALE;
+        uint256 expectedFee = _expectedBuySideFee(pyusd, expectedAmountIn, AMOUNT_OUT);
 
         uint256 usdcBefore = usdc.balanceOf(address(this));
         uint256 baseBefore = pyusd.balanceOf(address(this));

--- a/test/fork/PaxosARM/shared/Shared.sol
+++ b/test/fork/PaxosARM/shared/Shared.sol
@@ -223,8 +223,9 @@ abstract contract Fork_Shared_Test is Base_Test_ {
         return PaxosAssetAdapter(adapter);
     }
 
-    function _swapFeeMultiplier(uint256 buyPrice, uint256 crossPrice, uint256 fee) internal pure returns (uint256) {
-        if (buyPrice == 0 || fee == 0) return 0;
-        return (crossPrice - buyPrice) * fee * PRICE_SCALE / (buyPrice * FEE_SCALE);
+    function _expectedBuySideFee(IERC20 token, uint256 amountIn, uint256 amountOut) internal view returns (uint256) {
+        uint256 realizedAssets = amountIn * _crossPrice(token) / PRICE_SCALE;
+        uint256 gain = realizedAssets > amountOut ? realizedAssets - amountOut : 0;
+        return gain * arm.fee() / FEE_SCALE;
     }
 }

--- a/test/invariants/EthenaARM/TargetFunctions.sol
+++ b/test/invariants/EthenaARM/TargetFunctions.sol
@@ -22,6 +22,8 @@ import {Math} from "./helpers/Math.sol";
 /// @title TargetFunctions
 /// @notice TargetFunctions contract for tests, containing the target functions that should be tested.
 ///         This is the entry point with the contract we are testing. Ideally, it should never revert.
+/// @dev Target parameters use full ABI words so corpus mutations remain decodable in strict mode. Handlers
+///      derive booleans and bound narrower values internally.
 abstract contract TargetFunctions is Setup, StdUtils {
     // ╔══════════════════════════════════════════════════════════════════════════════╗
     // ║                              ✦✦✦ ETHENA ARM ✦✦✦                              ║
@@ -81,7 +83,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         crossPrice = crossPriceMem;
     }
 
-    function targetARMDeposit(uint88 amount, uint256 randomAddressIndex) external ensureExchangeRateIncrease {
+    function targetARMDeposit(uint256 amount, uint256 randomAddressIndex) external ensureExchangeRateIncrease {
         // Mirror AbstractARM._deposit's Insolvent() guard: when the ARM sits at the asset floor
         // (totalAssets() clamped to MIN_LIQUIDITY == 1e12), deposits revert if any senior liability
         // (accrued fees OR reserved LP withdrawals) is outstanding. Skip those inputs instead of reverting.
@@ -95,7 +97,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         uint256 totalAssets = arm.totalAssets();
         // Min amount to avoid 0 shares minting
         uint256 minAmount = totalAssets / totalSupply + 1;
-        amount = uint88(_bound(amount, minAmount, type(uint88).max));
+        amount = _bound(amount, minAmount, type(uint88).max);
 
         // Mint amount to user
         MockERC20(address(usde)).mint(user, amount);
@@ -116,13 +118,13 @@ abstract contract TargetFunctions is Setup, StdUtils {
         mintedUSDe[user] += amount;
     }
 
-    function targetARMRequestRedeem(uint88 shareAmount, uint248) external ensureExchangeRateIncrease {
+    function targetARMRequestRedeem(uint256 shareAmount, uint256) external ensureExchangeRateIncrease {
         address user;
         uint256 balance;
         (user, balance) = Find.getUserWithARMShares(makers, address(arm));
         if (assume(user != address(0))) return;
         // Bound shareAmount to [1, balance]
-        shareAmount = uint88(_bound(shareAmount, 1, balance));
+        shareAmount = _bound(shareAmount, 1, balance);
 
         // Request redeem as user
         vm.prank(user);
@@ -148,7 +150,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         sumARMUserRequestShares += shareAmount;
     }
 
-    function targetARMClaimRedeem(uint248 randomAddressIndex, uint248 randomArrayIndex)
+    function targetARMClaimRedeem(uint256 randomAddressIndex, uint256 randomArrayIndex)
         external
         ensureExchangeRateIncrease
         ensureTimeIncrease
@@ -168,8 +170,8 @@ abstract contract TargetFunctions is Setup, StdUtils {
             (user, requestId, claimTimestamp) = Find.getUserRequestWithAmount(
                 Find.GetUserRequestWithAmountStruct({
                     arm: address(arm),
-                    randomAddressIndex: randomAddressIndex,
-                    randomArrayIndex: randomArrayIndex,
+                    randomAddressIndex: uint248(randomAddressIndex),
+                    randomArrayIndex: uint248(randomArrayIndex),
                     users: makers,
                     claimable: uint128(claimable),
                     availableLiquidity: uint128(availableLiquidity)
@@ -238,7 +240,8 @@ abstract contract TargetFunctions is Setup, StdUtils {
         }
     }
 
-    function targetARMSetActiveMarket(bool isActive) external ensureExchangeRateIncrease {
+    function targetARMSetActiveMarket(uint256 activeSeed) external ensureExchangeRateIncrease {
+        bool isActive = activeSeed % 2 == 0;
         // If isActive is true it will `setActiveMarket` with MorphoMarket
         // else it will set it to address(0)
         address currentMarket = arm.activeMarket();
@@ -383,10 +386,11 @@ abstract contract TargetFunctions is Setup, StdUtils {
         }
     }
 
-    function targetARMSwapExactTokensForTokens(bool token0ForToken1, uint88 amountIn, uint256 randomAddressIndex)
+    function targetARMSwapExactTokensForTokens(uint256 sideSeed, uint256 amountIn, uint256 randomAddressIndex)
         external
         ensureExchangeRateIncrease
     {
+        bool token0ForToken1 = sideSeed % 2 == 0;
         (IERC20 tokenIn, IERC20 tokenOut) = token0ForToken1
             ? (IERC20(address(usde)), IERC20(address(susde)))
             : (IERC20(address(susde)), IERC20(address(usde)));
@@ -410,7 +414,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         if (assume(maxAmountIn > 0)) return;
 
         // Bound amountIn
-        amountIn = uint88(_bound(amountIn, 1, maxAmountIn));
+        amountIn = _bound(amountIn, 1, Math.min(maxAmountIn, type(uint88).max));
         // Select a random user from makers
         address user = traders[randomAddressIndex % TRADERS_COUNT];
 
@@ -457,10 +461,11 @@ abstract contract TargetFunctions is Setup, StdUtils {
         }
     }
 
-    function targetARMSwapTokensForExactTokens(bool token0ForToken1, uint88 amountOut, uint256 randomAddressIndex)
+    function targetARMSwapTokensForExactTokens(uint256 sideSeed, uint256 amountOut, uint256 randomAddressIndex)
         external
         ensureExchangeRateIncrease
     {
+        bool token0ForToken1 = sideSeed % 2 == 0;
         (IERC20 tokenIn, IERC20 tokenOut) = token0ForToken1
             ? (IERC20(address(usde)), IERC20(address(susde)))
             : (IERC20(address(susde)), IERC20(address(usde)));
@@ -477,7 +482,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         // Ensure there is liquidity available in ARM
         if (assume(maxAmountOut > 1)) return;
 
-        amountOut = uint88(_bound(amountOut, 1, maxAmountOut));
+        amountOut = _bound(amountOut, 1, Math.min(maxAmountOut, type(uint88).max));
 
         // What's the maximum amountIn we can provide to not exceed maxAmountOut?
         uint256 convertedAmountOut;
@@ -573,10 +578,10 @@ abstract contract TargetFunctions is Setup, StdUtils {
         sumUSDeFeesCollected += feesAccrued;
     }
 
-    function targetARMRequestBaseWithdrawal(uint88 amount) external ensureExchangeRateIncrease {
+    function targetARMRequestBaseWithdrawal(uint256 amount) external ensureExchangeRateIncrease {
         uint256 balance = susde.balanceOf(address(arm));
         if (assume(balance > 1)) return;
-        amount = uint88(_bound(amount, 1, balance));
+        amount = _bound(amount, 1, Math.min(balance, type(uint88).max));
 
         // Ensure there is an unstaker available
         uint256 nextIndex = ethenaAssetAdapter.nextUnstakerIndex();
@@ -680,13 +685,13 @@ abstract contract TargetFunctions is Setup, StdUtils {
     // ╔══════════════════════════════════════════════════════════════════════════════╗
     // ║                                ✦✦✦ SUSDE ✦✦✦                                 ║
     // ╚══════════════════════════════════════════════════════════════════════════════╝
-    function targetSUSDeDeposit(uint88 amount) external ensureExchangeRateIncrease {
+    function targetSUSDeDeposit(uint256 amount) external ensureExchangeRateIncrease {
         // Ensure we don't mint 0 shares.
         uint256 totalAssets = susde.totalAssets();
         uint256 totalSupply = susde.totalSupply();
         uint256 minAmount = totalAssets / totalSupply + 1;
         // Prevent zero deposits
-        amount = uint88(_bound(amount, minAmount, type(uint88).max));
+        amount = _bound(amount, minAmount, type(uint88).max);
 
         // Mint amount to grace
         MockERC20(address(usde)).mint(grace, amount);
@@ -702,7 +707,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         }
     }
 
-    function targetSUSDeCooldownShares(uint88 shareAmount) external ensureExchangeRateIncrease {
+    function targetSUSDeCooldownShares(uint256 shareAmount) external ensureExchangeRateIncrease {
         // Cache balance
         uint256 balance = susde.balanceOf(grace);
 
@@ -710,7 +715,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         if (assume(balance > 1)) return;
 
         // Bound shareAmount to [1, balance]
-        shareAmount = uint88(_bound(shareAmount, 1, balance));
+        shareAmount = _bound(shareAmount, 1, balance);
 
         // Cooldown shares as grace
         vm.prank(grace);
@@ -763,7 +768,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         MockERC20(address(usde)).burn(grace, cooldown.underlyingAmount);
     }
 
-    function targetSUSDeTransferInRewards(uint8 bps) external ensureExchangeRateIncrease ensureTimeIncrease {
+    function targetSUSDeTransferInRewards(uint256 bps) external ensureExchangeRateIncrease ensureTimeIncrease {
         // Ensure enough time has passed since last distribution
         uint256 lastDistribution = susde.lastDistributionTimestamp();
         if (block.timestamp < 8 hours + lastDistribution) {
@@ -788,7 +793,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
 
         uint256 balance = usde.balanceOf(address(susde));
         // Rewards can be distributed 3/days max. 1bps at every distribution -> 10 APR.
-        bps = uint8(_bound(bps, 1, 10));
+        bps = _bound(bps, 1, 10);
         uint256 rewards = (balance * bps) / 10_000;
         MockERC20(address(usde)).mint(governor, rewards);
         vm.prank(governor);
@@ -802,13 +807,13 @@ abstract contract TargetFunctions is Setup, StdUtils {
     // ╔══════════════════════════════════════════════════════════════════════════════╗
     // ║                                ✦✦✦ MORPHO ✦✦✦                                ║
     // ╚══════════════════════════════════════════════════════════════════════════════╝
-    function targetMorphoDeposit(uint88 amount) external ensureExchangeRateIncrease {
+    function targetMorphoDeposit(uint256 amount) external ensureExchangeRateIncrease {
         // Ensure we don't mint 0 shares.
         uint256 totalAssets = morpho.totalAssets();
         uint256 totalSupply = morpho.totalSupply();
         uint256 minAmount = totalAssets / totalSupply + 1;
         // Prevent zero deposits
-        amount = uint88(_bound(amount, minAmount, type(uint88).max));
+        amount = _bound(amount, minAmount, type(uint88).max);
 
         // Mint amount to harry
         MockERC20(address(usde)).mint(harry, amount);
@@ -824,7 +829,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         }
     }
 
-    function targetMorphoWithdraw(uint88 amount) external ensureExchangeRateIncrease {
+    function targetMorphoWithdraw(uint256 amount) external ensureExchangeRateIncrease {
         // Check harry's balance
         uint256 balance = morpho.balanceOf(harry);
 
@@ -832,7 +837,7 @@ abstract contract TargetFunctions is Setup, StdUtils {
         if (assume(balance > 1)) return;
 
         // Bound shareAmount to [1, balance]
-        amount = uint88(_bound(amount, 1, balance));
+        amount = _bound(amount, 1, balance);
 
         // Ensure there is enough liquidity to withdraw the amount
         uint256 maxWithdrawable = morpho.maxWithdraw(harry);
@@ -850,9 +855,9 @@ abstract contract TargetFunctions is Setup, StdUtils {
         MockERC20(address(usde)).burn(harry, amount);
     }
 
-    function targetMorphoTransferInRewards(uint8 bps) external ensureExchangeRateIncrease {
+    function targetMorphoTransferInRewards(uint256 bps) external ensureExchangeRateIncrease {
         uint256 balance = usde.balanceOf(address(morpho));
-        bps = uint8(_bound(bps, 1, 10));
+        bps = _bound(bps, 1, 10);
         uint256 rewards = (balance * bps) / 10_000;
         MockERC20(address(usde)).mint(address(morpho), rewards);
 

--- a/test/invariants/LidoARM/Properties.t.sol
+++ b/test/invariants/LidoARM/Properties.t.sol
@@ -181,17 +181,9 @@ abstract contract Properties is TargetFunction {
         return lidoARM.feesAccrued() + sum_fees_collected == sum_fees_accrued;
     }
 
-    // 13. Upper bound: fees cannot exceed max spread * max fee on total buy-side volume
+    // 13. Upper bound: fees cannot exceed the maximum 50% fee applied to realized buy-side gains.
     function property_fee_B() public view returns (bool) {
-        // maxSpread = (PRICE_SCALE - MINIMUM_BUY_PRICE) / MINIMUM_BUY_PRICE
-        // maxFee = FEE_SCALE / 2
-        // round up: conservative upper bound
-        uint256 maxFees = Math.mulDiv(
-            sum_weth_buyside_out,
-            (PRICE_SCALE - MINIMUM_BUY_PRICE) * (FEE_SCALE / 2),
-            MINIMUM_BUY_PRICE * FEE_SCALE,
-            Math.Rounding.Ceil
-        );
+        uint256 maxFees = sum_buyside_realized_gain * (FEE_SCALE / 2) / FEE_SCALE;
         return lidoARM.feesAccrued() + sum_fees_collected <= maxFees;
     }
 

--- a/test/invariants/LidoARM/TargetFunction.t.sol
+++ b/test/invariants/LidoARM/TargetFunction.t.sol
@@ -15,6 +15,8 @@ import {Invariant_LidoARM_Setup_Test} from "./base/Setup.t.sol";
 /// @title TargetFunctions
 /// @notice TargetFunctions contract for tests, containing the target functions that should be tested.
 ///         This is the entry point with the contract we are testing. Ideally, it should never revert.
+/// @dev Target parameters use full ABI words so corpus mutations remain decodable in strict mode. Handlers
+///      derive booleans and bound narrower production values internally.
 abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     // ╔══════════════════════════════════════════════════════════════════════════════╗
     // ║                              ✦✦✦ LIDO ARM ✦✦✦                               ║
@@ -55,10 +57,12 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- SWAPS
     ////////////////////////////////////////////////////
-    function targetSwapExactTokensForTokens(uint88 amount, bool stETHOrWstETH, bool buyOrSell)
+    function targetSwapExactTokensForTokens(uint256 amount, uint256 baseAssetSeed, uint256 sideSeed)
         public
         ensureSharePriceNotDecreased
     {
+        bool stETHOrWstETH = baseAssetSeed % 2 == 0;
+        bool buyOrSell = sideSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
         // buyOrSell: true = ARM buys base asset (trader sends base, gets WETH)
         //            false = ARM sells base asset (trader sends WETH, gets base)
@@ -104,6 +108,10 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
             amountIn = stETHOrWstETH ? sharesNeeded : mockWstETH.getStETHByWstETH(sharesNeeded);
         }
 
+        // Reverse conversion can round a dust wstETH input down to zero. The wstETH mint helper
+        // rejects zero-share mints, and a zero-input swap does not exercise meaningful behavior.
+        vm.assume(amountIn > 0);
+
         // 3. Deal tokenIn to swapper and execute
         if (tokenIn == address(wsteth)) {
             dealWsteth(grace, amountIn);
@@ -126,10 +134,12 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetSwapTokensForExactTokens(uint88 amount, bool stETHOrWstETH, bool buyOrSell)
+    function targetSwapTokensForExactTokens(uint256 amount, uint256 baseAssetSeed, uint256 sideSeed)
         public
         ensureSharePriceNotDecreased
     {
+        bool stETHOrWstETH = baseAssetSeed % 2 == 0;
+        bool buyOrSell = sideSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
         // buyOrSell: true = ARM buys base asset (trader sends base, gets WETH)
         //            false = ARM sells base asset (trader sends WETH, gets base)
@@ -194,7 +204,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- LIQUIDITY PROVIDERS
     ////////////////////////////////////////////////////
-    function targetDeposit(uint128 amount, uint16 from) public ensureSharePriceNotDecreased {
+    function targetDeposit(uint256 amount, uint256 from) public ensureSharePriceNotDecreased {
         (address user, uint256 balance) = selectUserWithLiqudity(from);
         vm.assume(user != address(0)); // Ensure we found a user with liquidity
 
@@ -206,7 +216,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         );
 
         // Bound amount
-        uint256 boundedAmount = _bound(amount, MINIMUM_DEPOSIT, uint128(balance));
+        uint256 boundedAmount = _bound(amount, MINIMUM_DEPOSIT, balance);
         vm.prank(user);
         lidoARM.deposit(boundedAmount);
         sum_weth_deposit += boundedAmount;
@@ -219,14 +229,14 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetRequestRedeem(uint128 shares, uint16 from) public ensureSharePriceNotDecreased {
+    function targetRequestRedeem(uint256 shares, uint256 from) public ensureSharePriceNotDecreased {
         (address user, uint256 balance) = selectUserWithShares(from);
         vm.assume(user != address(0)); // Ensure we found a user with shares to redeem
 
         // Bound shares
-        uint256 boundedShares = _bound(shares, MIN_SHARES_TO_REQUEST, uint128(balance));
+        uint256 boundedShares = _bound(shares, MIN_SHARES_TO_REQUEST, balance);
         vm.prank(user);
-        (uint256 requestId, uint256 requestAssets) = lidoARM.requestRedeem(boundedShares);
+        (uint256 requestId,) = lidoARM.requestRedeem(boundedShares);
         ghost_requestCounter++;
         sum_shares_requested += boundedShares;
 
@@ -239,7 +249,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         shuffle(_pendingRequestIds, from); // Shuffle pending request IDs to ensure randomness in claim
     }
 
-    function targetClaimRedeem(uint16 seed) public ensureSharePriceNotDecreased {
+    function targetClaimRedeem(uint256 seed) public ensureSharePriceNotDecreased {
         (address user, uint256 requestId, uint256 positionInList) = selectUserWithPendingRequest();
         vm.assume(user != address(0));
 
@@ -266,7 +276,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetTransferShares(uint128 amount, uint16 from, uint16 to) public ensureSharePriceNotDecreased {
+    function targetTransferShares(uint256 amount, uint256 from, uint256 to) public ensureSharePriceNotDecreased {
         (address source, uint256 balance) = selectUserWithShares(from);
         vm.assume(source != address(0));
 
@@ -287,7 +297,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetDonate(uint88 amount, uint8 tokenSeed) public ensureSharePriceNotDecreased {
+    function targetDonate(uint256 amount, uint256 tokenSeed) public ensureSharePriceNotDecreased {
         address donor = address(0xd074);
         uint256 boundedAmount = _bound(amount, 1, 1 ether);
 
@@ -320,7 +330,8 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- BASE ASSET REDEMPTIONS
     ////////////////////////////////////////////////////
-    function targetRequestBaseWithdrawal(uint128 amount, bool stETHOrWstETH) public ensureSharePriceNotDecreased {
+    function targetRequestBaseWithdrawal(uint256 amount, uint256 baseAssetSeed) public ensureSharePriceNotDecreased {
+        bool stETHOrWstETH = baseAssetSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
         uint256 bal = IERC20(baseAsset).balanceOf(address(lidoARM));
         vm.assume(bal > 0);
@@ -328,7 +339,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         uint256 boundedAmount = _bound(amount, 1, bal);
 
         vm.prank(operator);
-        (uint256 sharesRequested, uint256 assetsExpected) = lidoARM.requestBaseAssetRedeem(baseAsset, boundedAmount);
+        (uint256 sharesRequested,) = lidoARM.requestBaseAssetRedeem(baseAsset, boundedAmount);
 
         // Ghost: track base asset outflows
         if (stETHOrWstETH) sum_steth_baseRedeemRequested += boundedAmount;
@@ -347,7 +358,8 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetClaimBaseWithdrawals(uint8 count, bool stETHOrWstETH) public ensureSharePriceNotDecreased {
+    function targetClaimBaseWithdrawals(uint256 count, uint256 baseAssetSeed) public ensureSharePriceNotDecreased {
+        bool stETHOrWstETH = baseAssetSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
         uint256[] storage queue = stETHOrWstETH ? _pendingBaseRedeemShares_stETH : _pendingBaseRedeemShares_wstETH;
         vm.assume(queue.length > 0);
@@ -383,14 +395,14 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- LIQUIDITY MANAGMENT
     ////////////////////////////////////////////////////
-    function targetSetActiveMarket(uint16 seed) public ensureSharePriceNotDecreased {
+    function targetSetActiveMarket(uint256 seed) public ensureSharePriceNotDecreased {
         address current = lidoARM.activeMarket();
         address[3] memory candidates = [address(0), address(mockERC4626Market_A), address(mockERC4626Market_B)];
 
         // Pick among the 2 candidates that differ from current
-        uint256 s = seed;
-        address picked = candidates[s % 3];
-        if (picked == current) picked = candidates[(s + 1) % 3];
+        uint256 candidateIndex = seed % 3;
+        address picked = candidates[candidateIndex];
+        if (picked == current) picked = candidates[(candidateIndex + 1) % 3];
 
         // Switching away from a market redeems ALL shares via balanceOf. Skip the call if that full
         // redeem would revert: either the market can't cover it (maxRedeem < balanceOf), or the shares
@@ -424,7 +436,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetSetARMBuffer(uint16 seed) public ensureSharePriceNotDecreased {
+    function targetSetARMBuffer(uint256 seed) public ensureSharePriceNotDecreased {
         uint256 picked = uint256(keccak256(abi.encodePacked(seed))) % (1e18 + 1);
         uint256 bps = picked / 0.0001e18;
 
@@ -439,7 +451,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- LIDO (external protocol simulation)
     ////////////////////////////////////////////////////
-    function targetRebase(uint16 seed) public ensureSharePriceNotDecreased {
+    function targetRebase(uint256 seed) public ensureSharePriceNotDecreased {
         // Simulate stETH rebase by minting proportional stETH to all holders.
         // Max 10% APR → max ~0.027% per day → 27 bps per call.
         uint256 rebaseBps = uint256(keccak256(abi.encodePacked(seed))) % 28;
@@ -461,7 +473,8 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- ERC4626 MARKETS (external protocol simulation)
     ////////////////////////////////////////////////////
-    function targetSetUtilizationRate(uint8 seed, bool marketA) public ensureSharePriceNotDecreased {
+    function targetSetUtilizationRate(uint256 seed, uint256 marketSeed) public ensureSharePriceNotDecreased {
+        bool marketA = marketSeed % 2 == 0;
         MockMorpho market = marketA ? mockERC4626Market_A : mockERC4626Market_B;
 
         // Hash the seed to get uniform distribution across the range, avoiding _bound's edge bias
@@ -477,7 +490,8 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetMarketDeposit(uint128 amount, bool marketA) public ensureSharePriceNotDecreased {
+    function targetMarketDeposit(uint256 amount, uint256 marketSeed) public ensureSharePriceNotDecreased {
+        bool marketA = marketSeed % 2 == 0;
         MockMorpho market = marketA ? mockERC4626Market_A : mockERC4626Market_B;
         uint256 bal = weth.balanceOf(hanna);
         vm.assume(bal > 0);
@@ -495,7 +509,8 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetMarketWithdraw(uint128 amount, bool marketA) public ensureSharePriceNotDecreased {
+    function targetMarketWithdraw(uint256 amount, uint256 marketSeed) public ensureSharePriceNotDecreased {
+        bool marketA = marketSeed % 2 == 0;
         MockMorpho market = marketA ? mockERC4626Market_A : mockERC4626Market_B;
         uint256 maxW = market.maxWithdraw(hanna);
         vm.assume(maxW > 0);
@@ -510,7 +525,8 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetMarketTransferRewards(uint16 seed, bool marketA) public ensureSharePriceNotDecreased {
+    function targetMarketTransferRewards(uint256 seed, uint256 marketSeed) public ensureSharePriceNotDecreased {
+        bool marketA = marketSeed % 2 == 0;
         MockMorpho market = marketA ? mockERC4626Market_A : mockERC4626Market_B;
         uint256 totalAssets = market.totalAssets();
         vm.assume(totalAssets > 0);
@@ -540,10 +556,14 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- PRICES AND FEES MANAGEMENT
     ////////////////////////////////////////////////////
-    function targetSetPrices(bool stETHOrWstETH, uint16 buySeed, uint16 sellSeed, uint128 buyAmount, uint128 sellAmount)
-        public
-        ensureSharePriceNotDecreased
-    {
+    function targetSetPrices(
+        uint256 baseAssetSeed,
+        uint256 buySeed,
+        uint256 sellSeed,
+        uint256 buyAmount,
+        uint256 sellAmount
+    ) public ensureSharePriceNotDecreased {
+        bool stETHOrWstETH = baseAssetSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
         (,,,, uint128 crossPrice,,,,) = lidoARM.baseAssetConfigs(baseAsset);
 
@@ -553,9 +573,11 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         uint256 sellRange = MINUMUM_SELL_PRICE - crossPrice;
         uint256 buyPrice = MINIMUM_BUY_PRICE + uint256(keccak256(abi.encodePacked(buySeed))) % (buyRange + 1);
         uint256 sellPrice = crossPrice + uint256(keccak256(abi.encodePacked(sellSeed))) % (sellRange + 1);
+        uint256 boundedBuyAmount = _bound(buyAmount, 0, type(uint128).max);
+        uint256 boundedSellAmount = _bound(sellAmount, 0, type(uint128).max);
 
         vm.prank(operator);
-        lidoARM.setPrices(baseAsset, buyPrice, sellPrice, buyAmount, sellAmount);
+        lidoARM.setPrices(baseAsset, buyPrice, sellPrice, boundedBuyAmount, boundedSellAmount);
 
         if (consoleLogs) {
             string memory asset = stETHOrWstETH ? "stETH" : "wstETH";
@@ -564,7 +586,8 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetSetCrossPrice(bool stETHOrWstETH, uint16 seed) public updateSharePrice {
+    function targetSetCrossPrice(uint256 baseAssetSeed, uint256 seed) public updateSharePrice {
+        bool stETHOrWstETH = baseAssetSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
         (uint128 buyPrice, uint128 sellPrice,,, uint128 currentCross,,,,) = lidoARM.baseAssetConfigs(baseAsset);
 
@@ -611,7 +634,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetSetFee(uint16 seed) public ensureSharePriceNotDecreased {
+    function targetSetFee(uint256 seed) public ensureSharePriceNotDecreased {
         // Fee in [0, FEE_SCALE / 2] (0% to 50%)
         uint256 newFee = uint256(keccak256(abi.encodePacked(seed))) % (FEE_SCALE / 2 + 1);
 

--- a/test/invariants/LidoARM/TargetFunction.t.sol
+++ b/test/invariants/LidoARM/TargetFunction.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.23;
 
 import {console} from "forge-std/console.sol";
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {MockERC20} from "@solmate/test/utils/mocks/MockERC20.sol";
 import {MockMorpho} from "./mocks/MockMorpho.sol";
 
@@ -647,13 +646,14 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
             sum_weth_swapOut += amtOut;
             sum_weth_buyside_out += amtOut;
 
-            // Track fee accrued: mirrors _accrueSwapFee in AbstractARM
-            (uint128 buyPrice,,,, uint128 crossPrice,,,,) = lidoARM.baseAssetConfigs(baseAsset);
-            // round down: same as contract
-            uint256 feeMultiplier = Math.mulDiv(
-                (crossPrice - buyPrice) * uint256(lidoARM.fee()), PRICE_SCALE, uint256(buyPrice) * FEE_SCALE
-            );
-            sum_fees_accrued += Math.mulDiv(amtOut, feeMultiplier, PRICE_SCALE);
+            // Track the realized buy-side gain and fee using the same conversion and rounding as AbstractARM.
+            (,,,, uint128 crossPrice,, bool peggedToLiquidityAsset,, address adapter) =
+                lidoARM.baseAssetConfigs(baseAsset);
+            uint256 convertedAmountIn = peggedToLiquidityAsset ? amtIn : IAssetAdapter(adapter).convertToAssets(amtIn);
+            uint256 realizedAssets = convertedAmountIn * crossPrice / PRICE_SCALE;
+            uint256 gain = realizedAssets > amtOut ? realizedAssets - amtOut : 0;
+            sum_buyside_realized_gain += gain;
+            sum_fees_accrued += gain * uint256(lidoARM.fee()) / FEE_SCALE;
         } else {
             // ARM sells base (trader sends WETH, gets base)
             sum_weth_swapIn += amtIn;

--- a/test/invariants/LidoARM/base/Base.t.sol
+++ b/test/invariants/LidoARM/base/Base.t.sol
@@ -123,6 +123,7 @@ abstract contract Base_Test_ is Test {
     uint256 internal sum_fees_accrued;
     uint256 internal sum_fees_collected;
     uint256 internal sum_weth_buyside_out;
+    uint256 internal sum_buyside_realized_gain;
 
     // Market yield accrued to ARM
     uint256 internal sum_weth_marketYield;

--- a/test/invariants/LidoARM/helpers/Helpers.t.sol
+++ b/test/invariants/LidoARM/helpers/Helpers.t.sol
@@ -59,9 +59,10 @@ abstract contract Helpers is Base_Test_ {
     /// @notice Pick the first LP (round-robin from `seed`) that holds WETH.
     /// @return user  Address of the selected LP, or address(0) if none found.
     /// @return balance  WETH balance of the selected LP.
-    function selectUserWithLiqudity(uint16 seed) internal view returns (address, uint256) {
+    function selectUserWithLiqudity(uint256 seed) internal view returns (address, uint256) {
+        uint256 start = seed % LP_COUNT;
         for (uint256 i; i < LP_COUNT; i++) {
-            address user = lps[(seed + i) % LP_COUNT];
+            address user = lps[(start + i) % LP_COUNT];
             if (weth.balanceOf(user) > 0) {
                 return (user, weth.balanceOf(user));
             }
@@ -72,9 +73,10 @@ abstract contract Helpers is Base_Test_ {
     /// @notice Pick the first LP (round-robin from `seed`) that holds ARM shares.
     /// @return user  Address of the selected LP, or address(0) if none found.
     /// @return balance  ARM share balance of the selected LP.
-    function selectUserWithShares(uint16 seed) internal view returns (address, uint256) {
+    function selectUserWithShares(uint256 seed) internal view returns (address, uint256) {
+        uint256 start = seed % LP_COUNT;
         for (uint256 i; i < LP_COUNT; i++) {
-            address user = lps[(seed + i) % LP_COUNT];
+            address user = lps[(start + i) % LP_COUNT];
             if (lidoARM.balanceOf(user) > 0) {
                 return (user, lidoARM.balanceOf(user));
             }

--- a/test/unit/MultiAssetARM/Shared.t.sol
+++ b/test/unit/MultiAssetARM/Shared.t.sol
@@ -277,16 +277,4 @@ abstract contract Unit_MultiAssetARM_Shared_Test is Base_MultiAssetARM_Test {
     function adapterOf(IERC20 token) internal view returns (address v) {
         (,,,,,,,, v) = arm.baseAssetConfigs(address(token));
     }
-
-    //////////////////////////////////////////////////////
-    /// --- FEE HELPER
-    //////////////////////////////////////////////////////
-    function expectedBuySideFee(IERC20 token, uint256 amountOut) internal view returns (uint256) {
-        uint256 assetBuyPrice = buyPrice(token);
-        uint256 assetCrossPrice = crossPrice(token);
-        uint256 feeMultiplier = assetBuyPrice == 0
-            ? 0
-            : (assetCrossPrice - assetBuyPrice) * uint256(arm.fee()) * PRICE_SCALE / (assetBuyPrice * FEE_SCALE);
-        return amountOut * feeMultiplier / PRICE_SCALE;
-    }
 }

--- a/test/unit/MultiAssetARM/concrete/SwapTokensForExactTokens.t.sol
+++ b/test/unit/MultiAssetARM/concrete/SwapTokensForExactTokens.t.sol
@@ -84,6 +84,26 @@ contract SwapTokensForExactTokens_18dec_Test is SwapTokensForExactTokens_Test {
     function liquidityDecimals() internal pure override returns (uint8) {
         return 18;
     }
+
+    function test_BuyExactOut_Peg6_SubBaseUnit_AccruesFeeOnRealizedGain() public {
+        uint256 deepBuyPrice = MAX_CROSS_PRICE_DEVIATION; // 0.002e36 = 0.2% of the cross price.
+        vm.prank(governor);
+        arm.setPrices(address(peg6), deepBuyPrice, SELL_PRICE, type(uint128).max, type(uint128).max);
+
+        uint256 amountOut = 1e12 - 1; // Just below one 6-decimal base unit after scaling by 1e12.
+        dealLiquidityToARM(1 ether);
+        dealBaseToUser(peg6, alice, 1e6);
+
+        vm.prank(alice);
+        uint256[] memory amounts = arm.swapTokensForExactTokens(peg6, liquidity, amountOut, type(uint256).max, alice);
+
+        uint256 realizedAssets = _scaleBaseToLiquidity(peg6, amounts[0]) * CROSS_PRICE / PRICE_SCALE;
+        uint256 expectedGain = realizedAssets - amountOut;
+        uint256 expectedFee = expectedGain * DEFAULT_FEE / FEE_SCALE;
+
+        assertEq(amounts[0], 3, "input is only the rounding buffer");
+        assertEq(arm.feesAccrued(), expectedFee, "fee uses the realized gain");
+    }
 }
 
 contract SwapTokensForExactTokens_6dec_Test is SwapTokensForExactTokens_Test {

--- a/test/unit/MultiAssetARM/fuzz/Swap.fuzz.t.sol
+++ b/test/unit/MultiAssetARM/fuzz/Swap.fuzz.t.sol
@@ -139,12 +139,10 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
         // Valid buyPrice range from AbstractARM._validatePrices:
         // buyPrice >= MAX_CROSS_PRICE_DEVIATION (20e32) and buyPrice < crossPrice (1e36 here).
         // Reuse the existing sellPrice from setUp() — _validatePrices also requires sellPrice >= crossPrice.
-        uint256 spread;
         uint256 buyPriceFuzzed;
         {
             uint256 crossPriceCurrent = crossPrice(peg18);
             buyPriceFuzzed = _bound(uint256(fuzzedBuyPrice), MAX_CROSS_PRICE_DEVIATION, crossPriceCurrent - 1);
-            spread = crossPriceCurrent - buyPriceFuzzed;
 
             // Resolve every setPrices arg before the prank so no view-call between them consumes it.
             uint128 sellPriceArg = uint128(sellPrice(peg18));
@@ -153,17 +151,10 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
         }
 
         // Expected output uses the same scaling as the contract because there is no algebraic
-        // shortcut once buyPrice is arbitrary. The value of the test sits in the fee formula below.
+        // shortcut once buyPrice is arbitrary.
         uint256 expectedAmountOut = amountIn * buyPriceFuzzed / PRICE_SCALE;
         uint256 expectedTotalAssetsIncrease = amountIn - expectedAmountOut;
-
-        // Fee derivation takes a different multiply/divide order than the contract:
-        //   contract:  fee = amountOut * floor((cross - buy) * feeRate * PRICE_SCALE / (buy * FEE_SCALE)) / PRICE_SCALE
-        //   test:      fee = floor(amountOut * (cross - buy) / buy) * feeRate / FEE_SCALE
-        // Both converge on the same mathematical value, so a bug that mangles the multiplier
-        // scaling, swaps numerator/denominator, or applies the fee on the wrong side of the spread
-        // will diverge here.
-        uint256 expectedFee = expectedAmountOut.mulDiv(spread, buyPriceFuzzed) * DEFAULT_FEE / FEE_SCALE;
+        uint256 expectedFee = expectedTotalAssetsIncrease * DEFAULT_FEE / FEE_SCALE;
 
         // Property guard: buyPrice < crossPrice guarantees amountOut < amountIn (trader pays the spread).
         assertLt(expectedAmountOut, amountIn);
@@ -183,10 +174,7 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
         uint256[] memory amounts = arm.swapExactTokensForTokens(peg18, liquidity, amountIn, expectedAmountOut, alice);
 
         // Then
-        // Tolerance of 2 wei: the two formulas above each truncate at one step, so they can disagree
-        // by up to 1 wei from rounding, plus the contract's PRICE_SCALE intermediate truncation can
-        // shift the result by another wei at extreme prices.
-        assertApproxEqAbs(arm.feesAccrued(), expectedFee, 2);
+        assertEq(arm.feesAccrued(), expectedFee);
         assertEq(buyLiquidityRemaining(peg18), buyLiquidityBefore - expectedAmountOut);
         assertEq(sellLiquidityRemaining(peg18), sellLiquidityBefore);
         assertEq(liquidity.balanceOf(alice), expectedAmountOut);
@@ -201,7 +189,7 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
         // fee = gain * feeRate / FEE_SCALE algebraically, so with feeRate = 20% < 100% the gain
         // always exceeds the fee and totalAssets must strictly increase.
         assertGt(arm.totalAssets(), totalAssetsBefore);
-        assertApproxEqAbs(arm.totalAssets(), totalAssetsBefore + expectedTotalAssetsIncrease - expectedFee, 2);
+        assertEq(arm.totalAssets(), totalAssetsBefore + expectedTotalAssetsIncrease - expectedFee);
     }
 
     function testFuzz_SwapExactTokensForTokens_Weth_To_Steth_Amount(uint128 liquidityAmount) public {
@@ -401,12 +389,10 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
 
         // Valid buyPrice range from AbstractARM._validatePrices:
         // buyPrice >= MAX_CROSS_PRICE_DEVIATION (20e32) and buyPrice < crossPrice (1e36 here).
-        uint256 spread;
         uint256 buyPriceFuzzed;
         {
             uint256 crossPriceCurrent = crossPrice(peg18);
             buyPriceFuzzed = _bound(uint256(fuzzedBuyPrice), MAX_CROSS_PRICE_DEVIATION, crossPriceCurrent - 1);
-            spread = crossPriceCurrent - buyPriceFuzzed;
 
             // Resolve every setPrices arg before the prank so no view-call between them consumes it.
             uint128 sellPriceArg = uint128(sellPrice(peg18));
@@ -415,17 +401,10 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
         }
 
         // expectedAmountIn uses the same scaling as the contract because there is no algebraic
-        // shortcut once buyPrice is arbitrary. The value of the test sits in the fee formula below.
+        // shortcut once buyPrice is arbitrary.
         uint256 expectedAmountIn = amountOut.mulDiv(PRICE_SCALE, buyPriceFuzzed) + ROUNDING_BUFFER;
         uint256 expectedTotalAssetsIncrease = expectedAmountIn - amountOut;
-
-        // Fee derivation takes a different multiply/divide order than the contract:
-        //   contract:  fee = amountOut * floor((cross - buy) * feeRate * PRICE_SCALE / (buy * FEE_SCALE)) / PRICE_SCALE
-        //   test:      fee = floor(amountOut * (cross - buy) / buy) * feeRate / FEE_SCALE
-        // Both converge on the same mathematical value, so a bug that mangles the multiplier
-        // scaling, swaps numerator/denominator, or applies the fee on the wrong side of the spread
-        // will diverge here.
-        uint256 expectedFee = amountOut.mulDiv(spread, buyPriceFuzzed) * DEFAULT_FEE / FEE_SCALE;
+        uint256 expectedFee = expectedTotalAssetsIncrease * DEFAULT_FEE / FEE_SCALE;
 
         // Property guard: buyPrice < crossPrice guarantees amountIn > amountOut (trader pays the spread).
         assertGt(expectedAmountIn, amountOut);
@@ -447,10 +426,7 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
         uint256[] memory amounts = arm.swapTokensForExactTokens(peg18, liquidity, amountOut, expectedAmountIn, alice);
 
         // Then
-        // Tolerance of 2 wei: each formula truncates at a different step, so they can disagree by
-        // up to 1 wei from rounding, plus the contract's PRICE_SCALE intermediate truncation can
-        // shift the result by another wei at extreme prices.
-        assertApproxEqAbs(arm.feesAccrued(), expectedFee, 2);
+        assertEq(arm.feesAccrued(), expectedFee);
         assertEq(buyLiquidityRemaining(peg18), buyLiquidityBefore - amountOut);
         assertEq(sellLiquidityRemaining(peg18), sellLiquidityBefore);
         assertEq(liquidity.balanceOf(alice), amountOut);
@@ -465,7 +441,7 @@ contract Unit_Fuzz_MultiAssetARM_Swap_Test is Unit_MultiAssetARM_Shared_Test {
         // fee = gain * feeRate / FEE_SCALE algebraically, so with feeRate = 20% < 100% the gain
         // always exceeds the fee and totalAssets must strictly increase.
         assertGt(arm.totalAssets(), totalAssetsBefore);
-        assertApproxEqAbs(arm.totalAssets(), totalAssetsBefore + expectedTotalAssetsIncrease - expectedFee, 2);
+        assertEq(arm.totalAssets(), totalAssetsBefore + expectedTotalAssetsIncrease - expectedFee);
     }
 
     function testFuzz_SwapTokensForExactTokens_Weth_To_Steth_Amount(uint128 peg18Amount) public {

--- a/test/unit/adapters/shared/Shared.t.sol
+++ b/test/unit/adapters/shared/Shared.t.sol
@@ -271,16 +271,6 @@ abstract contract Unit_Lido_Shared_Test is Base_Lido_Test {
         return _pendingRedeemAssets;
     }
 
-    function expectedBuySideFee(IERC20 token, uint256 amountOut) internal view returns (uint256) {
-        uint256 assetBuyPrice = buyPrice(token);
-        uint256 assetCrossPrice = crossPrice(token);
-        uint256 feeMultiplier = assetBuyPrice == 0
-            ? 0
-            : (assetCrossPrice - assetBuyPrice) * uint256(arm.fee()) * PRICE_SCALE / (assetBuyPrice * FEE_SCALE);
-
-        return amountOut * feeMultiplier / PRICE_SCALE;
-    }
-
     function seedWstETHWithTargetExchangeRate() internal {
         uint256 initialStETH = 100 ether;
         uint256 accruedStETHRewards = 23.7 ether;


### PR DESCRIPTION
## Summary

- accrue buy-side performance fees from the value of the actual settled input rather than the quoted notional spread
- pass amountIn through swap liquidity validation so exact-input and exact-output swaps use the same realized-gain basis
- update fork, fuzz, and invariant fee expectations and add a regression test for 18-to-6 decimal truncation below one base unit
- harden the Ethena and Lido invariant handlers so corpus mutations remain ABI-decodable in strict mode

## Invariant harness

The invariant handlers accept full-word uint256 inputs and derive booleans or bound narrower values internally. This prevents mutated calldata from reverting in the Solidity ABI dispatcher before handler execution.

## Testing

- Full suite excluding invariants: 531 passed, 0 failed, 3 skipped
- Ethena invariants with FOUNDRY_INVARIANT_FAIL_ON_REVERT=true: 256 runs, 12,800 calls, 0 reverts
- Lido invariants with FOUNDRY_INVARIANT_FAIL_ON_REVERT=true: 256 runs, 12,800 calls, 0 reverts

## Audit report

Related yAudit issue: https://github.com/yAudit/origin-paxos-adapter-review/issues/3