### PR TITLE
fix(invariants): account for ERC4626 market rounding

### DIFF
--- a/test/invariants/LidoARM/FuzzerFoundry.t.sol
+++ b/test/invariants/LidoARM/FuzzerFoundry.t.sol
@@ -101,6 +101,25 @@ contract FuzzerFoundry_LidoARM is Properties {
         require(property_bal_wsteth(), "BAL_WSTETH: wstETH balance mismatch");
     }
 
+    function test_marketRotationRoundingLossIsAccountedFor() public {
+        targetDeposit(23_061, 1);
+        targetRequestRedeem(14_558, 1);
+
+        for (uint256 i; i < 36; ++i) {
+            targetSetActiveMarket(1);
+        }
+
+        targetRequestRedeem(558, 1);
+
+        for (uint256 i; i < 40; ++i) {
+            targetSetActiveMarket(1);
+        }
+
+        assertEq(sum_weth_marketRoundingLoss, 101, "tracked market rounding loss");
+        assertTrue(property_bal_weth(), "WETH balance conservation");
+        assertEq(maxWethBalanceDrift(), 0, "unaccounted WETH drift");
+    }
+
     /// @notice Optimization: fuzzer maximizes the worst-case LP rounding loss.
     function invariant_optimize_maxLpLoss() public view returns (int256) {
         return maxLpLoss();

--- a/test/invariants/LidoARM/Properties.t.sol
+++ b/test/invariants/LidoARM/Properties.t.sol
@@ -45,7 +45,7 @@ abstract contract Properties is TargetFunction {
     // [x] Invariant N: WETH balance + market value >= MIN_TOTAL_SUPPLY
     //                   + ∑deposit + ∑swapIn + ∑baseRedeemClaimed + ∑donated
     //                   - ∑swapOut - ∑userClaimed - ∑feesCollected
-    //                   (100 wei tolerance — optimization found worst-case 27 wei / 250k txs)
+    //                   - bounded ERC4626 market rounding losses tracked by the handlers
     // [x] Invariant O: stETH balance == ∑swapIn + ∑donated + ∑rebased
     //                                    - ∑swapOut - ∑baseRedeemRequested
     // [x] Invariant P: wstETH balance == ∑swapIn + ∑donated
@@ -206,11 +206,9 @@ abstract contract Properties is TargetFunction {
             MIN_TOTAL_SUPPLY + sum_weth_deposit + sum_weth_swapIn + sum_weth_baseRedeemClaimed + sum_weth_donated;
         uint256 outflows = sum_weth_swapOut + sum_weth_userClaimed + sum_weth_feesCollected;
 
-        // Rewrite as: lhs + outflows + tolerance >= inflows (avoids underflow)
+        // Rewrite as: lhs + outflows + tracked rounding losses >= inflows (avoids underflow)
         // Market yield can make lhs > inflows - outflows (ARM gained value from yield).
-        // ERC4626 rounding can lose a few wei per cycle.
-        // Optimization mode found worst-case of 27 wei over ~250k txs.
-        return armWeth + wethInMarkets + outflows + 100 >= inflows;
+        return armWeth + wethInMarkets + outflows + sum_weth_marketRoundingLoss >= inflows;
     }
 
     // 15. stETH balance == inflows - outflows
@@ -239,7 +237,7 @@ abstract contract Properties is TargetFunction {
     /// --- OPTIMIZATION METRICS
     ////////////////////////////////////////////////////
 
-    /// @notice Max WETH rounding loss from market deposit/withdraw cycles.
+    /// @notice Max unaccounted WETH loss after bounded market rounding is removed.
     function maxWethBalanceDrift() public view returns (int256) {
         uint256 armWeth = weth.balanceOf(address(lidoARM));
         uint256 wethInMarkets = IERC4626(address(mockERC4626Market_A))
@@ -251,8 +249,8 @@ abstract contract Properties is TargetFunction {
             MIN_TOTAL_SUPPLY + sum_weth_deposit + sum_weth_swapIn + sum_weth_baseRedeemClaimed + sum_weth_donated;
         uint256 outflows = sum_weth_swapOut + sum_weth_userClaimed + sum_weth_feesCollected;
 
-        uint256 lhs = armWeth + wethInMarkets + outflows;
-        // Return how much inflows exceeds lhs (positive = loss)
+        uint256 lhs = armWeth + wethInMarkets + outflows + sum_weth_marketRoundingLoss;
+        // Return how much inflows exceeds the rounding-adjusted lhs (positive = unexplained loss)
         if (inflows > lhs) return int256(inflows - lhs);
         return 0;
     }

--- a/test/invariants/LidoARM/TargetFunction.t.sol
+++ b/test/invariants/LidoARM/TargetFunction.t.sol
@@ -60,7 +60,12 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     function targetSwapExactTokensForTokens(uint256 amount, uint256 baseAssetSeed, uint256 sideSeed)
         public
         ensureSharePriceNotDecreased
+        trackWethMarketRounding
     {
+        _targetSwapExactTokensForTokens(amount, baseAssetSeed, sideSeed);
+    }
+
+    function _targetSwapExactTokensForTokens(uint256 amount, uint256 baseAssetSeed, uint256 sideSeed) internal {
         bool stETHOrWstETH = baseAssetSeed % 2 == 0;
         bool buyOrSell = sideSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
@@ -137,7 +142,12 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     function targetSwapTokensForExactTokens(uint256 amount, uint256 baseAssetSeed, uint256 sideSeed)
         public
         ensureSharePriceNotDecreased
+        trackWethMarketRounding
     {
+        _targetSwapTokensForExactTokens(amount, baseAssetSeed, sideSeed);
+    }
+
+    function _targetSwapTokensForExactTokens(uint256 amount, uint256 baseAssetSeed, uint256 sideSeed) internal {
         bool stETHOrWstETH = baseAssetSeed % 2 == 0;
         bool buyOrSell = sideSeed % 2 == 0;
         address baseAsset = stETHOrWstETH ? address(steth) : address(wsteth);
@@ -251,7 +261,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         shuffle(_pendingRequestIds, from); // Shuffle pending request IDs to ensure randomness in claim
     }
 
-    function targetClaimRedeem(uint256 seed) public ensureSharePriceNotDecreased {
+    function targetClaimRedeem(uint256 seed) public ensureSharePriceNotDecreased trackWethMarketRounding {
         (address user, uint256 requestId, uint256 positionInList) = selectUserWithPendingRequest();
         vm.assume(user != address(0));
 
@@ -397,7 +407,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
     ////////////////////////////////////////////////////
     /// --- LIQUIDITY MANAGMENT
     ////////////////////////////////////////////////////
-    function targetSetActiveMarket(uint256 seed) public ensureSharePriceNotDecreased {
+    function targetSetActiveMarket(uint256 seed) public ensureSharePriceNotDecreased trackWethMarketRounding {
         address current = lidoARM.activeMarket();
         address[3] memory candidates = [address(0), address(mockERC4626Market_A), address(mockERC4626Market_B)];
 
@@ -427,7 +437,7 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetAllocate() public ensureSharePriceNotDecreased {
+    function targetAllocate() public ensureSharePriceNotDecreased trackWethMarketRounding {
         vm.assume(lidoARM.activeMarket() != address(0));
 
         (int256 target, int256 actual) = lidoARM.allocate();
@@ -492,7 +502,11 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetMarketDeposit(uint256 amount, uint256 marketSeed) public ensureSharePriceNotDecreased {
+    function targetMarketDeposit(uint256 amount, uint256 marketSeed)
+        public
+        ensureSharePriceNotDecreased
+        trackWethMarketRounding
+    {
         bool marketA = marketSeed % 2 == 0;
         MockMorpho market = marketA ? mockERC4626Market_A : mockERC4626Market_B;
         uint256 bal = weth.balanceOf(hanna);
@@ -511,7 +525,11 @@ abstract contract TargetFunction is Invariant_LidoARM_Setup_Test {
         }
     }
 
-    function targetMarketWithdraw(uint256 amount, uint256 marketSeed) public ensureSharePriceNotDecreased {
+    function targetMarketWithdraw(uint256 amount, uint256 marketSeed)
+        public
+        ensureSharePriceNotDecreased
+        trackWethMarketRounding
+    {
         bool marketA = marketSeed % 2 == 0;
         MockMorpho market = marketA ? mockERC4626Market_A : mockERC4626Market_B;
         uint256 maxW = market.maxWithdraw(hanna);

--- a/test/invariants/LidoARM/base/Base.t.sol
+++ b/test/invariants/LidoARM/base/Base.t.sol
@@ -127,6 +127,8 @@ abstract contract Base_Test_ is Test {
 
     // Market yield accrued to ARM
     uint256 internal sum_weth_marketYield;
+    // WETH value lost to bounded ERC4626 rounding while interacting with lending markets
+    uint256 internal sum_weth_marketRoundingLoss;
 
     // Share price tracking
     uint256 internal ghost_lastSharePrice;

--- a/test/invariants/LidoARM/helpers/Helpers.t.sol
+++ b/test/invariants/LidoARM/helpers/Helpers.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.23;
 
 import {Vm} from "forge-std/Vm.sol";
 import {Base_Test_} from "../base/Base.t.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 // Mocks
 import {MockERC20} from "@solmate/test/utils/mocks/MockERC20.sol";
@@ -28,6 +29,49 @@ abstract contract Helpers is Base_Test_ {
         _;
         ghost_lastSharePrice = lidoARM.totalAssets() * 1e18 / lidoARM.totalSupply();
         ghost_crossPriceChanged = true;
+    }
+
+    /// @dev Tracks WETH value lost to ERC4626 rounding and rejects losses larger than one market share.
+    modifier trackWethMarketRounding() {
+        int256 valueBefore = _netTrackedWethValue();
+        uint256 maxLossBefore = _maxMarketShareValue();
+        _;
+        int256 valueAfter = _netTrackedWethValue();
+
+        if (valueAfter < valueBefore) {
+            uint256 loss = uint256(valueBefore - valueAfter);
+            uint256 maxLossAfter = _maxMarketShareValue();
+            uint256 maxExpectedLoss = maxLossBefore > maxLossAfter ? maxLossBefore : maxLossAfter;
+            require(loss <= maxExpectedLoss, "MARKET_ROUNDING_EXCEEDED");
+            sum_weth_marketRoundingLoss += loss;
+        }
+    }
+
+    /// @dev WETH held by the ARM and its markets, adjusted for tracked external flows.
+    function _netTrackedWethValue() internal view returns (int256) {
+        uint256 armAndMarketValue = weth.balanceOf(address(lidoARM))
+            + IERC4626(address(mockERC4626Market_A))
+                .convertToAssets(IERC4626(address(mockERC4626Market_A)).balanceOf(address(lidoARM)))
+            + IERC4626(address(mockERC4626Market_B))
+                .convertToAssets(IERC4626(address(mockERC4626Market_B)).balanceOf(address(lidoARM)));
+        uint256 inflows = sum_weth_deposit + sum_weth_swapIn + sum_weth_baseRedeemClaimed + sum_weth_donated;
+        uint256 outflows = sum_weth_swapOut + sum_weth_userClaimed + sum_weth_feesCollected;
+
+        return int256(armAndMarketValue + outflows) - int256(inflows);
+    }
+
+    /// @dev Maximum value of one market share, rounded up to WETH wei.
+    function _maxMarketShareValue() internal view returns (uint256) {
+        uint256 valueA = _marketShareValue(IERC4626(address(mockERC4626Market_A)));
+        uint256 valueB = _marketShareValue(IERC4626(address(mockERC4626Market_B)));
+        return valueA > valueB ? valueA : valueB;
+    }
+
+    function _marketShareValue(IERC4626 market) private view returns (uint256) {
+        uint256 supply = market.totalSupply();
+        uint256 assets = market.totalAssets();
+        if (supply == 0 || assets == 0) return 1;
+        return (assets - 1) / supply + 1;
     }
 
     ////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- replace the fixed 100 wei WETH conservation tolerance with exact ghost accounting for ERC4626 market rounding
- bound every recorded loss to at most one market share value so unexpected losses still fail the invariant
- cover handlers that can deposit into, withdraw from, or revalue the ARM market position
- add a deterministic regression for the CI counterexample: 101 wei of cumulative rounding after 76 market rotations

## Root cause

The failing LidoARM invariant alternates the active market 76 times. Each ERC4626 deposit rounds minted shares down and can lose up to two wei at the mocked market exchange rates. The cumulative loss is 101 wei, which exceeds the previous fixed 100 wei tolerance by one wei.

This is expected bounded ERC4626 rounding rather than an unexplained balance loss. A fixed tolerance is not invariant-safe because the loss grows with the number of market interactions.

Failing job: https://github.com/OriginProtocol/arm-oeth/actions/runs/29904352973/job/88872109503

## Testing

- `forge build`
- `forge fmt --check`
- `forge test --summary --fail-fast --show-progress --mp 'test/unit/**'`
- `FOUNDRY_PROFILE=lite FOUNDRY_INVARIANT_FAIL_ON_REVERT=true forge test --match-contract FuzzerFoundry_LidoARM -vv`
- `forge test --match-contract FuzzerFoundry_LidoARM --fuzz-seed 0xcd574f81fe803283b87931d638f92df2698e5688c663d73b5d0bb1865ecb2161 -vv`

No production contract code is changed.
