### PR TITLE
fix(invariants): account for market share price rounding

### DIFF
--- a/test/invariants/LidoARM/FuzzerFoundry.t.sol
+++ b/test/invariants/LidoARM/FuzzerFoundry.t.sol
@@ -120,6 +120,25 @@ contract FuzzerFoundry_LidoARM is Properties {
         assertEq(maxWethBalanceDrift(), 0, "unaccounted WETH drift");
     }
 
+    function test_setActiveMarketAllowsTrackedThreeWeiRoundingLoss() public {
+        uint256 targetArmWeth = 1_725_354_192_264_043_820;
+        targetDonate(targetArmWeth - weth.balanceOf(address(lidoARM)), 0);
+
+        // At this market share price, depositing all ARM liquidity loses 3 wei when the minted
+        // market shares are converted back to assets. This is within one market share of rounding.
+        deal(address(weth), address(mockERC4626Market_A), 21_842_260_027_410_998_593_879);
+
+        uint256 assetsBefore = lidoARM.totalAssets();
+        uint256 priceBefore = assetsBefore * 1e18 / lidoARM.totalSupply();
+        targetSetActiveMarket(0);
+        uint256 assetsAfter = lidoARM.totalAssets();
+        uint256 priceAfter = assetsAfter * 1e18 / lidoARM.totalSupply();
+
+        assertEq(assetsBefore - assetsAfter, 3, "market rounding loss");
+        assertEq(priceBefore - priceAfter, 3, "share price rounding loss");
+        assertEq(sum_weth_marketRoundingLoss, 3, "tracked market rounding loss");
+    }
+
     /// @notice Optimization: fuzzer maximizes the worst-case LP rounding loss.
     function invariant_optimize_maxLpLoss() public view returns (int256) {
         return maxLpLoss();

--- a/test/invariants/LidoARM/helpers/Helpers.t.sol
+++ b/test/invariants/LidoARM/helpers/Helpers.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 import {Vm} from "forge-std/Vm.sol";
 import {Base_Test_} from "../base/Base.t.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 // Mocks
 import {MockERC20} from "@solmate/test/utils/mocks/MockERC20.sol";
@@ -17,11 +18,19 @@ abstract contract Helpers is Base_Test_ {
     ////////////////////////////////////////////////////
 
     modifier ensureSharePriceNotDecreased() {
+        uint256 marketRoundingLossBefore = sum_weth_marketRoundingLoss;
         uint256 priceBefore = lidoARM.totalAssets() * 1e18 / lidoARM.totalSupply();
         _;
-        uint256 priceAfter = lidoARM.totalAssets() * 1e18 / lidoARM.totalSupply();
+        uint256 totalSupplyAfter = lidoARM.totalSupply();
+        uint256 priceAfter = lidoARM.totalAssets() * 1e18 / totalSupplyAfter;
         // Allow 2 wei tolerance for ERC4626 convertToAssets rounding on split operations
-        require(priceAfter + 2 >= priceBefore, "SHARE_PRICE_DECREASED");
+        // plus the share-price impact of any market rounding loss tracked by the inner modifier.
+        if (priceAfter < priceBefore) {
+            uint256 marketRoundingLoss = sum_weth_marketRoundingLoss - marketRoundingLossBefore;
+            uint256 marketRoundingPriceTolerance =
+                Math.mulDiv(marketRoundingLoss, 1e18, totalSupplyAfter, Math.Rounding.Ceil);
+            require(priceBefore - priceAfter <= 2 + marketRoundingPriceTolerance, "SHARE_PRICE_DECREASED");
+        }
         ghost_lastSharePrice = priceAfter;
     }
 


### PR DESCRIPTION
## Summary

- Derive the additional share-price tolerance from the ERC-4626 market rounding loss tracked during the current handler call.
- Preserve the existing 2 wei split-operation tolerance without allowing previously tracked losses to mask later share-price decreases.
- Add a regression test reproducing the 3 wei loss found by the LidoARM invariant CI.

## Context

The LidoARM invariant run failed when setActiveMarket deposited all ARM WETH into the active ERC-4626 market. The minted market shares converted back to 3 wei fewer assets. trackWethMarketRounding already recognized and recorded this as a valid one-market-share rounding loss, but ensureSharePriceNotDecreased still had a fixed 2 wei limit and reverted with SHARE_PRICE_DECREASED.

The modifier now snapshots the cumulative tracked loss before the handler, uses only the per-call delta, and converts that asset loss to share-price units with full-precision ceiling division.

## Testing

- forge fmt --check
- forge build
- Targeted market-rounding regression tests: 2 passed
- Full local LidoARM suite: 10 passed, including 12,800 calls per invariant
- Exact failing fuzz seed replayed twice at CI depth 100: 14,000 runs and 1,400,000 calls per replay, with 0 reverts. The original failure occurred at run 13,906.