### PR TITLE
[ARM] Deploy 039 USDC ARM on mainnet

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -191,6 +191,38 @@
         {
             "implementation": "0xf9cEDb3154c6502328C7B09c773a43a0b9C801eb",
             "name": "ETH_ARM_WEETH_ADAPTER"
+        },
+        {
+            "implementation": "0x9E3A7026E5767F2d7Ff5e83b0ed011005f45a170",
+            "name": "USDC_ARM"
+        },
+        {
+            "implementation": "0x19B1Edb2caD902F103a20A30011f125DCe44F954",
+            "name": "USDC_ARM_CAP_MAN"
+        },
+        {
+            "implementation": "0xDdF1954db1Ace4a58E07a4D25C0818aC977cb8bd",
+            "name": "USDC_ARM_CAP_IMPL"
+        },
+        {
+            "implementation": "0xef40f3548ec3277ade0eb88DbB80ebF63Ea59a96",
+            "name": "USDC_ARM_IMPL"
+        },
+        {
+            "implementation": "0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8",
+            "name": "USDC_ARM_PYUSD_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465",
+            "name": "USDC_ARM_PYUSD_ADAPTER"
+        },
+        {
+            "implementation": "0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05",
+            "name": "USDC_ARM_USDG_ADAPTER_IMPL"
+        },
+        {
+            "implementation": "0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f",
+            "name": "USDC_ARM_USDG_ADAPTER"
         }
     ],
     "executions": [
@@ -391,6 +423,12 @@
             "proposalId": 1,
             "tsDeployment": 1783504775,
             "tsGovernance": 1
+        },
+        {
+            "name": "039_DeployUSDCARMScript",
+            "proposalId": 1,
+            "tsDeployment": 1784724659,
+            "tsGovernance": 0
         }
     ]
 }

--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -428,7 +428,7 @@
             "name": "039_DeployUSDCARMScript",
             "proposalId": 1,
             "tsDeployment": 1784724659,
-            "tsGovernance": 0
+            "tsGovernance": 1
         }
     ]
 }

