### PR TITLE
[ARM] Redeploy USDC and WETH ARMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ There are currently five ARM contracts:
 1. [Lido ARM](https://docs.originprotocol.com/automated-redemption-manager-arm/steth-arm) on Ethereum with stETH as the base asset and WETH as the liquidity asset.
 2. [EtherFi ARM](https://docs.originprotocol.com/automated-redemption-manager-arm/eeth-arm) on Ethereum with eETH as the base asset and WETH as the liquidity asset.
 3. [Ethena ARM](https://docs.originprotocol.com/automated-redemption-manager-arm/susde-arm) on Ethereum with sUSDe as the base asset and USDe as the liquidity asset.
-4. USD ARM on Ethereum with PYUSD and USDG as base assets and USDC as the liquidity asset.
+4. USDC ARM on Ethereum with PYUSD and USDG as base assets and USDC as the liquidity asset.
 5. [OS ARM](https://docs.originprotocol.com/os-arm) on Sonic with OS as the base asset and wS as the liquidity asset.
 
 ## Deployed Contracts
@@ -109,9 +109,9 @@ function getReserves() external view returns (uint256 reserve0, uint256 reserve1
 
 /**
  * @notice Get available liquidity and base asset reserves for a supported base asset.
- * @dev Applies to the Ethena and USD ARMs.
+ * @dev Applies to the Ethena and USDC ARMs.
  * For the Ethena ARM, reserveBaseAsset is sUSDe and liquidityAssets are USDe.
- * For the USD ARM, reserveBaseAsset is PYUSD or USDG and liquidityAssets are USDC.
+ * For the USDC ARM, reserveBaseAsset is PYUSD or USDG and liquidityAssets are USDC.
  * Liquidity assets are net of outstanding LP withdrawal claims.
  * @param reserveBaseAsset Supported base asset whose reserve should be returned.
  * @return liquidityAssets Available liquidity assets.

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -43,15 +43,15 @@ Cron times are UTC. Enable state is managed in the database, not here.
 | `allocateEthena`            | `28 * * * *`  | Allocate liquidity for Ethena ARM          |
 | `setPricesEthena`           | `4 * * * *`   | Set prices for Ethena ARM                  |
 
-## USD ARM — mainnet
+## USDC ARM — mainnet
 
-| Action                   | Cron          | Description                                                         |
-| ------------------------ | ------------- | ------------------------------------------------------------------- |
-| `autoRequestUSDWithdraw` | `14 * * * *`  | Request and submit Paxos redemptions of PYUSD/USDG from the USD ARM |
-| `autoClaimUSDWithdraw`   | `44 * * * *`  | Claim USDC settled by Paxos redemptions for the USD ARM             |
-| `collectUSDFees`         | `50 23 * * *` | Collect fees from USD ARM                                           |
-| `allocateUSD`            | `26 * * * *`  | Allocate liquidity for USD ARM                                      |
-| `setPricesUSD`           | `6 * * * *`   | Set prices for USD ARM                                              |
+| Action                   | Cron          | Description                                                          |
+| ------------------------ | ------------- | -------------------------------------------------------------------- |
+| `autoRequestUSDWithdraw` | `14 * * * *`  | Request and submit Paxos redemptions of PYUSD/USDG from the USDC ARM |
+| `autoClaimUSDWithdraw`   | `44 * * * *`  | Claim USDC settled by Paxos redemptions for the USDC ARM             |
+| `collectUSDFees`         | `50 23 * * *` | Collect fees from USDC ARM                                           |
+| `allocateUSD`            | `26 * * * *`  | Allocate liquidity for USDC ARM                                      |
+| `setPricesUSD`           | `6 * * * *`   | Set prices for USDC ARM                                              |
 
 ## Origin ARM — Sonic
 
@@ -80,7 +80,7 @@ command before each run (see notes in `seed_schedules.sql`).
 | `pauseLido`                      | Pause the Lido ARM                                                     |
 | `pauseEtherFi`                   | Pause the EtherFi ARM                                                  |
 | `pauseEthena`                    | Pause the Ethena ARM                                                   |
-| `pauseUSD`                       | Pause the USD ARM                                                      |
+| `pauseUSD`                       | Pause the USDC ARM                                                     |
 | `claimRedeem`                    | Claim matured LP redeem requests on behalf of users (`--arm`, `--ids`) |
 | `setARMBufferAction`             | Set the ARM buffer (`--arm`, `--buffer`)                               |
 | `setLiquidityProviderCapsAction` | Set liquidity-provider caps (`--arm`, `--accounts`, `--cap`)           |

--- a/script/deploy/mainnet/038_DeployWETHARMScript.s.sol
+++ b/script/deploy/mainnet/038_DeployWETHARMScript.s.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {IWETH} from "contracts/Interfaces.sol";
+import {Proxy} from "contracts/Proxy.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+import {MultiAssetARM} from "contracts/MultiAssetARM.sol";
+import {CapManager} from "contracts/CapManager.sol";
+import {StETHAssetAdapter} from "contracts/adapters/StETHAssetAdapter.sol";
+import {WstETHAssetAdapter} from "contracts/adapters/WstETHAssetAdapter.sol";
+import {EtherFiAssetAdapter} from "contracts/adapters/EtherFiAssetAdapter.sol";
+import {WeETHAssetAdapter} from "contracts/adapters/WeETHAssetAdapter.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+
+/// @title Redeploy the WETH ARM
+/// @notice Deploys a single MultiAssetARM with WETH as the liquidity asset and four Lido/EtherFi base
+///         assets: stETH, wstETH, eETH and weETH. Each base asset is wired to its redemption adapter
+///         (Lido or EtherFi withdrawal queue). Ownership of the ARM, its CapManager and every adapter
+///         proxy is handed to the mainnet 2/8 multisig (`MULTISIG_2_OF_8`); the operational role
+///         ("strategist") is the Talos KMS relayer (`ARM_TALOS_RELAYER`).
+/// @dev Recreates the complete stack originally deployed by `036_DeployMultiAssetARMScript` under
+///      WETH-specific ERC-20 metadata and resolver keys. No lending market is wired up here (idle
+///      WETH stays in the ARM until a market is added in a follow-up script).
+contract $038_DeployWETHARMScript is AbstractDeployScript("038_DeployWETHARMScript") {
+    /// @dev Initial price band shared by every base asset, scaled to 1e36. The operator (Talos) tunes
+    ///      these per asset via setPrices() after deployment.
+    /// 0.99996e36 = base asset valued at 0.99996 WETH in totalAssets()
+    uint256 internal constant CROSS_PRICE = 0.99996e36;
+    /// 0.9997e36 = ARM pays 0.9997 WETH per base asset bought from traders (must stay below cross)
+    uint256 internal constant BUY_PRICE = 0.9997e36;
+    /// 1e36 = ARM charges 1 WETH per base asset sold to traders (must stay at/above cross)
+    uint256 internal constant SELL_PRICE = 1e36;
+
+    function _execute() internal override {
+        // 1. Deploy the ARM proxy.
+        Proxy armProxy = new Proxy();
+        _recordDeployment("WETH_ARM", address(armProxy));
+
+        // 2. Deploy the CapManager (proxy + implementation), owned and operated by the 2/8 multisig.
+        Proxy capManProxy = new Proxy();
+        _recordDeployment("WETH_ARM_CAP_MAN", address(capManProxy));
+
+        CapManager capManagerImpl = new CapManager(address(armProxy));
+        _recordDeployment("WETH_ARM_CAP_IMPL", address(capManagerImpl));
+
+        // Initialize the CapManager with the 2/8 multisig as operator; keep the deployer as owner for now.
+        bytes memory capManData = abi.encodeWithSignature("initialize(address)", Mainnet.MULTISIG_2_OF_8);
+        capManProxy.initialize(address(capManagerImpl), deployer, capManData);
+        CapManager capManager = CapManager(address(capManProxy));
+
+        // 3. Set the initial total-assets cap and per-LP caps. Tuned later by the CapManager operator.
+        capManager.setTotalAssetsCap(250 ether);
+        capManager.setAccountCapEnabled(true);
+        address[] memory lpAccounts = new address[](1);
+        lpAccounts[0] = Mainnet.TREASURY_LP;
+        capManager.setLiquidityProviderCaps(lpAccounts, 250 ether);
+
+        // 4. Hand the CapManager to the 2/8 multisig.
+        capManProxy.setOwner(Mainnet.MULTISIG_2_OF_8);
+
+        // 5. Deploy the MultiAssetARM implementation (WETH liquidity asset).
+        MultiAssetARM armImpl = new MultiAssetARM({
+            _liquidityAsset: Mainnet.WETH, _claimDelay: 10 minutes, _minSharesToRedeem: 1e7, _allocateThreshold: 1 ether
+        });
+        _recordDeployment("WETH_ARM_IMPL", address(armImpl));
+
+        // 6. Give the deployer the MIN_LIQUIDITY (1e12 WETH) that initialize() pulls to seed dead shares.
+        IWETH(Mainnet.WETH).deposit{value: 1e12}();
+        IWETH(Mainnet.WETH).approve(address(armProxy), 1e12);
+
+        // 7. Initialize the ARM proxy: deployer stays owner during setup, Talos is the operator.
+        bytes memory armData = abi.encodeWithSignature(
+            "initialize(string,string,address,uint256,address,address)",
+            "WETH ARM", // name
+            "ARM-WETH", // symbol
+            Mainnet.ARM_TALOS_RELAYER, // operator
+            2000, // 20% performance fee
+            Mainnet.BUYBACK_OPERATOR, // fee collector
+            address(capManager)
+        );
+        armProxy.initialize(address(armImpl), deployer, armData);
+        MultiAssetARM arm = MultiAssetARM(payable(address(armProxy)));
+
+        // 8. Deploy the stETH adapter (pegged 1:1) and register stETH.
+        {
+            StETHAssetAdapter adapterImpl =
+                new StETHAssetAdapter(address(armProxy), Mainnet.WETH, Mainnet.STETH, Mainnet.LIDO_WITHDRAWAL);
+            _recordDeployment("WETH_ARM_STETH_ADAPTER_IMPL", address(adapterImpl));
+            Proxy adapterProxy = new Proxy();
+            adapterProxy.initialize(
+                address(adapterImpl), Mainnet.MULTISIG_2_OF_8, abi.encodeWithSignature("initialize()")
+            );
+            _recordDeployment("WETH_ARM_STETH_ADAPTER", address(adapterProxy));
+            arm.addBaseAsset(
+                Mainnet.STETH,
+                address(adapterProxy),
+                BUY_PRICE,
+                SELL_PRICE,
+                type(uint128).max,
+                type(uint128).max,
+                CROSS_PRICE,
+                true
+            );
+        }
+
+        // 9. Deploy the wstETH adapter (non-pegged wrapper) and register wstETH.
+        {
+            WstETHAssetAdapter adapterImpl = new WstETHAssetAdapter(
+                address(armProxy), Mainnet.WETH, Mainnet.STETH, Mainnet.WSTETH, Mainnet.LIDO_WITHDRAWAL
+            );
+            _recordDeployment("WETH_ARM_WSTETH_ADAPTER_IMPL", address(adapterImpl));
+            Proxy adapterProxy = new Proxy();
+            adapterProxy.initialize(
+                address(adapterImpl), Mainnet.MULTISIG_2_OF_8, abi.encodeWithSignature("initialize()")
+            );
+            _recordDeployment("WETH_ARM_WSTETH_ADAPTER", address(adapterProxy));
+            arm.addBaseAsset(
+                Mainnet.WSTETH,
+                address(adapterProxy),
+                BUY_PRICE,
+                SELL_PRICE,
+                type(uint128).max,
+                type(uint128).max,
+                CROSS_PRICE,
+                false
+            );
+        }
+
+        // 10. Deploy the eETH adapter (pegged 1:1) and register eETH.
+        {
+            EtherFiAssetAdapter adapterImpl = new EtherFiAssetAdapter(
+                address(armProxy),
+                Mainnet.EETH,
+                Mainnet.WETH,
+                Mainnet.ETHERFI_WITHDRAWAL,
+                Mainnet.ETHERFI_WITHDRAWAL_NFT
+            );
+            _recordDeployment("WETH_ARM_EETH_ADAPTER_IMPL", address(adapterImpl));
+            Proxy adapterProxy = new Proxy();
+            adapterProxy.initialize(
+                address(adapterImpl), Mainnet.MULTISIG_2_OF_8, abi.encodeWithSignature("initialize()")
+            );
+            _recordDeployment("WETH_ARM_EETH_ADAPTER", address(adapterProxy));
+            arm.addBaseAsset(
+                Mainnet.EETH,
+                address(adapterProxy),
+                BUY_PRICE,
+                SELL_PRICE,
+                type(uint128).max,
+                type(uint128).max,
+                CROSS_PRICE,
+                true
+            );
+        }
+
+        // 11. Deploy the weETH adapter (non-pegged wrapper) and register weETH.
+        {
+            WeETHAssetAdapter adapterImpl = new WeETHAssetAdapter(
+                address(armProxy),
+                Mainnet.WEETH,
+                Mainnet.EETH,
+                Mainnet.WETH,
+                Mainnet.ETHERFI_WITHDRAWAL,
+                Mainnet.ETHERFI_WITHDRAWAL_NFT
+            );
+            _recordDeployment("WETH_ARM_WEETH_ADAPTER_IMPL", address(adapterImpl));
+            Proxy adapterProxy = new Proxy();
+            adapterProxy.initialize(
+                address(adapterImpl), Mainnet.MULTISIG_2_OF_8, abi.encodeWithSignature("initialize()")
+            );
+            _recordDeployment("WETH_ARM_WEETH_ADAPTER", address(adapterProxy));
+            arm.addBaseAsset(
+                Mainnet.WEETH,
+                address(adapterProxy),
+                BUY_PRICE,
+                SELL_PRICE,
+                type(uint128).max,
+                type(uint128).max,
+                CROSS_PRICE,
+                false
+            );
+        }
+
+        // 12. Hand ownership of the ARM to the 2/8 multisig.
+        armProxy.setOwner(Mainnet.MULTISIG_2_OF_8);
+    }
+}

--- a/script/deploy/mainnet/038_DeployWETHARMScript.s.sol
+++ b/script/deploy/mainnet/038_DeployWETHARMScript.s.sol
@@ -99,8 +99,8 @@ contract $038_DeployWETHARMScript is AbstractDeployScript("038_DeployWETHARMScri
                 address(adapterProxy),
                 BUY_PRICE,
                 SELL_PRICE,
-                type(uint128).max,
-                type(uint128).max,
+                0, // buyAmount: no swaps until the operator sets the swap limits via setPrices()
+                0, // sellAmount
                 CROSS_PRICE,
                 true
             );
@@ -122,8 +122,8 @@ contract $038_DeployWETHARMScript is AbstractDeployScript("038_DeployWETHARMScri
                 address(adapterProxy),
                 BUY_PRICE,
                 SELL_PRICE,
-                type(uint128).max,
-                type(uint128).max,
+                0, // buyAmount: no swaps until the operator sets the swap limits via setPrices()
+                0, // sellAmount
                 CROSS_PRICE,
                 false
             );
@@ -149,8 +149,8 @@ contract $038_DeployWETHARMScript is AbstractDeployScript("038_DeployWETHARMScri
                 address(adapterProxy),
                 BUY_PRICE,
                 SELL_PRICE,
-                type(uint128).max,
-                type(uint128).max,
+                0, // buyAmount: no swaps until the operator sets the swap limits via setPrices()
+                0, // sellAmount
                 CROSS_PRICE,
                 true
             );
@@ -177,8 +177,8 @@ contract $038_DeployWETHARMScript is AbstractDeployScript("038_DeployWETHARMScri
                 address(adapterProxy),
                 BUY_PRICE,
                 SELL_PRICE,
-                type(uint128).max,
-                type(uint128).max,
+                0, // buyAmount: no swaps until the operator sets the swap limits via setPrices()
+                0, // sellAmount
                 CROSS_PRICE,
                 false
             );

--- a/script/deploy/mainnet/039_DeployUSDCARMScript.s.sol
+++ b/script/deploy/mainnet/039_DeployUSDCARMScript.s.sol
@@ -18,14 +18,14 @@ import {State} from "script/deploy/helpers/DeploymentTypes.sol";
 ///         base assets: PYUSD and USDG. Each base asset is wired to its own PaxosAssetAdapter,
 ///         whose redemption queue is fully off-chain: the operator submits queued base assets to a
 ///         Paxos deposit address and Paxos Actions settle USDC 1:1 back to the adapter. Ownership
-///         of the ARM, its CapManager and both adapter proxies is handed to the multi-chain 2/8
-///         multisig (`MULTISIG_2_OF_8`); the operational role is the Talos KMS relayer
-///         (`ARM_TALOS_RELAYER`).
-/// @dev Recreates the complete stack originally deployed by `037_DeployUSDARMScript` under
-///      USDC-specific ERC-20 metadata and resolver keys. The adapters' `paxosRecipient` is set to a
-///      placeholder at deployment - the adapter owner replaces it with the real Paxos deposit
-///      address via setPaxosRecipient() once Paxos provides it. No lending market is wired up here
-///      (idle USDC stays in the ARM until a market is added in a follow-up script).
+///         of the ARM and its CapManager is handed to the multi-chain 2/8 multisig
+///         (`MULTISIG_2_OF_8`), which already owns both reused adapter proxies; the operational role
+///         is the Talos KMS relayer (`ARM_TALOS_RELAYER`).
+/// @dev Recreates the ARM and CapManager originally deployed by `037_DeployUSDARMScript` under
+///      USDC-specific ERC-20 metadata and resolver keys. The existing Paxos adapter proxies are
+///      reused to preserve their whitelisted addresses and configuration, while their implementations
+///      are upgraded to reference the new ARM. No lending market is wired up here (idle USDC stays
+///      in the ARM until a market is added in a follow-up script).
 contract $039_DeployUSDCARMScript is AbstractDeployScript("039_DeployUSDCARMScript") {
     /// @dev Owner of the ARM, CapManager and both PaxosAssetAdapter proxies: the multi-chain 2/8 multisig.
     address internal constant OWNER_2_OF_8 = Mainnet.MULTISIG_2_OF_8;
@@ -113,17 +113,12 @@ contract $039_DeployUSDCARMScript is AbstractDeployScript("039_DeployUSDCARMScri
         armProxy.initialize(address(armImpl), deployer, armData);
         MultiAssetARM arm = MultiAssetARM(payable(address(armProxy)));
 
-        // 8. Deploy the PYUSD Paxos adapter (pegged 1:1) and register PYUSD.
+        // 8. Deploy a PYUSD adapter implementation for the new ARM, reuse the Paxos-whitelisted
+        //    proxy from 037, and register PYUSD. The multisig upgrades the proxy in _fork().
         {
             PaxosAssetAdapter adapterImpl = new PaxosAssetAdapter(address(armProxy), Mainnet.PYUSD, Mainnet.USDC);
             _recordDeployment("USDC_ARM_PYUSD_ADAPTER_IMPL", address(adapterImpl));
-            Proxy adapterProxy = new Proxy();
-            // paxosRecipient is a placeholder - the 2/8 multisig owner replaces it via setPaxosRecipient().
-            adapterProxy.initialize(
-                address(adapterImpl),
-                OWNER_2_OF_8,
-                abi.encodeWithSelector(PaxosAssetAdapter.initialize.selector, OPERATOR_TALOS, Mainnet.PAXOS_RECIPIENT)
-            );
+            Proxy adapterProxy = Proxy(payable(resolver.resolve("USD_ARM_PYUSD_ADAPTER")));
             _recordDeployment("USDC_ARM_PYUSD_ADAPTER", address(adapterProxy));
             arm.addBaseAsset(
                 Mainnet.PYUSD,
@@ -137,17 +132,12 @@ contract $039_DeployUSDCARMScript is AbstractDeployScript("039_DeployUSDCARMScri
             );
         }
 
-        // 9. Deploy the USDG Paxos adapter (pegged 1:1) and register USDG.
+        // 9. Deploy a USDG adapter implementation for the new ARM, reuse the Paxos-whitelisted
+        //    proxy from 037, and register USDG. The multisig upgrades the proxy in _fork().
         {
             PaxosAssetAdapter adapterImpl = new PaxosAssetAdapter(address(armProxy), Mainnet.USDG, Mainnet.USDC);
             _recordDeployment("USDC_ARM_USDG_ADAPTER_IMPL", address(adapterImpl));
-            Proxy adapterProxy = new Proxy();
-            // paxosRecipient is a placeholder - the 2/8 multisig owner replaces it via setPaxosRecipient().
-            adapterProxy.initialize(
-                address(adapterImpl),
-                OWNER_2_OF_8,
-                abi.encodeWithSelector(PaxosAssetAdapter.initialize.selector, OPERATOR_TALOS, Mainnet.PAXOS_RECIPIENT)
-            );
+            Proxy adapterProxy = Proxy(payable(resolver.resolve("USD_ARM_USDG_ADAPTER")));
             _recordDeployment("USDC_ARM_USDG_ADAPTER", address(adapterProxy));
             arm.addBaseAsset(
                 Mainnet.USDG,
@@ -164,5 +154,21 @@ contract $039_DeployUSDCARMScript is AbstractDeployScript("039_DeployUSDCARMScri
         // 10. Hand ownership of the ARM to the 2/8 multisig. The owner will later be moved to the
         //     Timelock (governance) before the CapManager is removed.
         armProxy.setOwner(OWNER_2_OF_8);
+    }
+
+    function _fork() internal override {
+        _upgradeAdapter("USDC_ARM_PYUSD_ADAPTER", "USDC_ARM_PYUSD_ADAPTER_IMPL");
+        _upgradeAdapter("USDC_ARM_USDG_ADAPTER", "USDC_ARM_USDG_ADAPTER_IMPL");
+    }
+
+    function _upgradeAdapter(string memory proxyName, string memory implementationName) internal {
+        Proxy adapterProxy = Proxy(payable(resolver.resolve(proxyName)));
+        address adapterImpl = resolver.resolve(implementationName);
+
+        // Idempotent: the deployment runner can replay pending multisig actions on forks.
+        if (adapterProxy.implementation() == adapterImpl) return;
+
+        vm.prank(adapterProxy.owner());
+        adapterProxy.upgradeTo(adapterImpl);
     }
 }

--- a/script/deploy/mainnet/039_DeployUSDCARMScript.s.sol
+++ b/script/deploy/mainnet/039_DeployUSDCARMScript.s.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {IERC20} from "contracts/Interfaces.sol";
+import {Proxy} from "contracts/Proxy.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+import {MultiAssetARM} from "contracts/MultiAssetARM.sol";
+import {CapManager} from "contracts/CapManager.sol";
+import {PaxosAssetAdapter} from "contracts/adapters/PaxosAssetAdapter.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+import {State} from "script/deploy/helpers/DeploymentTypes.sol";
+
+/// @title Redeploy the USDC ARM with Paxos base assets
+/// @notice Deploys a single MultiAssetARM with USDC as the liquidity asset and two Paxos-issued
+///         base assets: PYUSD and USDG. Each base asset is wired to its own PaxosAssetAdapter,
+///         whose redemption queue is fully off-chain: the operator submits queued base assets to a
+///         Paxos deposit address and Paxos Actions settle USDC 1:1 back to the adapter. Ownership
+///         of the ARM, its CapManager and both adapter proxies is handed to the multi-chain 2/8
+///         multisig (`MULTISIG_2_OF_8`); the operational role is the Talos KMS relayer
+///         (`ARM_TALOS_RELAYER`).
+/// @dev Recreates the complete stack originally deployed by `037_DeployUSDARMScript` under
+///      USDC-specific ERC-20 metadata and resolver keys. The adapters' `paxosRecipient` is set to a
+///      placeholder at deployment - the adapter owner replaces it with the real Paxos deposit
+///      address via setPaxosRecipient() once Paxos provides it. No lending market is wired up here
+///      (idle USDC stays in the ARM until a market is added in a follow-up script).
+contract $039_DeployUSDCARMScript is AbstractDeployScript("039_DeployUSDCARMScript") {
+    /// @dev Owner of the ARM, CapManager and both PaxosAssetAdapter proxies: the multi-chain 2/8 multisig.
+    address internal constant OWNER_2_OF_8 = Mainnet.MULTISIG_2_OF_8;
+    /// @dev Operational role (request/claim redemptions, submit Paxos redeems, set prices): the
+    ///      Talos KMS relayer.
+    address internal constant OPERATOR_TALOS = Mainnet.ARM_TALOS_RELAYER;
+
+    /// @dev Initial price band shared by both Paxos base assets, scaled to 1e36. The operator
+    ///      (Talos) tunes these per asset via setPrices() after deployment.
+    /// 0.99997e36 = base asset valued at 0.99997 USDC in totalAssets() (0.3 bps discount, as the
+    ///              Paxos assets trade at around 1 bps)
+    uint256 internal constant CROSS_PRICE = 0.99997e36;
+    /// 0.998e36 = ARM pays 0.998 USDC per base asset bought from traders (must stay below cross)
+    uint256 internal constant BUY_PRICE = 0.998e36;
+    /// 1e36 = ARM charges 1 USDC per base asset sold to traders (must stay at/above cross)
+    uint256 internal constant SELL_PRICE = 1e36;
+
+    /// @dev Sky/Maker LitePSM, the largest USDC holder (~4.25B USDC at the pinned fork block).
+    ///      Used only in fork states to seed the pranked deployer with the MIN_LIQUIDITY dust that
+    ///      initialize() pulls.
+    address internal constant USDC_WHALE = 0x37305B1cD40574E4C5Ce33f8e8306Be057fD7341;
+    /// @dev 1000 = 0.001 USDC. Comfortable margin over the 1 atomic unit
+    ///      of USDC (0.000001 USDC) that initialize() pulls.
+    uint256 internal constant USDC_SEED = 1000;
+
+    function _execute() internal override {
+        // 1. Deploy the ARM proxy.
+        Proxy armProxy = new Proxy();
+        _recordDeployment("USDC_ARM", address(armProxy));
+
+        // 2. Deploy the CapManager (proxy + implementation), owned by the 2/8 multisig and
+        //    operated by Talos.
+        Proxy capManProxy = new Proxy();
+        _recordDeployment("USDC_ARM_CAP_MAN", address(capManProxy));
+
+        CapManager capManagerImpl = new CapManager(address(armProxy));
+        _recordDeployment("USDC_ARM_CAP_IMPL", address(capManagerImpl));
+
+        // Initialize the CapManager with Talos as operator; keep the deployer as owner for now.
+        bytes memory capManData = abi.encodeWithSignature("initialize(address)", OPERATOR_TALOS);
+        capManProxy.initialize(address(capManagerImpl), deployer, capManData);
+        CapManager capManager = CapManager(address(capManProxy));
+
+        // 3. Set the initial total-assets cap and per-LP caps. Tuned later by the CapManager operator.
+        capManager.setTotalAssetsCap(uint248(100_000e6)); // 100,000 USDC
+        capManager.setAccountCapEnabled(true);
+        address[] memory lpAccounts = new address[](1);
+        lpAccounts[0] = Mainnet.TREASURY_LP;
+        capManager.setLiquidityProviderCaps(lpAccounts, 100_000e6); // 100,000 USDC
+
+        // 4. Hand the CapManager to the 2/8 multisig.
+        capManProxy.setOwner(OWNER_2_OF_8);
+
+        // 5. Deploy the MultiAssetARM implementation (USDC liquidity asset). The parameters are the
+        //    6-decimal analogues of 035's 18-decimal WETH values: 1e6 = 1 USDC minimum market
+        //    shares to redeem (vs 1e7 wei WETH), 100e6 = 100 USDC allocate threshold (vs 1 WETH).
+        MultiAssetARM armImpl = new MultiAssetARM({
+            _liquidityAsset: Mainnet.USDC, _claimDelay: 10 minutes, _minSharesToRedeem: 1e6, _allocateThreshold: 100e6
+        });
+        _recordDeployment("USDC_ARM_IMPL", address(armImpl));
+
+        // 6. Give the deployer the MIN_LIQUIDITY (1 atomic unit of USDC, i.e. 0.000001 USDC) that
+        //    initialize() pulls to seed dead shares. 035 wraps ETH into WETH for this, but USDC
+        //    cannot be wrapped from ETH and the pranked deployer holds no USDC on a fork, so in
+        //    fork states a dust amount is borrowed from the Sky/Maker LitePSM whale.
+        //    In REAL_DEPLOYING the deployer wallet must already hold at least 1 atomic unit of USDC.
+        if (state != State.REAL_DEPLOYING) {
+            vm.stopPrank();
+            vm.prank(USDC_WHALE);
+            IERC20(Mainnet.USDC).transfer(deployer, USDC_SEED);
+            vm.startPrank(deployer);
+        }
+        IERC20(Mainnet.USDC).approve(address(armProxy), USDC_SEED);
+
+        // 7. Initialize the ARM proxy: deployer stays owner during setup, Talos is the operator.
+        bytes memory armData = abi.encodeWithSignature(
+            "initialize(string,string,address,uint256,address,address)",
+            "USDC ARM", // name
+            "ARM-USDC", // symbol
+            OPERATOR_TALOS, // operator
+            2000, // 20% performance fee
+            Mainnet.BUYBACK_OPERATOR, // fee collector
+            address(capManager)
+        );
+        armProxy.initialize(address(armImpl), deployer, armData);
+        MultiAssetARM arm = MultiAssetARM(payable(address(armProxy)));
+
+        // 8. Deploy the PYUSD Paxos adapter (pegged 1:1) and register PYUSD.
+        {
+            PaxosAssetAdapter adapterImpl = new PaxosAssetAdapter(address(armProxy), Mainnet.PYUSD, Mainnet.USDC);
+            _recordDeployment("USDC_ARM_PYUSD_ADAPTER_IMPL", address(adapterImpl));
+            Proxy adapterProxy = new Proxy();
+            // paxosRecipient is a placeholder - the 2/8 multisig owner replaces it via setPaxosRecipient().
+            adapterProxy.initialize(
+                address(adapterImpl),
+                OWNER_2_OF_8,
+                abi.encodeWithSelector(PaxosAssetAdapter.initialize.selector, OPERATOR_TALOS, Mainnet.PAXOS_RECIPIENT)
+            );
+            _recordDeployment("USDC_ARM_PYUSD_ADAPTER", address(adapterProxy));
+            arm.addBaseAsset(
+                Mainnet.PYUSD,
+                address(adapterProxy),
+                BUY_PRICE,
+                SELL_PRICE,
+                0, // buyAmount: no swaps until the Operator sets the swap limits via setPrices()
+                0, // sellAmount
+                CROSS_PRICE,
+                true
+            );
+        }
+
+        // 9. Deploy the USDG Paxos adapter (pegged 1:1) and register USDG.
+        {
+            PaxosAssetAdapter adapterImpl = new PaxosAssetAdapter(address(armProxy), Mainnet.USDG, Mainnet.USDC);
+            _recordDeployment("USDC_ARM_USDG_ADAPTER_IMPL", address(adapterImpl));
+            Proxy adapterProxy = new Proxy();
+            // paxosRecipient is a placeholder - the 2/8 multisig owner replaces it via setPaxosRecipient().
+            adapterProxy.initialize(
+                address(adapterImpl),
+                OWNER_2_OF_8,
+                abi.encodeWithSelector(PaxosAssetAdapter.initialize.selector, OPERATOR_TALOS, Mainnet.PAXOS_RECIPIENT)
+            );
+            _recordDeployment("USDC_ARM_USDG_ADAPTER", address(adapterProxy));
+            arm.addBaseAsset(
+                Mainnet.USDG,
+                address(adapterProxy),
+                BUY_PRICE,
+                SELL_PRICE,
+                0, // buyAmount: no swaps until the Operator sets the swap limits via setPrices()
+                0, // sellAmount
+                CROSS_PRICE,
+                true
+            );
+        }
+
+        // 10. Hand ownership of the ARM to the 2/8 multisig. The owner will later be moved to the
+        //     Timelock (governance) before the CapManager is removed.
+        armProxy.setOwner(OWNER_2_OF_8);
+    }
+}

--- a/src/js/tasks/actions/allocateUSD.ts
+++ b/src/js/tasks/actions/allocateUSD.ts
@@ -7,12 +7,12 @@ const multiAssetARMAbi = require("../../../abis/MultiAssetARM.json");
 
 action({
   name: "allocateUSD",
-  description: "Allocate liquidity for USD ARM",
+  description: "Allocate liquidity for USDC ARM",
   chains: [1],
   run: async ({ signer, log }) => {
     const arm = new ethers.Contract(mainnet.usdARM, multiAssetARMAbi, signer);
 
-    log.info("Allocating liquidity for USD ARM");
+    log.info("Allocating liquidity for USDC ARM");
     await allocate({
       signer,
       arm,

--- a/src/js/tasks/actions/autoClaimUSDWithdraw.ts
+++ b/src/js/tasks/actions/autoClaimUSDWithdraw.ts
@@ -9,7 +9,7 @@ const multiAssetARMAbi = require("../../../abis/MultiAssetARM.json");
 
 action({
   name: "autoClaimUSDWithdraw",
-  description: "Claim USDC settled by Paxos redemptions for the USD ARM",
+  description: "Claim USDC settled by Paxos redemptions for the USDC ARM",
   chains: [1],
   params: (t) =>
     t
@@ -28,7 +28,7 @@ action({
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.usdARM, multiAssetARMAbi, signer);
 
-    log.info("Claiming USD ARM withdrawals settled by Paxos");
+    log.info("Claiming USDC ARM withdrawals settled by Paxos");
     await runForBases({
       bases: String(args.bases).split(","),
       actionName: "Claiming withdrawals",
@@ -36,7 +36,7 @@ action({
       options: {
         signer,
         arm,
-        armName: "USD",
+        armName: "USDC",
         minAmount: args.minAmount,
       },
     });

--- a/src/js/tasks/actions/autoRequestUSDWithdraw.ts
+++ b/src/js/tasks/actions/autoRequestUSDWithdraw.ts
@@ -10,7 +10,7 @@ const multiAssetARMAbi = require("../../../abis/MultiAssetARM.json");
 action({
   name: "autoRequestUSDWithdraw",
   description:
-    "Request and submit Paxos redemptions of PYUSD/USDG from the USD ARM",
+    "Request and submit Paxos redemptions of PYUSD/USDG from the USDC ARM",
   chains: [1],
   params: (t) =>
     t
@@ -35,7 +35,7 @@ action({
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.usdARM, multiAssetARMAbi, signer);
 
-    log.info("Requesting USD ARM withdrawals via Paxos");
+    log.info("Requesting USDC ARM withdrawals via Paxos");
     await runForBases({
       bases: String(args.bases).split(","),
       actionName: "Requesting withdrawals",
@@ -43,7 +43,7 @@ action({
       options: {
         signer,
         arm,
-        armName: "USD",
+        armName: "USDC",
         minAmount: args.minAmount,
         thresholdAmount: args.thresholdAmount,
       },

--- a/src/js/tasks/actions/collectUSDFees.ts
+++ b/src/js/tasks/actions/collectUSDFees.ts
@@ -7,12 +7,12 @@ const multiAssetARMAbi = require("../../../abis/MultiAssetARM.json");
 
 action({
   name: "collectUSDFees",
-  description: "Collect fees from USD ARM",
+  description: "Collect fees from USDC ARM",
   chains: [1],
   run: async ({ signer, log }) => {
     const arm = new ethers.Contract(mainnet.usdARM, multiAssetARMAbi, signer);
 
-    log.info("Collecting fees from USD ARM");
+    log.info("Collecting fees from USDC ARM");
     await collectFees({ signer, arm, decimals: 6 });
   },
 });

--- a/src/js/tasks/actions/setPricesUSD.ts
+++ b/src/js/tasks/actions/setPricesUSD.ts
@@ -10,7 +10,7 @@ const multiAssetARMAbi = require("../../../abis/MultiAssetARM.json");
 
 action({
   name: "setPricesUSD",
-  description: "Set prices for USD ARM",
+  description: "Set prices for USDC ARM",
   chains: [1],
   // Price points are operator-overridable from the scheduled command in
   // talos (talos UI → schedules → command field).
@@ -97,7 +97,7 @@ action({
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.usdARM, multiAssetARMAbi, signer);
 
-    log.info("Setting prices for USD ARM");
+    log.info("Setting prices for USDC ARM");
     const amount = await resolveUsdAggregatorAmount({
       arm,
       amount: args.amount,
@@ -112,7 +112,7 @@ action({
       options: {
         signer,
         arm,
-        armName: "USD",
+        armName: "USDC",
         maxSellPrice: args.maxSellPrice,
         minSellPrice: args.minSellPrice,
         maxBuyPrice: args.maxBuyPrice,

--- a/src/js/tasks/lib/arm.ts
+++ b/src/js/tasks/lib/arm.ts
@@ -37,7 +37,7 @@ const MAINNET_ARMS = {
   usd: {
     abi: multiAssetARMAbi,
     address: mainnet.usdARM,
-    name: "USD",
+    name: "USDC",
     decimals: 6,
   },
 };

--- a/src/js/tasks/liquidity.js
+++ b/src/js/tasks/liquidity.js
@@ -175,7 +175,7 @@ const logSnapForBase = async ({
         ? `${baseContext.baseSymbol}/WETH`
         : arm === "Ethena"
           ? `${baseContext.baseSymbol}/USDe`
-          : arm === "USD"
+          : arm === "USDC"
             ? `${baseContext.baseSymbol}/USDC`
             : arm == "Origin" && chainId === 146
               ? `${baseContext.baseSymbol}/wS`

--- a/src/js/utils/addressParser.js
+++ b/src/js/utils/addressParser.js
@@ -13,10 +13,9 @@ const log = require("./logger")("utils:addressParser");
 const resolveArmContract = async (arm) => {
   const deployName = deployNameForArm(arm);
   const armAddress = await parseDeployedAddress(deployName);
-  const contractNameOrAbi =
-    normalizeArmName(arm) === "USD"
-      ? multiAssetARMAbi
-      : contractNameForArm(arm);
+  const contractNameOrAbi = ["USDC", "WETH"].includes(normalizeArmName(arm))
+    ? multiAssetARMAbi
+    : contractNameForArm(arm);
   const armContract = await ethers.getContractAt(contractNameOrAbi, armAddress);
 
   return armContract;

--- a/src/js/utils/arm.js
+++ b/src/js/utils/arm.js
@@ -42,7 +42,8 @@ const ARM_BASES = {
   Ethena: { defaultBase: "SUSDE", liquidity: "USDE" },
   Oeth: { defaultBase: "OETH", liquidity: "WETH" },
   Origin: { defaultBase: "OS", liquidity: "WS" },
-  USD: { defaultBase: "PYUSD", liquidity: "USDC" },
+  USDC: { defaultBase: "PYUSD", liquidity: "USDC" },
+  WETH: { defaultBase: "STETH", liquidity: "WETH" },
 };
 
 const BASE_ALIASES = {

--- a/src/js/utils/armNames.js
+++ b/src/js/utils/armNames.js
@@ -6,18 +6,23 @@ const ARM_NAME_ALIASES = {
   ethena: "Ethena",
   oeth: "Oeth",
   origin: "Origin",
-  usd: "USD",
+  eth: "WETH",
+  weth: "WETH",
+  usd: "USDC",
+  usdc: "USDC",
 };
 
 const ARM_DEPLOY_NAMES = {
   EtherFi: "ETHER_FI_ARM",
   Oeth: "OETH_ARM",
-  USD: "USD_ARM",
+  USDC: "USDC_ARM",
+  WETH: "WETH_ARM",
 };
 
 const ARM_CONTRACT_NAMES = {
   Oeth: "OriginARM",
-  USD: "MultiAssetARM",
+  USDC: "MultiAssetARM",
+  WETH: "MultiAssetARM",
 };
 
 const normalizeArmName = (arm) => {

--- a/src/js/utils/usdPricing.js
+++ b/src/js/utils/usdPricing.js
@@ -27,7 +27,7 @@ const resolveUsdAggregatorAmount = async ({
   // configured base can be used to resolve them
   const baseContext = await resolveArmBaseFn({
     arm,
-    armName: "USD",
+    armName: "USDC",
     base: "PYUSD",
     blockTag,
   });
@@ -39,7 +39,7 @@ const resolveUsdAggregatorAmount = async ({
 
   if (liquidityAssets < MIN_USD_AGGREGATOR_AMOUNT) {
     log?.info?.(
-      `Skipping USD price update: only ${formatUnits(liquidityAssets, 6)} USDC withdrawable in ARM and lending market, below the ${formatUnits(MIN_USD_AGGREGATOR_AMOUNT, 6)} USDC minimum aggregator quote amount`,
+      `Skipping USDC ARM price update: only ${formatUnits(liquidityAssets, 6)} USDC withdrawable in ARM and lending market, below the ${formatUnits(MIN_USD_AGGREGATOR_AMOUNT, 6)} USDC minimum aggregator quote amount`,
     );
     return undefined;
   }

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -24,7 +24,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
     IERC20 pyusd;
     IERC20 usdg;
     Proxy armProxy;
-    MultiAssetARM usdARM;
+    MultiAssetARM usdcARM;
     PaxosAssetAdapter pyusdAdapter;
     PaxosAssetAdapter usdgAdapter;
     CapManager capManager;
@@ -42,25 +42,25 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         vm.label(address(usdg), "USDG");
         vm.label(address(operator), "OPERATOR");
 
-        armProxy = Proxy(payable(resolver.resolve("USD_ARM")));
-        usdARM = MultiAssetARM(payable(resolver.resolve("USD_ARM")));
-        pyusdAdapter = PaxosAssetAdapter(resolver.resolve("USD_ARM_PYUSD_ADAPTER"));
-        usdgAdapter = PaxosAssetAdapter(resolver.resolve("USD_ARM_USDG_ADAPTER"));
-        capManager = CapManager(resolver.resolve("USD_ARM_CAP_MAN"));
+        armProxy = Proxy(payable(resolver.resolve("USDC_ARM")));
+        usdcARM = MultiAssetARM(payable(resolver.resolve("USDC_ARM")));
+        pyusdAdapter = PaxosAssetAdapter(resolver.resolve("USDC_ARM_PYUSD_ADAPTER"));
+        usdgAdapter = PaxosAssetAdapter(resolver.resolve("USDC_ARM_USDG_ADAPTER"));
+        capManager = CapManager(resolver.resolve("USDC_ARM_CAP_MAN"));
     }
 
     function test_initialConfig() external view {
-        assertEq(usdARM.name(), "USD ARM", "Name");
-        assertEq(usdARM.symbol(), "ARM-USD", "Symbol");
-        assertEq(usdARM.owner(), Mainnet.MULTISIG_2_OF_8, "Owner");
-        assertEq(usdARM.operator(), operator, "Operator");
-        assertEq(usdARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
-        assertEq(usdARM.fee(), 2000, "Performance fee");
-        assertEq(usdARM.liquidityAsset(), Mainnet.USDC, "liquidity asset");
-        assertEq(usdARM.claimDelay(), 10 minutes, "claim delay");
+        assertEq(usdcARM.name(), "USDC ARM", "Name");
+        assertEq(usdcARM.symbol(), "ARM-USDC", "Symbol");
+        assertEq(usdcARM.owner(), Mainnet.MULTISIG_2_OF_8, "Owner");
+        assertEq(usdcARM.operator(), operator, "Operator");
+        assertEq(usdcARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
+        assertEq(usdcARM.fee(), 2000, "Performance fee");
+        assertEq(usdcARM.liquidityAsset(), Mainnet.USDC, "liquidity asset");
+        assertEq(usdcARM.claimDelay(), 10 minutes, "claim delay");
 
         // PYUSD adapter
-        assertEq(pyusdAdapter.arm(), address(usdARM), "PYUSD adapter arm");
+        assertEq(pyusdAdapter.arm(), address(usdcARM), "PYUSD adapter arm");
         assertEq(address(pyusdAdapter.baseAsset()), Mainnet.PYUSD, "PYUSD adapter base asset");
         assertEq(pyusdAdapter.asset(), Mainnet.USDC, "PYUSD adapter liquidity asset");
         assertEq(pyusdAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "PYUSD adapter owner");
@@ -68,18 +68,18 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertNotEq(pyusdAdapter.paxosRecipient(), address(0), "PYUSD adapter paxos recipient");
 
         // USDG adapter
-        assertEq(usdgAdapter.arm(), address(usdARM), "USDG adapter arm");
+        assertEq(usdgAdapter.arm(), address(usdcARM), "USDG adapter arm");
         assertEq(address(usdgAdapter.baseAsset()), Mainnet.USDG, "USDG adapter base asset");
         assertEq(usdgAdapter.asset(), Mainnet.USDC, "USDG adapter liquidity asset");
         assertEq(usdgAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "USDG adapter owner");
         assertEq(usdgAdapter.operator(), operator, "USDG adapter operator");
         assertNotEq(usdgAdapter.paxosRecipient(), address(0), "USDG adapter paxos recipient");
 
-        address[] memory baseAssets = usdARM.getBaseAssets();
+        address[] memory baseAssets = usdcARM.getBaseAssets();
         _assertBaseAssetListed(baseAssets, Mainnet.PYUSD, "PYUSD listed as base asset");
         _assertBaseAssetListed(baseAssets, Mainnet.USDG, "USDG listed as base asset");
 
-        assertEq(capManager.arm(), address(usdARM), "cap manager arm");
+        assertEq(capManager.arm(), address(usdcARM), "cap manager arm");
         assertEq(capManager.totalAssetsCap(), 100_000e6, "total assets cap");
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
         assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 100_000e6, "liquidity provider cap");
@@ -100,7 +100,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
             bool peggedToLiquidityAsset,
             uint8 baseAssetDecimals,
             address adapter
-        ) = usdARM.baseAssetConfigs(baseAsset);
+        ) = usdcARM.baseAssetConfigs(baseAsset);
 
         assertGe(buyPrice, MIN_BUY_PRICE, string.concat(label, " minimum buy price"));
         assertLe(buyPrice, MAX_BUY_PRICE, string.concat(label, " maximum buy price"));
@@ -120,20 +120,20 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // Give the ARM USDC inventory and the trader PYUSD. Deal directly - deposits from
         // arbitrary accounts are blocked by the CapManager's account caps.
-        deal(address(usdc), address(usdARM), 1_000_000e6);
+        deal(address(usdc), address(usdcARM), 1_000_000e6);
         deal(address(pyusd), address(this), 1_000e6);
 
-        pyusd.approve(address(usdARM), amountIn);
+        pyusd.approve(address(usdcARM), amountIn);
 
         // The deployment registers base assets with zero swap liquidity, so the operator must set
         // the buy/sell amounts before any swap is possible.
         vm.prank(operator);
-        usdARM.setPrices(address(pyusd), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
+        usdcARM.setPrices(address(pyusd), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
 
         uint256 startIn = pyusd.balanceOf(address(this));
         uint256 startOut = usdc.balanceOf(address(this));
 
-        usdARM.swapExactTokensForTokens(pyusd, usdc, amountIn, 0, address(this));
+        usdcARM.swapExactTokensForTokens(pyusd, usdc, amountIn, 0, address(this));
 
         assertEq(pyusd.balanceOf(address(this)), startIn - amountIn, "PYUSD in actual");
         assertEq(usdc.balanceOf(address(this)), startOut + expectedOut, "USDC out actual");
@@ -147,20 +147,20 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // Give the ARM USDG inventory and the trader USDC. Deal directly - deposits from
         // arbitrary accounts are blocked by the CapManager's account caps.
-        deal(address(usdg), address(usdARM), 1_000e6);
+        deal(address(usdg), address(usdcARM), 1_000e6);
         deal(address(usdc), address(this), 1_000e6);
 
-        usdc.approve(address(usdARM), amountIn);
+        usdc.approve(address(usdcARM), amountIn);
 
         // The deployment registers base assets with zero swap liquidity, so the operator must set
         // the buy/sell amounts before any swap is possible.
         vm.prank(operator);
-        usdARM.setPrices(address(usdg), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
+        usdcARM.setPrices(address(usdg), 0.998e36, 1e36, type(uint128).max, type(uint128).max);
 
         uint256 startIn = usdc.balanceOf(address(this));
         uint256 startOut = usdg.balanceOf(address(this));
 
-        usdARM.swapExactTokensForTokens(usdc, usdg, amountIn, 0, address(this));
+        usdcARM.swapExactTokensForTokens(usdc, usdg, amountIn, 0, address(this));
 
         assertEq(usdc.balanceOf(address(this)), startIn - amountIn, "USDC in actual");
         assertEq(usdg.balanceOf(address(this)), startOut + expectedOut, "USDG out actual");
@@ -181,17 +181,17 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         uint256 shares = 1_000e6;
         uint256 pendingSharesBefore = adapter.pendingShares();
         uint256 settlingSharesBefore = adapter.settlingShares();
-        (,,,,, uint128 pendingRedeemAssetsBefore,,,) = usdARM.baseAssetConfigs(address(baseAsset));
+        (,,,,, uint128 pendingRedeemAssetsBefore,,,) = usdcARM.baseAssetConfigs(address(baseAsset));
 
         // Give the ARM base asset inventory (as if bought from traders).
-        deal(address(baseAsset), address(usdARM), shares);
+        deal(address(baseAsset), address(usdcARM), shares);
 
-        uint256 totalAssetsBefore = usdARM.totalAssets();
-        uint256 armUsdcBefore = usdc.balanceOf(address(usdARM));
+        uint256 totalAssetsBefore = usdcARM.totalAssets();
+        uint256 armUsdcBefore = usdc.balanceOf(address(usdcARM));
 
         // 1. Operator queues the base assets for Paxos redemption. The adapter pulls them from the ARM.
         vm.prank(operator);
-        usdARM.requestBaseAssetRedeem(address(baseAsset), shares);
+        usdcARM.requestBaseAssetRedeem(address(baseAsset), shares);
         assertEq(adapter.pendingShares(), pendingSharesBefore + shares, "pending shares after request");
         assertGe(baseAsset.balanceOf(address(adapter)), shares, "adapter base balance after request");
 
@@ -212,14 +212,14 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // 5. Operator claims the settled USDC back into the ARM.
         vm.prank(operator);
-        usdARM.claimBaseAssetRedeem(address(baseAsset), shares);
+        usdcARM.claimBaseAssetRedeem(address(baseAsset), shares);
 
         assertEq(adapter.pendingShares(), pendingSharesBefore, "pending shares after claim");
         assertEq(adapter.settlingShares(), settlingSharesBefore, "settling shares after claim");
-        assertEq(usdc.balanceOf(address(usdARM)), armUsdcBefore + shares, "ARM USDC balance after claim");
-        (,,,,, uint128 pendingRedeemAssets,,,) = usdARM.baseAssetConfigs(address(baseAsset));
+        assertEq(usdc.balanceOf(address(usdcARM)), armUsdcBefore + shares, "ARM USDC balance after claim");
+        (,,,,, uint128 pendingRedeemAssets,,,) = usdcARM.baseAssetConfigs(address(baseAsset));
         assertEq(pendingRedeemAssets, pendingRedeemAssetsBefore, "pending redeem assets after claim");
-        assertGe(usdARM.totalAssets(), totalAssetsBefore, "total assets not decreased");
+        assertGe(usdcARM.totalAssets(), totalAssetsBefore, "total assets not decreased");
     }
 
     function test_proxy_unauthorizedAccess() external {
@@ -245,7 +245,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // Implementation's restricted methods.
         vm.expectRevert(onlyOwnerError);
-        usdARM.setOwner(RANDOM_ADDRESS);
+        usdcARM.setOwner(RANDOM_ADDRESS);
     }
 
     /// @dev Assert `expected` appears in the ARM's `getBaseAssets()` list. A membership check

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -66,6 +66,9 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(pyusdAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "PYUSD adapter owner");
         assertEq(pyusdAdapter.operator(), operator, "PYUSD adapter operator");
         assertNotEq(pyusdAdapter.paxosRecipient(), address(0), "PYUSD adapter paxos recipient");
+        assertEq(
+            address(pyusdAdapter), resolver.resolve("USD_ARM_PYUSD_ADAPTER"), "PYUSD adapter proxy reused from USD ARM"
+        );
 
         // USDG adapter
         assertEq(usdgAdapter.arm(), address(usdcARM), "USDG adapter arm");
@@ -74,6 +77,9 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(usdgAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "USDG adapter owner");
         assertEq(usdgAdapter.operator(), operator, "USDG adapter operator");
         assertNotEq(usdgAdapter.paxosRecipient(), address(0), "USDG adapter paxos recipient");
+        assertEq(
+            address(usdgAdapter), resolver.resolve("USD_ARM_USDG_ADAPTER"), "USDG adapter proxy reused from USD ARM"
+        );
 
         address[] memory baseAssets = usdcARM.getBaseAssets();
         _assertBaseAssetListed(baseAssets, Mainnet.PYUSD, "PYUSD listed as base asset");

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {AbstractSmokeTest} from "./AbstractSmokeTest.sol";
+
+import {MultiAssetARM} from "contracts/MultiAssetARM.sol";
+import {CapManager} from "contracts/CapManager.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+
+contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
+    MultiAssetARM internal wethARM;
+    CapManager internal capManager;
+
+    function setUp() public override {
+        super.setUp();
+
+        wethARM = MultiAssetARM(payable(resolver.resolve("WETH_ARM")));
+        capManager = CapManager(resolver.resolve("WETH_ARM_CAP_MAN"));
+    }
+
+    function test_InitialConfig() external view {
+        assertEq(wethARM.name(), "WETH ARM", "name");
+        assertEq(wethARM.symbol(), "ARM-WETH", "symbol");
+        assertEq(wethARM.owner(), Mainnet.MULTISIG_2_OF_8, "owner");
+        assertEq(wethARM.operator(), Mainnet.ARM_TALOS_RELAYER, "operator");
+        assertEq(wethARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "fee collector");
+        assertEq(wethARM.fee(), 2000, "performance fee");
+        assertEq(wethARM.liquidityAsset(), Mainnet.WETH, "liquidity asset");
+        assertEq(wethARM.claimDelay(), 10 minutes, "claim delay");
+
+        assertEq(capManager.arm(), address(wethARM), "cap manager arm");
+        assertEq(capManager.totalAssetsCap(), 250 ether, "total assets cap");
+        assertTrue(capManager.accountCapEnabled(), "account cap enabled");
+        assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 250 ether, "liquidity provider cap");
+        assertEq(capManager.operator(), Mainnet.MULTISIG_2_OF_8, "cap manager operator");
+        assertEq(capManager.owner(), Mainnet.MULTISIG_2_OF_8, "cap manager owner");
+    }
+
+    function test_BaseAssetConfigs() external view {
+        address[] memory baseAssets = wethARM.getBaseAssets();
+        assertEq(baseAssets.length, 4, "base asset count");
+        assertEq(baseAssets[0], Mainnet.STETH, "stETH order");
+        assertEq(baseAssets[1], Mainnet.WSTETH, "wstETH order");
+        assertEq(baseAssets[2], Mainnet.EETH, "eETH order");
+        assertEq(baseAssets[3], Mainnet.WEETH, "weETH order");
+
+        _assertBaseAssetConfig(Mainnet.STETH, "WETH_ARM_STETH_ADAPTER", true);
+        _assertBaseAssetConfig(Mainnet.WSTETH, "WETH_ARM_WSTETH_ADAPTER", false);
+        _assertBaseAssetConfig(Mainnet.EETH, "WETH_ARM_EETH_ADAPTER", true);
+        _assertBaseAssetConfig(Mainnet.WEETH, "WETH_ARM_WEETH_ADAPTER", false);
+    }
+
+    function _assertBaseAssetConfig(address baseAsset, string memory adapterName, bool pegged) internal view {
+        (
+            uint128 buyPrice,
+            uint128 sellPrice,
+            uint128 buyLiquidityRemaining,
+            uint128 sellLiquidityRemaining,
+            uint128 crossPrice,
+            uint128 pendingRedeemAssets,
+            bool peggedToLiquidityAsset,
+            uint8 baseAssetDecimals,
+            address adapter
+        ) = wethARM.baseAssetConfigs(baseAsset);
+
+        assertEq(buyPrice, 0.9997e36, "buy price");
+        assertEq(sellPrice, 1e36, "sell price");
+        assertEq(buyLiquidityRemaining, type(uint128).max, "buy liquidity");
+        assertEq(sellLiquidityRemaining, type(uint128).max, "sell liquidity");
+        assertEq(crossPrice, 0.99996e36, "cross price");
+        assertEq(pendingRedeemAssets, 0, "pending redeem assets");
+        assertEq(peggedToLiquidityAsset, pegged, "pegged");
+        assertEq(baseAssetDecimals, 18, "base asset decimals");
+        assertEq(adapter, resolver.resolve(adapterName), "adapter");
+    }
+}

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -65,8 +65,8 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
 
         assertEq(buyPrice, 0.9997e36, "buy price");
         assertEq(sellPrice, 1e36, "sell price");
-        assertEq(buyLiquidityRemaining, type(uint128).max, "buy liquidity");
-        assertEq(sellLiquidityRemaining, type(uint128).max, "sell liquidity");
+        assertEq(buyLiquidityRemaining, 0, "buy liquidity disabled");
+        assertEq(sellLiquidityRemaining, 0, "sell liquidity disabled");
         assertEq(crossPrice, 0.99996e36, "cross price");
         assertEq(pendingRedeemAssets, 0, "pending redeem assets");
         assertEq(peggedToLiquidityAsset, pegged, "pegged");


### PR DESCRIPTION
## Summary

- rename the multi-asset ARM metadata from `ETH ARM` / `ARM-ETH` to `WETH ARM` / `ARM-WETH`
- rename the Paxos ARM metadata from `USD ARM` / `ARM-USD` to `USDC ARM` / `ARM-USDC`
- add deployment `038` to redeploy the full WETH stack: ARM proxy and implementation, CapManager proxy and implementation, plus the stETH, wstETH, eETH and weETH adapter proxies and implementations
- initialize both buy-side and sell-side swap liquidity to zero for all four WETH ARM adapters
- add deployment `039` to redeploy the full USDC stack: ARM proxy and implementation, CapManager proxy and implementation, plus both Paxos adapter proxies and implementations
- register the new deployments under `WETH_ARM_*` and `USDC_ARM_*` resolver keys while preserving the historical `036` and `037` deployments
- update off-chain ARM name normalization, action labels and documentation; `ETH` and `USD` remain accepted as backward-compatible aliases
- update the Paxos smoke suite and add WETH deployment smoke coverage

## Testing

- `make simulate` — full mainnet fork deployment simulation passed for both new stacks before the final liquidity-limit adjustment
- `forge test --match-path 'test/smoke/WETHARMSmokeTest.t.sol'` — 2 passed
- `forge test --match-path 'test/smoke/PaxosARMSmokeTest.t.sol'` — 7 passed
- `forge test --no-match-path 'test/invariants/**'` — 532 passed, 0 failed, 3 skipped
- `pnpm lint`
- `pnpm exec tsc --noEmit --typeRoots node_modules/.pnpm/@types+node@25.5.2/node_modules/@types`
- Prettier check on all changed JS, TypeScript and documentation files
