### PR TITLE
docs: document TALOS_PACKAGE_TOKEN in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ FORK_BLOCK_NUMBER_SONIC=
 # Shared Postgres URL (nonce queue + schedules + runs)
 # DATABASE_URL=
 
+# read:packages PAT for the local runner image build (`docker compose build actions`):
+# installs the optional @oplabs/talos-client peer from GitHub Packages. Classic PAT,
+# read:packages scope (+ SSO where required); same value as the CI repo secret.
+# TALOS_PACKAGE_TOKEN=
+
 # ╔══════════════════════════════════════════════════════════════════════════════╗
 # ║                                AWS KMS SIGNER                                ║
 # ╚══════════════════════════════════════════════════════════════════════════════╝


### PR DESCRIPTION
Adds `TALOS_PACKAGE_TOKEN` to `.env.example` (AUTOMATON RUNTIME section) so contributors know it's needed for a local runner image build.

The runner image installs the optional `@oplabs/talos-client` peer from GitHub Packages; `docker compose build actions` reads the token from the env. Notes the required scope (classic PAT, `read:packages`, + SSO where required) and that it's the same value as the CI `TALOS_PACKAGE_TOKEN` repo secret.

Docs-only; commented-out like the other example vars.