### PR TITLE
Set price support for exact prices and remaining liquidity

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -13,6 +13,19 @@ runner works.
 
 Cron times are UTC. Enable state is managed in the database, not here.
 
+The mainnet `setPrices*` actions use `--amount` as the DEX swap amount when
+fetching the reference price quote. This is separate from `--buy-amount` and
+`--sell-amount`, which set the buy-side liquidity-asset and sell-side base-asset
+liquidity remaining on the Ethena and USD ARMs. If omitted, each limit is set to
+the maximum `uint128` value. Liquidity amounts are integer native token units
+(for example, `100000000` is 100 tokens for an asset with 6 decimals).
+
+`--buy-price` and `--sell-price` bypass DEX-derived pricing and set an exact
+pair. Both must be supplied together; `--amount` is not used in this mode.
+When the Ethena or USD action derives `--amount` from withdrawable liquidity,
+it rounds the available amount up to the minimum DEX quote size of 1,000 USDe
+or 1,000 USDC respectively; an explicit `--amount` override is used as supplied.
+
 ## Lido ARM — mainnet
 
 | Action                    | Cron                    | Description                            |

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -16,13 +16,13 @@ Cron times are UTC. Enable state is managed in the database, not here.
 The mainnet `setPrices*` actions use `--amount` as the DEX swap amount when
 fetching the reference price quote. This is separate from `--buy-amount` and
 `--sell-amount`, which set the buy-side liquidity-asset and sell-side base-asset
-liquidity remaining on the Ethena and USD ARMs. If omitted, each limit is set to
+liquidity remaining on the Ethena and USDC ARMs. If omitted, each limit is set to
 the maximum `uint128` value. Liquidity amounts are integer native token units
 (for example, `100000000` is 100 tokens for an asset with 6 decimals).
 
 `--buy-price` and `--sell-price` bypass DEX-derived pricing and set an exact
 pair. Both must be supplied together; `--amount` is not used in this mode.
-When the Ethena or USD action derives `--amount` from withdrawable liquidity,
+When the Ethena or USDC action derives `--amount` from withdrawable liquidity,
 it rounds the available amount up to the minimum DEX quote size of 1,000 USDe
 or 1,000 USDC respectively; an explicit `--amount` override is used as supplied.
 

