### PR TITLE
[ARM] Record 041 EtherFi adapter deployment

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -193,7 +193,7 @@
             "name": "WETH_ARM_WSTETH_ADAPTER"
         },
         {
-            "implementation": "0xb1104B6bD6f07D19E6D679e88AD4035CFD1F2A48",
+            "implementation": "0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44",
             "name": "WETH_ARM_EETH_ADAPTER_IMPL"
         },
         {
@@ -201,7 +201,7 @@
             "name": "WETH_ARM_EETH_ADAPTER"
         },
         {
-            "implementation": "0x20c66066f30fa935B31878A439c53aC76d4C53cB",
+            "implementation": "0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1",
             "name": "WETH_ARM_WEETH_ADAPTER_IMPL"
         },
         {
@@ -451,6 +451,18 @@
             "proposalId": 1,
             "tsDeployment": 1784724659,
             "tsGovernance": 1
+        },
+        {
+            "name": "040_UnpauseEtherFi",
+            "proposalId": 1,
+            "tsDeployment": 1784724659,
+            "tsGovernance": 1
+        },
+        {
+            "name": "041_RedeployEtherFiAdaptersScript",
+            "proposalId": 1,
+            "tsDeployment": 1785134531,
+            "tsGovernance": 0
         }
     ]
 }


### PR DESCRIPTION
# Description

Record the mainnet deployment of new `EtherFiAssetAdapter` and `WeETHAssetAdapter` implementations for the WETH ARM. These implementations add the Ether.fi withdrawal-claim gate introduced in #320 so claim proceeds can only arrive during an adapter-initiated redemption.

The existing adapter proxies are reused, preserving their addresses and pending withdrawal-request storage. This PR also records the completed execution of `040_UnpauseEtherFi`.

The following PR is included in this deployment:

### ARM

- https://github.com/OriginProtocol/arm-oeth/pull/320

## Deployment

Script `script/deploy/mainnet/041_RedeployEtherFiAdaptersScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| New `EtherFiAssetAdapter` implementation | [`0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44`](https://etherscan.io/address/0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44) |
| Reused eETH adapter proxy | [`0xFa205c9a110a3e82Bd8d223CccCB15C5b9E6434e`](https://etherscan.io/address/0xFa205c9a110a3e82Bd8d223CccCB15C5b9E6434e) |
| New `WeETHAssetAdapter` implementation | [`0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1`](https://etherscan.io/address/0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1) |
| Reused weETH adapter proxy | [`0xD5F61bFd890169c28858039f6b6c9b517407C852`](https://etherscan.io/address/0xD5F61bFd890169c28858039f6b6c9b517407C852) |

## Contract diff

```sh
make match file=src/contracts/adapters/EtherFiAssetAdapter.sol addr=0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44
make match file=src/contracts/Proxy.sol addr=0xFa205c9a110a3e82Bd8d223CccCB15C5b9E6434e
make match file=src/contracts/adapters/WeETHAssetAdapter.sol addr=0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1
make match file=src/contracts/Proxy.sol addr=0xD5F61bFd890169c28858039f6b6c9b517407C852
```

## Configuration

| Parameter | Value |
| - | - |
| WETH ARM | `0x68025A4615407993A680102b08a23A61D11C657C` |
| eETH | `0x35fA164735182de50811E8e2E824cFb9B6118ac2` |
| weETH | `0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee` |
| WETH | `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2` |
| Ether.fi withdrawal queue | `0x308861A430be4cce5502d0A12724771Fc6DaF216` |
| Ether.fi withdrawal NFT | `0x7d5706f6ef3F89B3951E23e557CDFBC3239D4E2c` |

## Governance

There is no `GovernorSix` proposal. Both adapter proxies are owned by the mainnet 2/8 multisig (`0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971`).

`041_RedeployEtherFiAdaptersScript` is recorded with `proposalId: 1` and `tsGovernance: 0` because both proxy upgrades remain pending manual multisig execution. `040_UnpauseEtherFi` is recorded as fully executed.

## Required post-deployment actions (2/8 multisig)

| Proxy | Current implementation | Required implementation | Action |
| - | - | - | - |
| eETH adapter `0xFa205c9a110a3e82Bd8d223CccCB15C5b9E6434e` | `0xb1104B6bD6f07D19E6D679e88AD4035CFD1F2A48` | `0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44` | `upgradeTo(0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44)` |
| weETH adapter `0xD5F61bFd890169c28858039f6b6c9b517407C852` | `0x20c66066f30fa935B31878A439c53aC76d4C53cB` | `0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1` | `upgradeTo(0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1)` |

## Tests

- `jq empty build/deployments-1.json`
- confirmed on-chain that both proxies remain on the previous implementations and are owned by the mainnet 2/8 multisig