### PR TITLE
[yAudit-04] Emit Paxos redemption lifecycle events

### DIFF
--- a/src/contracts/adapters/PaxosAssetAdapter.sol
+++ b/src/contracts/adapters/PaxosAssetAdapter.sol
@@ -35,7 +35,11 @@ contract PaxosAssetAdapter is Initializable, IAssetAdapter, OwnableOperable {
     error DecimalsMismatch(); // 0x5a8dbaed
 
     event PaxosRecipientUpdated(address indexed paxosRecipient);
+    /// @notice Emitted when base assets are queued for redemption, where `100e6` is 100 tokens for 6-decimal assets.
+    event PaxosRedeemRequested(uint256 shares, uint256 assetsExpected);
     event PaxosRedeemSubmitted(bytes32 indexed paxosRedemptionId, uint256 shares, address indexed paxosRecipient);
+    /// @notice Emitted when settled liquidity assets are transferred to the ARM, where `100e6` is 100 USDC.
+    event PaxosRedeemClaimed(uint256 shares, uint256 assetsExpected, uint256 assetsReceived);
     event ExcessLiquidityRecovered(address indexed to, uint256 amount);
 
     modifier onlyARM() {
@@ -132,6 +136,8 @@ contract PaxosAssetAdapter is Initializable, IAssetAdapter, OwnableOperable {
 
         sharesRequested = shares;
         assetsExpected = shares;
+
+        emit PaxosRedeemRequested(sharesRequested, assetsExpected);
     }
 
     /// @notice Claims settled USDC after Paxos Actions complete on-chain settlement to this adapter.
@@ -157,6 +163,8 @@ contract PaxosAssetAdapter is Initializable, IAssetAdapter, OwnableOperable {
         sharesClaimed = shares;
         assetsExpected = shares;
         assetsReceived = shares;
+
+        emit PaxosRedeemClaimed(sharesClaimed, assetsExpected, assetsReceived);
     }
 
     /// @notice Recovers liquidity asset held beyond what `settlingShares` still owes, e.g. donated tokens

--- a/test/unit/adapters/concrete/PaxosAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/PaxosAssetAdapter.t.sol
@@ -32,7 +32,9 @@ contract Unit_PaxosAssetAdapter_Test is Test {
     uint256 internal constant ARM_PYUSD_BALANCE = 5_000e6;
 
     event PaxosRecipientUpdated(address indexed paxosRecipient);
+    event PaxosRedeemRequested(uint256 shares, uint256 assetsExpected);
     event PaxosRedeemSubmitted(bytes32 indexed paxosRedemptionId, uint256 shares, address indexed paxosRecipient);
+    event PaxosRedeemClaimed(uint256 shares, uint256 assetsExpected, uint256 assetsReceived);
     event ExcessLiquidityRecovered(address indexed to, uint256 amount);
 
     function setUp() public {
@@ -217,6 +219,8 @@ contract Unit_PaxosAssetAdapter_Test is Test {
     function test_RequestRedeem_PullsBaseAssetAndTracksPending() public {
         uint256 shares = 500e6;
 
+        vm.expectEmit(false, false, false, true, address(adapter));
+        emit PaxosRedeemRequested(shares, shares);
         vm.prank(arm);
         (uint256 sharesRequested, uint256 assetsExpected) = adapter.requestRedeem(shares);
 
@@ -329,6 +333,8 @@ contract Unit_PaxosAssetAdapter_Test is Test {
         // Simulate Paxos settling USDC 1:1 to the adapter.
         usdc.mint(address(adapter), shares);
 
+        vm.expectEmit(false, false, false, true, address(adapter));
+        emit PaxosRedeemClaimed(shares, shares, shares);
         vm.prank(arm);
         (uint256 sharesClaimed, uint256 assetsExpected, uint256 assetsReceived) = adapter.redeem(shares);
 


### PR DESCRIPTION
## Summary

- emit `PaxosRedeemRequested` when base assets enter the Paxos redemption queue
- emit `PaxosRedeemClaimed` when settled liquidity is transferred back to the ARM
- include requested/claimed shares plus expected and received asset amounts in the lifecycle logs
- add unit assertions for both event emissions

Fixes the finding reported in https://github.com/yAudit/origin-paxos-adapter-review/issues/4

## Testing

- `forge test --match-path 'test/unit/adapters/concrete/PaxosAssetAdapter.t.sol'` (34 passed)
- `forge test --match-path 'test/fork/PaxosARM/**'` (22 passed)
- `forge test --no-match-path 'test/invariants/**'` (530 passed, 0 failed, 3 skipped)
