### PR TITLE
[yAudit-01] Derive minimum liquidity from asset decimals

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -243,7 +243,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         liquidityAssetDecimals = decimals_;
         // Native-liquidity floor. 1e12 for an 18-decimal asset keeps existing deployments unchanged;
         // 1 for a 6-decimal asset is the same 1e-6-token magnitude.
-        MIN_LIQUIDITY = decimals_ == 18 ? 1e12 : 1;
+        MIN_LIQUIDITY = 10 ** (decimals_ - 6);
         claimDelay = _claimDelay;
         minSharesToRedeem = _minSharesToRedeem;
         allocateThreshold = _allocateThreshold;


### PR DESCRIPTION
## Summary

- derive MIN_LIQUIDITY with exponentiation from the validated liquidity asset decimals
- preserve the existing values of 1 for 6-decimal assets and 1e12 for 18-decimal assets

## Testing

- forge test --no-match-path test/invariants/**
- 530 passed, 0 failed, 3 skipped

## Audit report

Related yAudit issue: https://github.com/yAudit/origin-paxos-adapter-review/issues/1