### PR TITLE
[ARM] Unpause EtherFi ARM

### DIFF
--- a/script/deploy/mainnet/040_UnpauseEtherFi.s.sol
+++ b/script/deploy/mainnet/040_UnpauseEtherFi.s.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";
+
+contract $040_UnpauseEtherFi is AbstractDeployScript("040_UnpauseEtherFi") {
+    using GovHelper for GovProposal;
+
+    function _buildGovernanceProposal() internal override {
+        govProposal.setDescription("Unpause EtherFi ARM");
+        govProposal.action(resolver.resolve("ETHER_FI_ARM"), "unpause()", "");
+    }
+}


### PR DESCRIPTION
## Summary

- add a mainnet governance deployment script to unpause the EtherFi ARM
- resolve the deployed ARM through `ETHER_FI_ARM` and queue `unpause()` through governance

## Governance
- Gov proposal [link](https://app.originprotocol.com/#/ogn/governance/1:0x1d3fbd4d129ddd2372ea85c5fa00b2682081c9ec:31257177221554002601475684198286132773102114806867329571141981145813260101109).
- Gov proposal ID: `31257177221554002601475684198286132773102114806867329571141981145813260101109`

## Verification

- confirmed the mainnet EtherFi ARM is paused and owned by the Origin Timelock
- `forge fmt --check script/deploy/mainnet/040_UnpauseEtherFi.s.sol`
- `forge build`
- `make test-smoke` (39 passed)