--- a/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
+++ b/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
@@ -51,6 +51,9 @@ contract $037_DeployUSDARMScript is AbstractDeployScript("037_DeployUSDARMScript
     ///      of USDC (0.000001 USDC) that initialize() pulls.
     uint256 internal constant USDC_SEED = 1000;
 
+    // Legacy deploy code. Replaced by 039_DeployUSDCARMScript.s.sol.
+    bool public constant override skip = true;
+
     function _execute() internal override {
         // 1. Deploy the ARM proxy.
         Proxy armProxy = new Proxy();


### PR DESCRIPTION
# Description

Record the mainnet deployment of the **USDC ARM**: a USDC-quoted `MultiAssetARM` with two Paxos-issued base assets. The deployment reuses the existing Paxos-whitelisted adapter proxies and deploys a new `PaxosAssetAdapter` implementation for each proxy:

- **PYUSD** — pegged 1:1 to USDC, redeemed off-chain through Paxos Actions that settle USDC back to the adapter.
- **USDG** — pegged 1:1 to USDC, using the same off-chain Paxos redemption flow.

Ownership of the ARM, its `CapManager`, and both reused adapter proxies is held by the mainnet 2/8 multisig (`MULTISIG_2_OF_8`). The operational role is the Talos KMS relayer (`ARM_TALOS_RELAYER`). No lending market is wired up; idle USDC remains in the ARM until a market is added in a follow-up deployment.

This deployment supersedes the legacy USD ARM deployed by `037_DeployUSDARMScript`. The legacy resolver entries and execution history remain recorded because `039` reuses the existing Paxos adapter proxies, while the old deployment script is explicitly skipped.

> The companion WETH-quoted ARM deployed in the same round is recorded in #314.

The following PRs are included in this deployment:

### ARM

- https://github.com/OriginProtocol/arm-oeth/pull/310
- https://github.com/OriginProtocol/arm-oeth/pull/311
- https://github.com/OriginProtocol/arm-oeth/pull/312

## Deployment

Script `script/deploy/mainnet/039_DeployUSDCARMScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| USDC ARM (`MultiAssetARM`) proxy | [0x9E3A7026E5767F2d7Ff5e83b0ed011005f45a170](https://etherscan.io/address/0x9E3A7026E5767F2d7Ff5e83b0ed011005f45a170) |
| USDC ARM implementation (`MultiAssetARM`) | [0xef40f3548ec3277ade0eb88DbB80ebF63Ea59a96](https://etherscan.io/address/0xef40f3548ec3277ade0eb88DbB80ebF63Ea59a96) |
| USDC ARM `CapManager` proxy | [0x19B1Edb2caD902F103a20A30011f125DCe44F954](https://etherscan.io/address/0x19B1Edb2caD902F103a20A30011f125DCe44F954) |
| USDC ARM `CapManager` implementation | [0xDdF1954db1Ace4a58E07a4D25C0818aC977cb8bd](https://etherscan.io/address/0xDdF1954db1Ace4a58E07a4D25C0818aC977cb8bd) |
| New `PaxosAssetAdapter` (PYUSD) implementation | [0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8](https://etherscan.io/address/0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8) |
| Reused `PaxosAssetAdapter` (PYUSD) proxy | [0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465](https://etherscan.io/address/0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465) |
| New `PaxosAssetAdapter` (USDG) implementation | [0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05](https://etherscan.io/address/0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05) |
| Reused `PaxosAssetAdapter` (USDG) proxy | [0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f](https://etherscan.io/address/0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f) |

## Contract diff

```python
make match file=src/contracts/Proxy.sol addr=0x9E3A7026E5767F2d7Ff5e83b0ed011005f45a170
make match file=src/contracts/MultiAssetARM.sol addr=0xef40f3548ec3277ade0eb88DbB80ebF63Ea59a96
make match file=src/contracts/Proxy.sol addr=0x19B1Edb2caD902F103a20A30011f125DCe44F954
make match file=src/contracts/CapManager.sol addr=0xDdF1954db1Ace4a58E07a4D25C0818aC977cb8bd
make match file=src/contracts/adapters/PaxosAssetAdapter.sol addr=0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8
make match file=src/contracts/Proxy.sol addr=0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465
make match file=src/contracts/adapters/PaxosAssetAdapter.sol addr=0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05
make match file=src/contracts/Proxy.sol addr=0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f
```

## Configuration

| Param | Value | Note |
| - | - | - |
| `liquidityAsset` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` | USDC |
| `claimDelay` | `10 minutes` | |
| `minSharesToRedeem` | `1e6` | 1 USDC |
| `allocateThreshold` | `100e6` | 100 USDC |
| `name` / `symbol` | `USDC ARM` / `ARM-USDC` | |
| performance fee | `2000` | 20% |
| fee collector | `0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c` | `BUYBACK_OPERATOR` |
| `owner` | `0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971` | Mainnet 2/8 multisig |
| ARM / CapManager `operator` | `0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b` | `ARM_TALOS_RELAYER` |

**CapManager:** total-assets cap `100,000e6` (100,000 USDC), account cap enabled, per-LP cap `100,000e6` for `TREASURY_LP` (`0x6E3fddab68Bf1EBaf9daCF9F7907c7Bc0951D1dc`).

### `addBaseAsset` parameters

| Base asset | Adapter proxy | Buy price | Sell price | Cross price | Pegged to USDC |
| - | - | - | - | - | - |
| PYUSD | `0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465` | `0.998e36` | `1e36` | `0.99997e36` | `true` |
| USDG | `0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f` | `0.998e36` | `1e36` | `0.99997e36` | `true` |

Both assets start with `buyAmount = 0` and `sellAmount = 0`; trading remains disabled until the operator sets swap limits with `setPrices()`.

## Governance

There is no `GovernorSix` proposal. Ownership of the ARM and `CapManager` was transferred directly to the mainnet 2/8 multisig during deployment. The two reused Paxos adapter proxies were already owned by the same multisig.

`039_DeployUSDCARMScript` is recorded with `proposalId: 1` and `tsGovernance: 0` because the adapter proxy upgrades are still pending manual execution by the 2/8 multisig.

## Required post-deployment actions (2/8 multisig)

The mainnet 2/8 multisig **must manually upgrade both reused adapter proxies**:

| Proxy | Current implementation | Required new implementation | Action |
| - | - | - | - |
| PYUSD `0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465` | `0x50223D4f7c027DF74939555E92584C6332c613B2` | `0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8` | `upgradeTo(0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8)` |
| USDG `0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f` | `0x7c4c0B599E17C3Ad4ae37Ba61Eef50980e13203B` | `0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05` | `upgradeTo(0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05)` |

Until these upgrades are executed, the reused proxies still target the legacy USD ARM adapter implementations, so the new USDC ARM redemption paths are not operational. Once both upgrades are confirmed on-chain, update `tsGovernance` to `1` in `build/deployments-1.json`.

## Other post-deployment follow-ups (operator)

- **Enable trading.** `buyAmount` and `sellAmount` are `0` for both assets. Talos must set the intended swap limits through `setPrices()` before swaps are enabled.

## Tests

- `forge build`
- `forge test --match-contract Fork_PaxosARM_Smoke_Test --fork-url "$MAINNET_URL" -vv` — 7/7 tests passed. Because `tsGovernance` is pending, the deployment framework simulates both 2/8 proxy upgrades on the fork before running the smoke tests.
- Confirmed on-chain that the USDC ARM and `CapManager` proxies point to the implementations recorded above and are administered by the mainnet 2/8 multisig.
- Confirmed on-chain that the PYUSD and USDG proxies are still administered by the 2/8 multisig and currently point to the legacy implementations listed in the upgrade table.
