### PR TITLE
[yAudit-02] Allow deposits at exact solvency

### DIFF
--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -786,7 +786,7 @@ abstract contract AbstractARM is OwnableOperable, ERC20Upgradeable, ReentrancyGu
         // Treat accrued fees as a senior liability. If gross assets no longer cover
         // accrued fees plus the minimum native-liquidity floor, new deposits would be
         // minted against the floor and backfill the shortfall, so block deposits.
-        bool atAssetFloor = feesAccruedMem + MIN_LIQUIDITY >= grossAssets;
+        bool atAssetFloor = feesAccruedMem + MIN_LIQUIDITY > grossAssets;
         if (atAssetFloor && (feesAccruedMem != 0 || reservedWithdrawLiquidity != 0)) revert Insolvent();
 
         uint256 netAssets = atAssetFloor ? MIN_LIQUIDITY : grossAssets - feesAccruedMem;

--- a/test/unit/MultiAssetARM/concrete/Deposit.t.sol
+++ b/test/unit/MultiAssetARM/concrete/Deposit.t.sol
@@ -89,12 +89,30 @@ abstract contract Deposit_Test is Unit_MultiAssetARM_Shared_Test {
         uint256 fees = _generateFees();
         assertEq(arm.reservedWithdrawLiquidity(), 0, "no reserved withdrawals");
 
-        // Simulate a loss that leaves accrued fees undercollateralized at the asset floor.
-        _setArmBalances(fees + MIN_LIQUIDITY(), 0);
+        // Simulate a loss that leaves accrued fees undercollateralized below the asset floor.
+        _setArmBalances(fees + MIN_LIQUIDITY() - 1, 0);
 
         vm.expectRevert(AbstractARM.Insolvent.selector);
         vm.prank(alice);
         arm.deposit(LIQUIDITY_UNIT());
+    }
+
+    function test_Deposit_WhenAccruedFeesExactlyBacked() public {
+        uint256 fees = _generateFees();
+        assertEq(arm.reservedWithdrawLiquidity(), 0, "no reserved withdrawals");
+
+        _setArmBalances(fees + MIN_LIQUIDITY(), 0);
+
+        uint256 amount = LIQUIDITY_UNIT();
+        uint256 expectedShares = amount * arm.totalSupply() / MIN_LIQUIDITY();
+        _mint(liquidity, bobby, amount);
+
+        vm.prank(bobby);
+        uint256 shares = arm.deposit(amount);
+
+        assertEq(shares, expectedShares, "shares returned");
+        assertEq(arm.balanceOf(bobby), expectedShares, "bobby shares");
+        assertEq(arm.totalAssets(), MIN_LIQUIDITY() + amount, "net assets increase by deposit");
     }
 
     function _generateFees() internal returns (uint256 fees) {


### PR DESCRIPTION
## Summary

- treat exact coverage of accrued fees plus `MIN_LIQUIDITY` as solvent
- keep deposits blocked when gross assets are even one unit below the required floor
- add regression coverage for both 6-decimal and 18-decimal configurations

Fixes the finding reported in https://github.com/yAudit/origin-paxos-adapter-review/issues/2

## Testing

- `forge test --match-path 'test/unit/MultiAssetARM/concrete/Deposit.t.sol'` (16 passed)
- `forge test --no-match-path 'test/invariants/**'` (532 passed, 0 failed, 3 skipped)