--- a/src/js/tasks/actions/setPricesEthena.ts
+++ b/src/js/tasks/actions/setPricesEthena.ts
@@ -19,6 +19,30 @@ action({
   params: (t) =>
     t
       .addOptionalParam(
+        "buyPrice",
+        "Exact buy price; when set, sellPrice must also be set (USDe per sUSDe).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
+        "sellPrice",
+        "Exact sell price; when set, buyPrice must also be set (sUSDe per USDe).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
+        "buyAmount",
+        "Liquidity asset amount remaining at the buy price for multi-base ARMs, as an integer in native token units.",
+        undefined,
+        types.string,
+      )
+      .addOptionalParam(
+        "sellAmount",
+        "Base asset amount remaining at the sell price for multi-base ARMs, as an integer in native token units.",
+        undefined,
+        types.string,
+      )
+      .addOptionalParam(
         "maxBuyPrice",
         "Upper bound for buy-side price (USDe per sUSDe).",
         0.99985,
@@ -44,7 +68,7 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "Override for the reference swap amount used when fetching aggregator quotes.",
+        "Override for the DEX swap amount used to fetch the reference price quote.",
         undefined,
         types.float,
       )
@@ -94,13 +118,16 @@ action({
     const arm = new ethers.Contract(mainnet.ethenaARM, ethenaARMAbi, signer);
 
     log.info("Setting prices for Ethena ARM");
-    const amount = await resolveEthenaAggregatorAmount({
-      arm,
-      amount: args.amount,
-      log,
-      blockTag: "latest",
-    });
-    if (amount === undefined) return;
+    const exactPrices =
+      args.buyPrice !== undefined && args.sellPrice !== undefined;
+    let amount = args.amount;
+    if (!exactPrices && amount === undefined) {
+      amount = await resolveEthenaAggregatorAmount({
+        arm,
+        log,
+        blockTag: "latest",
+      });
+    }
 
     await setPricesForBases({
       setPrices,
@@ -109,6 +136,10 @@ action({
         signer,
         arm,
         armName: "Ethena",
+        buyPrice: args.buyPrice,
+        sellPrice: args.sellPrice,
+        buyAmount: args.buyAmount,
+        sellAmount: args.sellAmount,
         maxSellPrice: args.maxSellPrice,
         minSellPrice: args.minSellPrice,
         maxBuyPrice: args.maxBuyPrice,

--- a/src/js/tasks/actions/setPricesEtherFi.ts
+++ b/src/js/tasks/actions/setPricesEtherFi.ts
@@ -18,6 +18,18 @@ action({
   params: (t) =>
     t
       .addOptionalParam(
+        "buyPrice",
+        "Exact buy price; when set, sellPrice must also be set (ETH per base asset).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
+        "sellPrice",
+        "Exact sell price; when set, buyPrice must also be set (base asset per ETH).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
         "maxBuyPrice",
         "Upper bound for buy-side price (ETH per eETH).",
         0.9998,
@@ -43,7 +55,7 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "Reference swap amount used when fetching aggregator quotes.",
+        "DEX swap amount used to fetch the reference price quote.",
         20,
         types.float,
       )
@@ -100,6 +112,8 @@ action({
         signer,
         arm,
         armName: "EtherFi",
+        buyPrice: args.buyPrice,
+        sellPrice: args.sellPrice,
         maxSellPrice: args.maxSellPrice,
         minSellPrice: args.minSellPrice,
         maxBuyPrice: args.maxBuyPrice,

--- a/src/js/tasks/actions/setPricesLido.ts
+++ b/src/js/tasks/actions/setPricesLido.ts
@@ -18,6 +18,18 @@ action({
   params: (t) =>
     t
       .addOptionalParam(
+        "buyPrice",
+        "Exact buy price; when set, sellPrice must also be set (ETH per base asset).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
+        "sellPrice",
+        "Exact sell price; when set, buyPrice must also be set (base asset per ETH).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
         "maxBuyPrice",
         "Upper bound for buy-side price (ETH per stETH).",
         0.9999,
@@ -43,7 +55,7 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "Reference swap amount used when fetching aggregator quotes.",
+        "DEX swap amount used to fetch the reference price quote.",
         20,
         types.float,
       )
@@ -100,6 +112,8 @@ action({
         signer,
         arm,
         armName: "Lido",
+        buyPrice: args.buyPrice,
+        sellPrice: args.sellPrice,
         maxSellPrice: args.maxSellPrice,
         minSellPrice: args.minSellPrice,
         maxBuyPrice: args.maxBuyPrice,

--- a/src/js/tasks/actions/setPricesOETH.ts
+++ b/src/js/tasks/actions/setPricesOETH.ts
@@ -18,6 +18,18 @@ action({
   params: (t) =>
     t
       .addOptionalParam(
+        "buyPrice",
+        "Exact buy price; when set, sellPrice must also be set (WETH per base asset).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
+        "sellPrice",
+        "Exact sell price; when set, buyPrice must also be set (base asset per WETH).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
         "maxBuyPrice",
         "Upper bound for buy-side price (WETH per OETH).",
         0.9995,
@@ -43,7 +55,7 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "Reference swap amount used when fetching aggregator quotes.",
+        "DEX swap amount used to fetch the reference price quote.",
         10,
         types.float,
       )
@@ -100,6 +112,8 @@ action({
         signer,
         arm,
         armName: "Oeth",
+        buyPrice: args.buyPrice,
+        sellPrice: args.sellPrice,
         maxSellPrice: args.maxSellPrice,
         minSellPrice: args.minSellPrice,
         maxBuyPrice: args.maxBuyPrice,

--- a/src/js/tasks/actions/setPricesUSD.ts
+++ b/src/js/tasks/actions/setPricesUSD.ts
@@ -121,7 +121,7 @@ action({
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.usdARM, multiAssetARMAbi, signer);
 
-    log.info("Setting prices for USD ARM");
+    log.info("Setting prices for USDC ARM");
     const exactPrices =
       args.buyPrice !== undefined && args.sellPrice !== undefined;
     let amount = args.amount;
@@ -139,7 +139,7 @@ action({
       options: {
         signer,
         arm,
-        armName: "USD",
+        armName: "USDC",
         buyPrice: args.buyPrice,
         sellPrice: args.sellPrice,
         buyAmount: args.buyAmount,

--- a/src/js/tasks/actions/setPricesUSD.ts
+++ b/src/js/tasks/actions/setPricesUSD.ts
@@ -23,6 +23,30 @@ action({
         types.string,
       )
       .addOptionalParam(
+        "buyPrice",
+        "Exact buy price; when set, sellPrice must also be set (USDC per base asset).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
+        "sellPrice",
+        "Exact sell price; when set, buyPrice must also be set (base asset per USDC).",
+        undefined,
+        types.float,
+      )
+      .addOptionalParam(
+        "buyAmount",
+        "Liquidity asset amount remaining at the buy price for multi-base ARMs, as an integer in native token units.",
+        undefined,
+        types.string,
+      )
+      .addOptionalParam(
+        "sellAmount",
+        "Base asset amount remaining at the sell price for multi-base ARMs, as an integer in native token units.",
+        undefined,
+        types.string,
+      )
+      .addOptionalParam(
         "maxBuyPrice",
         "Upper bound for buy-side price (USDC per base asset).",
         0.99995,
@@ -48,7 +72,7 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "Override for the reference swap amount used when fetching aggregator quotes.",
+        "Override for the DEX swap amount used to fetch the reference price quote.",
         undefined,
         types.float,
       )
@@ -98,13 +122,16 @@ action({
     const arm = new ethers.Contract(mainnet.usdARM, multiAssetARMAbi, signer);
 
     log.info("Setting prices for USD ARM");
-    const amount = await resolveUsdAggregatorAmount({
-      arm,
-      amount: args.amount,
-      log,
-      blockTag: "latest",
-    });
-    if (amount === undefined) return;
+    const exactPrices =
+      args.buyPrice !== undefined && args.sellPrice !== undefined;
+    let amount = args.amount;
+    if (!exactPrices && amount === undefined) {
+      amount = await resolveUsdAggregatorAmount({
+        arm,
+        log,
+        blockTag: "latest",
+      });
+    }
 
     await setPricesForBases({
       setPrices,
@@ -113,6 +140,10 @@ action({
         signer,
         arm,
         armName: "USD",
+        buyPrice: args.buyPrice,
+        sellPrice: args.sellPrice,
+        buyAmount: args.buyAmount,
+        sellAmount: args.sellAmount,
         maxSellPrice: args.maxSellPrice,
         minSellPrice: args.minSellPrice,
         maxBuyPrice: args.maxBuyPrice,

--- a/src/js/utils/ethenaPricing.js
+++ b/src/js/utils/ethenaPricing.js
@@ -1,8 +1,8 @@
-const { formatUnits } = require("ethers");
+const { formatUnits, parseUnits } = require("ethers");
 
 const { resolveArmBase } = require("./arm");
 
-const DEFAULT_ETHENA_AGGREGATOR_AMOUNT = 2000;
+const MIN_ETHENA_AGGREGATOR_AMOUNT = parseUnits("1000", 18); // 1,000 USDe
 
 const hasAmountOverride = (amount) => amount !== undefined && amount !== null;
 
@@ -15,7 +15,7 @@ const resolveEthenaAggregatorAmount = async ({
   log,
   blockTag = "latest",
   resolveArmBaseFn = resolveArmBase,
-  defaultAmount = DEFAULT_ETHENA_AGGREGATOR_AMOUNT,
+  minAmount = MIN_ETHENA_AGGREGATOR_AMOUNT,
 }) => {
   if (hasAmountOverride(amount)) {
     log?.info?.(`Using configured aggregator quote amount: ${amount} USDe`);
@@ -30,10 +30,11 @@ const resolveEthenaAggregatorAmount = async ({
   });
 
   if (baseContext.version !== "multiBase") {
+    const formattedMinAmount = formatUnits(minAmount, 18);
     log?.info?.(
-      `Using default aggregator quote amount for legacy Ethena ARM: ${defaultAmount} USDe`,
+      `Using minimum aggregator quote amount for legacy Ethena ARM: ${formattedMinAmount} USDe`,
     );
-    return defaultAmount;
+    return formattedMinAmount;
   }
 
   const reserves = await arm.getReserves(baseContext.baseAddress, {
@@ -41,11 +42,11 @@ const resolveEthenaAggregatorAmount = async ({
   });
   const liquidityAssets = readReserveLiquidity(reserves);
 
-  if (liquidityAssets === 0n) {
+  if (liquidityAssets < minAmount) {
     log?.info?.(
-      "Skipping Ethena price update: no withdrawable USDe available in ARM or lending market",
+      `Using minimum aggregator quote amount of ${formatUnits(minAmount, 18)} USDe; only ${formatUnits(liquidityAssets, 18)} USDe is withdrawable in ARM and lending market`,
     );
-    return undefined;
+    return formatUnits(minAmount, 18);
   }
 
   const resolvedAmount = formatUnits(liquidityAssets, 18);
@@ -56,6 +57,6 @@ const resolveEthenaAggregatorAmount = async ({
 };
 
 module.exports = {
-  DEFAULT_ETHENA_AGGREGATOR_AMOUNT,
+  MIN_ETHENA_AGGREGATOR_AMOUNT,
   resolveEthenaAggregatorAmount,
 };

--- a/src/js/utils/usdPricing.js
+++ b/src/js/utils/usdPricing.js
@@ -4,7 +4,7 @@ const { resolveArmBase } = require("./arm");
 
 // Below this the aggregators return unusable quotes: dust amounts get
 // quantized into garbage price ratios and Kyber rejects the request outright
-const MIN_USD_AGGREGATOR_AMOUNT = parseUnits("100", 6); // 100 USDC
+const MIN_USD_AGGREGATOR_AMOUNT = parseUnits("1000", 6); // 1,000 USDC
 
 const hasAmountOverride = (amount) => amount !== undefined && amount !== null;
 
@@ -39,9 +39,9 @@ const resolveUsdAggregatorAmount = async ({
 
   if (liquidityAssets < MIN_USD_AGGREGATOR_AMOUNT) {
     log?.info?.(
-      `Skipping USD price update: only ${formatUnits(liquidityAssets, 6)} USDC withdrawable in ARM and lending market, below the ${formatUnits(MIN_USD_AGGREGATOR_AMOUNT, 6)} USDC minimum aggregator quote amount`,
+      `Using minimum aggregator quote amount of ${formatUnits(MIN_USD_AGGREGATOR_AMOUNT, 6)} USDC; only ${formatUnits(liquidityAssets, 6)} USDC is withdrawable in ARM and lending market`,
     );
-    return undefined;
+    return formatUnits(MIN_USD_AGGREGATOR_AMOUNT, 6);
   }
 
   const resolvedAmount = formatUnits(liquidityAssets, 6);
@@ -52,5 +52,6 @@ const resolveUsdAggregatorAmount = async ({
 };
 
 module.exports = {
+  MIN_USD_AGGREGATOR_AMOUNT,
   resolveUsdAggregatorAmount,
 };

--- a/test/js/ethenaPricing.test.js
+++ b/test/js/ethenaPricing.test.js
@@ -3,7 +3,7 @@ const assert = require("assert");
 const { parseUnits } = require("ethers");
 
 const {
-  DEFAULT_ETHENA_AGGREGATOR_AMOUNT,
+  MIN_ETHENA_AGGREGATOR_AMOUNT,
   resolveEthenaAggregatorAmount,
 } = require("../../src/js/utils/ethenaPricing");
 
@@ -56,43 +56,43 @@ const run = async () => {
       arm: {
         getReserves: async (baseAddress) => {
           requestedBaseAddress = baseAddress;
-          return [parseUnits("789.123", 18), 0n];
+          return [parseUnits("2789.123", 18), 0n];
         },
       },
       resolveArmBaseFn: multiBaseResolver,
     });
 
     assert.strictEqual(requestedBaseAddress, sUSDe);
-    assert.strictEqual(amount, "789.123");
+    assert.strictEqual(amount, "2789.123");
   }
 
   {
     const amount = await resolveEthenaAggregatorAmount({
       arm: {
         getReserves: async () => ({
-          liquidityAssets: parseUnits("321", 18),
+          liquidityAssets: MIN_ETHENA_AGGREGATOR_AMOUNT,
           baseAssetReserve: 0n,
         }),
       },
       resolveArmBaseFn: multiBaseResolver,
     });
 
-    assert.strictEqual(amount, "321.0");
+    assert.strictEqual(amount, "1000.0");
   }
 
   {
     const log = logger();
     const amount = await resolveEthenaAggregatorAmount({
       arm: {
-        getReserves: async () => [0n, 0n],
+        getReserves: async () => [parseUnits("999.999", 18), 0n],
       },
       log,
       resolveArmBaseFn: multiBaseResolver,
     });
 
-    assert.strictEqual(amount, undefined);
+    assert.strictEqual(amount, "1000.0");
     assert.deepStrictEqual(log.messages, [
-      "Skipping Ethena price update: no withdrawable USDe available in ARM or lending market",
+      "Using minimum aggregator quote amount of 1000.0 USDe; only 999.999 USDe is withdrawable in ARM and lending market",
     ]);
   }
 
@@ -108,7 +108,7 @@ const run = async () => {
       resolveArmBaseFn: legacyResolver,
     });
 
-    assert.strictEqual(amount, DEFAULT_ETHENA_AGGREGATOR_AMOUNT);
+    assert.strictEqual(amount, "1000.0");
     assert.strictEqual(getReservesCalled, false);
   }
 
@@ -116,7 +116,7 @@ const run = async () => {
     let commonPricingAmount;
     const resolvedAmount = await resolveEthenaAggregatorAmount({
       arm: {
-        getReserves: async () => [parseUnits("654", 18), 0n],
+        getReserves: async () => [parseUnits("2654", 18), 0n],
       },
       resolveArmBaseFn: multiBaseResolver,
     });
@@ -132,7 +132,7 @@ const run = async () => {
       },
     });
 
-    assert.strictEqual(commonPricingAmount, "654.0");
+    assert.strictEqual(commonPricingAmount, "2654.0");
   }
 };
 

--- a/test/js/usdPricing.test.js
+++ b/test/js/usdPricing.test.js
@@ -1,0 +1,89 @@
+const assert = require("assert");
+
+const { parseUnits } = require("ethers");
+
+const {
+  MIN_USD_AGGREGATOR_AMOUNT,
+  resolveUsdAggregatorAmount,
+} = require("../../src/js/utils/usdPricing");
+
+const PYUSD = "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8";
+
+const logger = () => {
+  const messages = [];
+  return {
+    messages,
+    info: (message) => messages.push(message),
+  };
+};
+
+const multiBaseResolver = async () => ({
+  version: "multiBase",
+  baseAddress: PYUSD,
+});
+
+const run = async () => {
+  {
+    let getReservesCalled = false;
+    const amount = await resolveUsdAggregatorAmount({
+      amount: 123,
+      arm: {
+        getReserves: async () => {
+          getReservesCalled = true;
+          return [parseUnits("456", 6), 0n];
+        },
+      },
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(amount, 123);
+    assert.strictEqual(getReservesCalled, false);
+  }
+
+  {
+    const log = logger();
+    const amount = await resolveUsdAggregatorAmount({
+      arm: {
+        getReserves: async () => [parseUnits("999.999999", 6), 0n],
+      },
+      log,
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(amount, "1000.0");
+    assert.deepStrictEqual(log.messages, [
+      "Using minimum aggregator quote amount of 1000.0 USDC; only 999.999999 USDC is withdrawable in ARM and lending market",
+    ]);
+  }
+
+  {
+    const amount = await resolveUsdAggregatorAmount({
+      arm: {
+        getReserves: async () => [MIN_USD_AGGREGATOR_AMOUNT, 0n],
+      },
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(amount, "1000.0");
+  }
+
+  {
+    const amount = await resolveUsdAggregatorAmount({
+      arm: {
+        getReserves: async () => [parseUnits("1654.25", 6), 0n],
+      },
+      resolveArmBaseFn: multiBaseResolver,
+    });
+
+    assert.strictEqual(amount, "1654.25");
+  }
+};
+
+run()
+  .then(() => {
+    console.log("usdPricing tests passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary

- Add `--buy-price` and `--sell-price` overrides to the Lido, EtherFi, OETH, Ethena, and USD Talos price actions.
- Bypass DEX-derived pricing when both exact prices are supplied.
- Add `--buy-amount` and `--sell-amount` liquidity-remaining parameters for the Ethena and USD ARMs.
- Keep `--amount` specifically for the DEX reference quote size.
- Use an explicit `--amount` directly instead of resolving it from ARM liquidity.
- Floor dynamically resolved Ethena and USD quote amounts at 1,000 USDe or USDC.
- Document the new Talos parameters and their units.

Needs Talos PR https://github.com/oplabs/talos/pull/18