### PR TITLE
[ARM] Deploy 042 WETH ARM Morpho market on mainnet

### DIFF
--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -239,6 +239,14 @@
         {
             "implementation": "0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f",
             "name": "USDC_ARM_USDG_ADAPTER"
+        },
+        {
+            "implementation": "0xe192824f42ae3D643ac867774b45E8d233d86c72",
+            "name": "MORPHO_MARKET_WETH_ARM"
+        },
+        {
+            "implementation": "0x4E715556Cd84926FD5EAc206a016711E38273aD4",
+            "name": "MORPHO_MARKET_WETH_ARM_IMPL"
         }
     ],
     "executions": [
@@ -462,6 +470,12 @@
             "name": "041_RedeployEtherFiAdaptersScript",
             "proposalId": 1,
             "tsDeployment": 1785134531,
+            "tsGovernance": 1
+        },
+        {
+            "name": "042_DeployWETHMorphoMarketScript",
+            "proposalId": 1,
+            "tsDeployment": 1785160163,
             "tsGovernance": 0
         }
     ]

--- a/build/deployments-1.json
+++ b/build/deployments-1.json
@@ -1,482 +1,482 @@
 {
-    "contracts": [
-        {
-            "implementation": "0xE11EDbd5AE4Fa434Af7f8D7F03Da1742996e7Ab2",
-            "name": "ARM_ZAPPER"
-        },
-        {
-            "implementation": "0xCEDa2d856238aA0D12f6329de20B9115f07C366d",
-            "name": "ETHENA_ARM"
-        },
-        {
-            "implementation": "0x7073F39ae371962C2469D72f01f907375bB11E08",
-            "name": "ETHENA_ARM_CAP_IMPL"
-        },
-        {
-            "implementation": "0x687AFB5A52A15122fD5FC54A8B52cfd58346fb0C",
-            "name": "ETHENA_ARM_CAP_MAN"
-        },
-        {
-            "implementation": "0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe",
-            "name": "ETHENA_ARM_IMPL"
-        },
-        {
-            "implementation": "0x6DB596b66FED6a9994e09EeD70b6d210F01705E5",
-            "name": "ETHERFI_ARM_IMPL"
-        },
-        {
-            "implementation": "0xfB0A3CF9B019BFd8827443d131b235B3E0FC58d2",
-            "name": "ETHER_FI_ARM"
-        },
-        {
-            "implementation": "0xe27720Fc3f3707D47015e274D81a99e5B0800472",
-            "name": "ETHER_FI_ARM_CAP_IMPL"
-        },
-        {
-            "implementation": "0xf2A18F7330141Ec737EB73A0A5Ea8E4d7e9bE7ec",
-            "name": "ETHER_FI_ARM_CAP_MAN"
-        },
-        {
-            "implementation": "0x00B53CEE151c043CBe4bbFe4cfD2938Cb4fabCEB",
-            "name": "ETHER_FI_ARM_IMPL"
-        },
-        {
-            "implementation": "0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6",
-            "name": "LIDO_ARM"
-        },
-        {
-            "implementation": "0x8506486813d025C5935dF481E450e27D2e483dc9",
-            "name": "LIDO_ARM_CAP_IMPL"
-        },
-        {
-            "implementation": "0xf54ebff575f699d281645c6F14Fe427dFFE629CF",
-            "name": "LIDO_ARM_CAP_MAN"
-        },
-        {
-            "implementation": "0x850da2E21F1F71479E2A307EDab114777D9F6217",
-            "name": "LIDO_ARM_IMPL"
-        },
-        {
-            "implementation": "0x01F30B7358Ba51f637d1aa05D9b4A60f76DAD680",
-            "name": "LIDO_ARM_ZAPPER"
-        },
-        {
-            "implementation": "0x8Cf42b82fFFa3E7714D62a2cA223acBeC1Eef095",
-            "name": "MORPHO_MARKET_ETHERFI"
-        },
-        {
-            "implementation": "0xB7CeFE4CB483Be80C2963D3D9Edb991e69ff39cf",
-            "name": "MORPHO_MARKET_LIDO"
-        },
-        {
-            "implementation": "0xa52cC5aDFE6C638cE31694eAFfD8F993A0324f22",
-            "name": "MORPHO_MARKET_LIDO_IMPL"
-        },
-        {
-            "implementation": "0x2a1b59870f7806E60dF58415B0C220C096f57658",
-            "name": "MORPHO_MARKET_ETHERFI_IMPL"
-        },
-        {
-            "implementation": "0x29c4Bb7B1eBcc53e8CBd16480B5bAe52C69806D3",
-            "name": "MORPHO_MARKET_MEVCAPITAL"
-        },
-        {
-            "implementation": "0x90c7ABC962f96de171ee395A242D2Ff794D0a04c",
-            "name": "MORPHO_MARKET_MEVCAPITAL_IMP"
-        },
-        {
-            "implementation": "0x0ad39D67404aE36Fe476eFDDE1306a5414383544",
-            "name": "MORPHO_MARKET_ORIGIN"
-        },
-        {
-            "implementation": "0x2ea9D1827973813D77aA8f35BD23cb1F1311A648",
-            "name": "MORPHO_MARKET_ORIGIN_IMPL"
-        },
-        {
-            "implementation": "0x6bac785889A4127dB0e0CeFEE88E0a9F1Aaf3cC7",
-            "name": "OETH_ARM"
-        },
-        {
-            "implementation": "0x9A2be51E45Eec98F75b3e6e1b334246c94663641",
-            "name": "OETH_ARM_IMPL"
-        },
-        {
-            "implementation": "0xbcae2Eb1cc47F137D8B2D351B0E0ea8DdA4C6184",
-            "name": "PENDLE_ORIGIN_ARM_SY"
-        },
-        {
-            "implementation": "0x1707b933037287eAf35A64ff1E89Cb00Db809aaB",
-            "name": "ETHENA_ARM_SUSDE_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0xE620aFB67223AE03C260112aE21A717Af94C90f0",
-            "name": "ETHENA_ARM_SUSDE_ADAPTER"
-        },
-        {
-            "implementation": "0xB9B85dFEe7E53654180C28427a4B3dF46d4b988A",
-            "name": "ETH_ARM"
-        },
-        {
-            "implementation": "0xf129dF4442aB86dc93D82aF4c6339A619163f93c",
-            "name": "ETH_ARM_CAP_MAN"
-        },
-        {
-            "implementation": "0xdf15C16C73F352fEf32A9B1B9d76aB9383a489B3",
-            "name": "ETH_ARM_CAP_IMPL"
-        },
-        {
-            "implementation": "0xC92bBE73fa0D1d9908aF8E2dF5dFE1996D57a911",
-            "name": "ETH_ARM_IMPL"
-        },
-        {
-            "implementation": "0x1c3A844E572Cc59C4a007E6d2B3Eba62Fdbf216c",
-            "name": "ETH_ARM_STETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0x6190ae78517D50c50D1C58144b79610Bc92593D5",
-            "name": "ETH_ARM_STETH_ADAPTER"
-        },
-        {
-            "implementation": "0xc6fF6ce92FC5f24F8c0e3CaEC9Bcb26C307D1dee",
-            "name": "ETH_ARM_WSTETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0xf990AD13867640305ad2B00D980817A1AfC1d68B",
-            "name": "ETH_ARM_WSTETH_ADAPTER"
-        },
-        {
-            "implementation": "0xf617233753bdBfcDB09093A3F04041467303DF3a",
-            "name": "ETH_ARM_EETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0x9e409A4a0259b494B3A993Ca06466aa7523d6871",
-            "name": "ETH_ARM_EETH_ADAPTER"
-        },
-        {
-            "implementation": "0x89f12CcE7C51DfDBBF83c00dEa15455B19c88D02",
-            "name": "ETH_ARM_WEETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0xf9cEDb3154c6502328C7B09c773a43a0b9C801eb",
-            "name": "ETH_ARM_WEETH_ADAPTER"
-        },
-        {
-            "implementation": "0x68025A4615407993A680102b08a23A61D11C657C",
-            "name": "WETH_ARM"
-        },
-        {
-            "implementation": "0x19D2977a1cc5A73bF5d827aCE07a3BE3e56BdfEa",
-            "name": "WETH_ARM_CAP_MAN"
-        },
-        {
-            "implementation": "0x7488F5352207Ba9fA91FF09F6964c51Db2d662d1",
-            "name": "WETH_ARM_CAP_IMPL"
-        },
-        {
-            "implementation": "0xe0Dba0eF9A1C7dF2a94386A3187e9360e1B2c1fb",
-            "name": "WETH_ARM_IMPL"
-        },
-        {
-            "implementation": "0x2b8b088B29349f4a9Af1719f0fb3115587E84c26",
-            "name": "WETH_ARM_STETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0x7b0a90552D2dc01936301A45bFC813717Af7E8a9",
-            "name": "WETH_ARM_STETH_ADAPTER"
-        },
-        {
-            "implementation": "0x4ab7E8c06d651F7462df728419D4293126764Ed4",
-            "name": "WETH_ARM_WSTETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0xE28ca056A12134b6B872D1CbE04cd1A82fDfeA95",
-            "name": "WETH_ARM_WSTETH_ADAPTER"
-        },
-        {
-            "implementation": "0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44",
-            "name": "WETH_ARM_EETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0xFa205c9a110a3e82Bd8d223CccCB15C5b9E6434e",
-            "name": "WETH_ARM_EETH_ADAPTER"
-        },
-        {
-            "implementation": "0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1",
-            "name": "WETH_ARM_WEETH_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0xD5F61bFd890169c28858039f6b6c9b517407C852",
-            "name": "WETH_ARM_WEETH_ADAPTER"
-        },
-        {
-            "implementation": "0x9E3A7026E5767F2d7Ff5e83b0ed011005f45a170",
-            "name": "USDC_ARM"
-        },
-        {
-            "implementation": "0x19B1Edb2caD902F103a20A30011f125DCe44F954",
-            "name": "USDC_ARM_CAP_MAN"
-        },
-        {
-            "implementation": "0xDdF1954db1Ace4a58E07a4D25C0818aC977cb8bd",
-            "name": "USDC_ARM_CAP_IMPL"
-        },
-        {
-            "implementation": "0xef40f3548ec3277ade0eb88DbB80ebF63Ea59a96",
-            "name": "USDC_ARM_IMPL"
-        },
-        {
-            "implementation": "0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8",
-            "name": "USDC_ARM_PYUSD_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465",
-            "name": "USDC_ARM_PYUSD_ADAPTER"
-        },
-        {
-            "implementation": "0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05",
-            "name": "USDC_ARM_USDG_ADAPTER_IMPL"
-        },
-        {
-            "implementation": "0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f",
-            "name": "USDC_ARM_USDG_ADAPTER"
-        },
-        {
-            "implementation": "0xe192824f42ae3D643ac867774b45E8d233d86c72",
-            "name": "MORPHO_MARKET_WETH_ARM"
-        },
-        {
-            "implementation": "0x4E715556Cd84926FD5EAc206a016711E38273aD4",
-            "name": "MORPHO_MARKET_WETH_ARM_IMPL"
-        }
-    ],
-    "executions": [
-        {
-            "name": "001_CoreMainnet",
-            "proposalId": 1,
-            "tsDeployment": 1723685111,
-            "tsGovernance": 1
-        },
-        {
-            "name": "002_UpgradeMainnet",
-            "proposalId": 1,
-            "tsDeployment": 1726812322,
-            "tsGovernance": 1
-        },
-        {
-            "name": "003_UpgradeLidoARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1729073099,
-            "tsGovernance": 1
-        },
-        {
-            "name": "004_UpdateCrossPriceScript",
-            "proposalId": "35014690349432723957288190501753589450218643401938485181692293616657480917203",
-            "tsDeployment": 1739872607,
-            "tsGovernance": 1741006739
-        },
-        {
-            "name": "005_RegisterLidoWithdrawalsScript",
-            "proposalId": "64044440920440270085747261797126167860462634313138171523652997655161275965731",
-            "tsDeployment": 1743500783,
-            "tsGovernance": 1744160999
-        },
-        {
-            "name": "006_ChangeFeeCollector",
-            "proposalId": "109363689626229981205538511015089771588377155562499137759609037731650725632486",
-            "tsDeployment": 1751894483,
-            "tsGovernance": 1752344483
-        },
-        {
-            "name": "007_UpgradeLidoARMMorphoScript",
-            "proposalId": "59265604807181750059374521697037203647325806747129712398293966379088988710865",
-            "tsDeployment": 1754407535,
-            "tsGovernance": 1755065999
-        },
-        {
-            "name": "008_DeployPendleAdaptor",
-            "proposalId": 1,
-            "tsDeployment": 1755770303,
-            "tsGovernance": 1
-        },
-        {
-            "name": "009_UpgradeLidoARMSetBufferScript",
-            "proposalId": "102890619681967819838810828305071236237724717056692746223348120761300245862771",
-            "tsDeployment": 1755692387,
-            "tsGovernance": 1756300859
-        },
-        {
-            "name": "010_UpgradeLidoARMAssetScript",
-            "proposalId": "37708940508805836655115654926134468712278199739053834927259119548435770049054",
-            "tsDeployment": 1764755207,
-            "tsGovernance": 1765250063
-        },
-        {
-            "name": "011_DeployEtherFiARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1761812927,
-            "tsGovernance": 1
-        },
-        {
-            "name": "012_UpgradeEtherFiARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1763557643,
-            "tsGovernance": 1
-        },
-        {
-            "name": "013_UpgradeOETHARMScript",
-            "proposalId": "13037237308267442172275484225525115297039100275207017031248147012600338883646",
-            "tsDeployment": 1765353455,
-            "tsGovernance": 1765977443
-        },
-        {
-            "name": "014_DeployEthenaARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1764664655,
-            "tsGovernance": 1
-        },
-        {
-            "name": "015_UpgradeEthenaARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1766319523,
-            "tsGovernance": 1
-        },
-        {
-            "name": "016_UpgradeLidoARMCrossPriceScript",
-            "proposalId": "31708125563490321189508956336526281463837110092407433451282139238539907004461",
-            "tsDeployment": 1767616727,
-            "tsGovernance": 1768078823
-        },
-        {
-            "name": "017_DeployNewMorphoMarketForEtherFiARM",
-            "proposalId": 1,
-            "tsDeployment": 1770197063,
-            "tsGovernance": 1
-        },
-        {
-            "name": "018_DeployNewMorphoMarketForLidoARM",
-            "proposalId": "104193745767957728487777538680481562234753615557563590994770579038567345820296",
-            "tsDeployment": 1770716663,
-            "tsGovernance": 1771230167
-        },
-        {
-            "name": "019_DeployPendleAdaptor_EtherFi",
-            "proposalId": 1,
-            "tsDeployment": 1770793835,
-            "tsGovernance": 1
-        },
-        {
-            "name": "020_UpgradeEthenaARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1771799051,
-            "tsGovernance": 1
-        },
-        {
-            "name": "021_UpgradeEtherFiARMCrossPriceScript",
-            "proposalId": "114812379648161625831369461227769038450456221701260101122620166047089230034199",
-            "tsDeployment": 1774843907,
-            "tsGovernance": 1775301371
-        },
-        {
-            "name": "022_UpgradeEtherFiARMDepositScript",
-            "proposalId": 1,
-            "tsDeployment": 1763557667,
-            "tsGovernance": 1
-        },
-        {
-            "name": "023_UpgradeEthenaARMDepositScript",
-            "proposalId": 1,
-            "tsDeployment": 1771799087,
-            "tsGovernance": 1
-        },
-        {
-            "name": "026_UpgradeEthenaARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1775631059,
-            "tsGovernance": 1
-        },
-        {
-            "name": "027_UpgradeEthenaARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1777952339,
-            "tsGovernance": 1
-        },
-        {
-            "name": "028_UpgradeARMsPauseScript",
-            "proposalId": "107456588163205703004763727598618132346480115183205972270610010610877561869240",
-            "tsDeployment": 1780037867,
-            "tsGovernance": 1781164307
-        },
-        {
-            "name": "029_SetTalosKMSOperatorScript",
-            "proposalId": "12986865731251129814295460769943611973912941096599758191915201739619928664693",
-            "tsDeployment": 1781035763,
-            "tsGovernance": 1781594591
-        },
-        {
-            "name": "030_SetEthenaTalosKMSOperatorScript",
-            "proposalId": 1,
-            "tsDeployment": 1781035763,
-            "tsGovernance": 1
-        },
-        {
-            "name": "031_UpgradeEthenaARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1781612483,
-            "tsGovernance": 1
-        },
-        {
-            "name": "034_UpgradeEthenaARMGetBaseAssetsScript",
-            "proposalId": 1,
-            "tsDeployment": 1781855555,
-            "tsGovernance": 1
-        },
-        {
-            "name": "035_UnpauseEthenaARMScript",
-            "proposalId": "105952564920326880829480980653921695351704517467605619581569766325476268429476",
-            "tsDeployment": 1782206279,
-            "tsGovernance": 1
-        },
-        {
-            "name": "037_DeployUSDARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1783493495,
-            "tsGovernance": 1
-        },
-        {
-            "name": "036_DeployMultiAssetARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1783504775,
-            "tsGovernance": 1
-        },
-        {
-            "name": "038_DeployWETHARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1784724659,
-            "tsGovernance": 1
-        },
-        {
-            "name": "039_DeployUSDCARMScript",
-            "proposalId": 1,
-            "tsDeployment": 1784724659,
-            "tsGovernance": 1
-        },
-        {
-            "name": "040_UnpauseEtherFi",
-            "proposalId": 1,
-            "tsDeployment": 1784724659,
-            "tsGovernance": 1
-        },
-        {
-            "name": "041_RedeployEtherFiAdaptersScript",
-            "proposalId": 1,
-            "tsDeployment": 1785134531,
-            "tsGovernance": 1
-        },
-        {
-            "name": "042_DeployWETHMorphoMarketScript",
-            "proposalId": 1,
-            "tsDeployment": 1785160163,
-            "tsGovernance": 0
-        }
-    ]
+  "contracts": [
+    {
+      "implementation": "0xE11EDbd5AE4Fa434Af7f8D7F03Da1742996e7Ab2",
+      "name": "ARM_ZAPPER"
+    },
+    {
+      "implementation": "0xCEDa2d856238aA0D12f6329de20B9115f07C366d",
+      "name": "ETHENA_ARM"
+    },
+    {
+      "implementation": "0x7073F39ae371962C2469D72f01f907375bB11E08",
+      "name": "ETHENA_ARM_CAP_IMPL"
+    },
+    {
+      "implementation": "0x687AFB5A52A15122fD5FC54A8B52cfd58346fb0C",
+      "name": "ETHENA_ARM_CAP_MAN"
+    },
+    {
+      "implementation": "0xebB2B66759b593Ea50eB8C306E2E13464cDB99Fe",
+      "name": "ETHENA_ARM_IMPL"
+    },
+    {
+      "implementation": "0x6DB596b66FED6a9994e09EeD70b6d210F01705E5",
+      "name": "ETHERFI_ARM_IMPL"
+    },
+    {
+      "implementation": "0xfB0A3CF9B019BFd8827443d131b235B3E0FC58d2",
+      "name": "ETHER_FI_ARM"
+    },
+    {
+      "implementation": "0xe27720Fc3f3707D47015e274D81a99e5B0800472",
+      "name": "ETHER_FI_ARM_CAP_IMPL"
+    },
+    {
+      "implementation": "0xf2A18F7330141Ec737EB73A0A5Ea8E4d7e9bE7ec",
+      "name": "ETHER_FI_ARM_CAP_MAN"
+    },
+    {
+      "implementation": "0x00B53CEE151c043CBe4bbFe4cfD2938Cb4fabCEB",
+      "name": "ETHER_FI_ARM_IMPL"
+    },
+    {
+      "implementation": "0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6",
+      "name": "LIDO_ARM"
+    },
+    {
+      "implementation": "0x8506486813d025C5935dF481E450e27D2e483dc9",
+      "name": "LIDO_ARM_CAP_IMPL"
+    },
+    {
+      "implementation": "0xf54ebff575f699d281645c6F14Fe427dFFE629CF",
+      "name": "LIDO_ARM_CAP_MAN"
+    },
+    {
+      "implementation": "0x850da2E21F1F71479E2A307EDab114777D9F6217",
+      "name": "LIDO_ARM_IMPL"
+    },
+    {
+      "implementation": "0x01F30B7358Ba51f637d1aa05D9b4A60f76DAD680",
+      "name": "LIDO_ARM_ZAPPER"
+    },
+    {
+      "implementation": "0x8Cf42b82fFFa3E7714D62a2cA223acBeC1Eef095",
+      "name": "MORPHO_MARKET_ETHERFI"
+    },
+    {
+      "implementation": "0xB7CeFE4CB483Be80C2963D3D9Edb991e69ff39cf",
+      "name": "MORPHO_MARKET_LIDO"
+    },
+    {
+      "implementation": "0xa52cC5aDFE6C638cE31694eAFfD8F993A0324f22",
+      "name": "MORPHO_MARKET_LIDO_IMPL"
+    },
+    {
+      "implementation": "0x2a1b59870f7806E60dF58415B0C220C096f57658",
+      "name": "MORPHO_MARKET_ETHERFI_IMPL"
+    },
+    {
+      "implementation": "0x29c4Bb7B1eBcc53e8CBd16480B5bAe52C69806D3",
+      "name": "MORPHO_MARKET_MEVCAPITAL"
+    },
+    {
+      "implementation": "0x90c7ABC962f96de171ee395A242D2Ff794D0a04c",
+      "name": "MORPHO_MARKET_MEVCAPITAL_IMP"
+    },
+    {
+      "implementation": "0x0ad39D67404aE36Fe476eFDDE1306a5414383544",
+      "name": "MORPHO_MARKET_ORIGIN"
+    },
+    {
+      "implementation": "0x2ea9D1827973813D77aA8f35BD23cb1F1311A648",
+      "name": "MORPHO_MARKET_ORIGIN_IMPL"
+    },
+    {
+      "implementation": "0x6bac785889A4127dB0e0CeFEE88E0a9F1Aaf3cC7",
+      "name": "OETH_ARM"
+    },
+    {
+      "implementation": "0x9A2be51E45Eec98F75b3e6e1b334246c94663641",
+      "name": "OETH_ARM_IMPL"
+    },
+    {
+      "implementation": "0xbcae2Eb1cc47F137D8B2D351B0E0ea8DdA4C6184",
+      "name": "PENDLE_ORIGIN_ARM_SY"
+    },
+    {
+      "implementation": "0x1707b933037287eAf35A64ff1E89Cb00Db809aaB",
+      "name": "ETHENA_ARM_SUSDE_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0xE620aFB67223AE03C260112aE21A717Af94C90f0",
+      "name": "ETHENA_ARM_SUSDE_ADAPTER"
+    },
+    {
+      "implementation": "0xB9B85dFEe7E53654180C28427a4B3dF46d4b988A",
+      "name": "ETH_ARM"
+    },
+    {
+      "implementation": "0xf129dF4442aB86dc93D82aF4c6339A619163f93c",
+      "name": "ETH_ARM_CAP_MAN"
+    },
+    {
+      "implementation": "0xdf15C16C73F352fEf32A9B1B9d76aB9383a489B3",
+      "name": "ETH_ARM_CAP_IMPL"
+    },
+    {
+      "implementation": "0xC92bBE73fa0D1d9908aF8E2dF5dFE1996D57a911",
+      "name": "ETH_ARM_IMPL"
+    },
+    {
+      "implementation": "0x1c3A844E572Cc59C4a007E6d2B3Eba62Fdbf216c",
+      "name": "ETH_ARM_STETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0x6190ae78517D50c50D1C58144b79610Bc92593D5",
+      "name": "ETH_ARM_STETH_ADAPTER"
+    },
+    {
+      "implementation": "0xc6fF6ce92FC5f24F8c0e3CaEC9Bcb26C307D1dee",
+      "name": "ETH_ARM_WSTETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0xf990AD13867640305ad2B00D980817A1AfC1d68B",
+      "name": "ETH_ARM_WSTETH_ADAPTER"
+    },
+    {
+      "implementation": "0xf617233753bdBfcDB09093A3F04041467303DF3a",
+      "name": "ETH_ARM_EETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0x9e409A4a0259b494B3A993Ca06466aa7523d6871",
+      "name": "ETH_ARM_EETH_ADAPTER"
+    },
+    {
+      "implementation": "0x89f12CcE7C51DfDBBF83c00dEa15455B19c88D02",
+      "name": "ETH_ARM_WEETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0xf9cEDb3154c6502328C7B09c773a43a0b9C801eb",
+      "name": "ETH_ARM_WEETH_ADAPTER"
+    },
+    {
+      "implementation": "0x68025A4615407993A680102b08a23A61D11C657C",
+      "name": "WETH_ARM"
+    },
+    {
+      "implementation": "0x19D2977a1cc5A73bF5d827aCE07a3BE3e56BdfEa",
+      "name": "WETH_ARM_CAP_MAN"
+    },
+    {
+      "implementation": "0x7488F5352207Ba9fA91FF09F6964c51Db2d662d1",
+      "name": "WETH_ARM_CAP_IMPL"
+    },
+    {
+      "implementation": "0xe0Dba0eF9A1C7dF2a94386A3187e9360e1B2c1fb",
+      "name": "WETH_ARM_IMPL"
+    },
+    {
+      "implementation": "0x2b8b088B29349f4a9Af1719f0fb3115587E84c26",
+      "name": "WETH_ARM_STETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0x7b0a90552D2dc01936301A45bFC813717Af7E8a9",
+      "name": "WETH_ARM_STETH_ADAPTER"
+    },
+    {
+      "implementation": "0x4ab7E8c06d651F7462df728419D4293126764Ed4",
+      "name": "WETH_ARM_WSTETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0xE28ca056A12134b6B872D1CbE04cd1A82fDfeA95",
+      "name": "WETH_ARM_WSTETH_ADAPTER"
+    },
+    {
+      "implementation": "0x0dA9cA22A10252eD87D880F3E45b736Bb10efc44",
+      "name": "WETH_ARM_EETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0xFa205c9a110a3e82Bd8d223CccCB15C5b9E6434e",
+      "name": "WETH_ARM_EETH_ADAPTER"
+    },
+    {
+      "implementation": "0x367B54A531b8D1e611326957A5e7c1f67DB3dCe1",
+      "name": "WETH_ARM_WEETH_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0xD5F61bFd890169c28858039f6b6c9b517407C852",
+      "name": "WETH_ARM_WEETH_ADAPTER"
+    },
+    {
+      "implementation": "0x9E3A7026E5767F2d7Ff5e83b0ed011005f45a170",
+      "name": "USDC_ARM"
+    },
+    {
+      "implementation": "0x19B1Edb2caD902F103a20A30011f125DCe44F954",
+      "name": "USDC_ARM_CAP_MAN"
+    },
+    {
+      "implementation": "0xDdF1954db1Ace4a58E07a4D25C0818aC977cb8bd",
+      "name": "USDC_ARM_CAP_IMPL"
+    },
+    {
+      "implementation": "0xef40f3548ec3277ade0eb88DbB80ebF63Ea59a96",
+      "name": "USDC_ARM_IMPL"
+    },
+    {
+      "implementation": "0x0bD1bE3B983DE582291dc16DFB123C74dcd65ae8",
+      "name": "USDC_ARM_PYUSD_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0x0C9ac6D63B2b2A1b502E29eC47a53d0966Ea9465",
+      "name": "USDC_ARM_PYUSD_ADAPTER"
+    },
+    {
+      "implementation": "0xB4723D7a5724D6Ce35AACf6c3A6E6E2BeE0c2E05",
+      "name": "USDC_ARM_USDG_ADAPTER_IMPL"
+    },
+    {
+      "implementation": "0xAb98aC901B8A26636d9cf3Cf38d9aCdcD045788f",
+      "name": "USDC_ARM_USDG_ADAPTER"
+    },
+    {
+      "implementation": "0xe192824f42ae3D643ac867774b45E8d233d86c72",
+      "name": "MORPHO_MARKET_WETH_ARM"
+    },
+    {
+      "implementation": "0x4E715556Cd84926FD5EAc206a016711E38273aD4",
+      "name": "MORPHO_MARKET_WETH_ARM_IMPL"
+    }
+  ],
+  "executions": [
+    {
+      "name": "001_CoreMainnet",
+      "proposalId": 1,
+      "tsDeployment": 1723685111,
+      "tsGovernance": 1
+    },
+    {
+      "name": "002_UpgradeMainnet",
+      "proposalId": 1,
+      "tsDeployment": 1726812322,
+      "tsGovernance": 1
+    },
+    {
+      "name": "003_UpgradeLidoARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1729073099,
+      "tsGovernance": 1
+    },
+    {
+      "name": "004_UpdateCrossPriceScript",
+      "proposalId": "35014690349432723957288190501753589450218643401938485181692293616657480917203",
+      "tsDeployment": 1739872607,
+      "tsGovernance": 1741006739
+    },
+    {
+      "name": "005_RegisterLidoWithdrawalsScript",
+      "proposalId": "64044440920440270085747261797126167860462634313138171523652997655161275965731",
+      "tsDeployment": 1743500783,
+      "tsGovernance": 1744160999
+    },
+    {
+      "name": "006_ChangeFeeCollector",
+      "proposalId": "109363689626229981205538511015089771588377155562499137759609037731650725632486",
+      "tsDeployment": 1751894483,
+      "tsGovernance": 1752344483
+    },
+    {
+      "name": "007_UpgradeLidoARMMorphoScript",
+      "proposalId": "59265604807181750059374521697037203647325806747129712398293966379088988710865",
+      "tsDeployment": 1754407535,
+      "tsGovernance": 1755065999
+    },
+    {
+      "name": "008_DeployPendleAdaptor",
+      "proposalId": 1,
+      "tsDeployment": 1755770303,
+      "tsGovernance": 1
+    },
+    {
+      "name": "009_UpgradeLidoARMSetBufferScript",
+      "proposalId": "102890619681967819838810828305071236237724717056692746223348120761300245862771",
+      "tsDeployment": 1755692387,
+      "tsGovernance": 1756300859
+    },
+    {
+      "name": "010_UpgradeLidoARMAssetScript",
+      "proposalId": "37708940508805836655115654926134468712278199739053834927259119548435770049054",
+      "tsDeployment": 1764755207,
+      "tsGovernance": 1765250063
+    },
+    {
+      "name": "011_DeployEtherFiARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1761812927,
+      "tsGovernance": 1
+    },
+    {
+      "name": "012_UpgradeEtherFiARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1763557643,
+      "tsGovernance": 1
+    },
+    {
+      "name": "013_UpgradeOETHARMScript",
+      "proposalId": "13037237308267442172275484225525115297039100275207017031248147012600338883646",
+      "tsDeployment": 1765353455,
+      "tsGovernance": 1765977443
+    },
+    {
+      "name": "014_DeployEthenaARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1764664655,
+      "tsGovernance": 1
+    },
+    {
+      "name": "015_UpgradeEthenaARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1766319523,
+      "tsGovernance": 1
+    },
+    {
+      "name": "016_UpgradeLidoARMCrossPriceScript",
+      "proposalId": "31708125563490321189508956336526281463837110092407433451282139238539907004461",
+      "tsDeployment": 1767616727,
+      "tsGovernance": 1768078823
+    },
+    {
+      "name": "017_DeployNewMorphoMarketForEtherFiARM",
+      "proposalId": 1,
+      "tsDeployment": 1770197063,
+      "tsGovernance": 1
+    },
+    {
+      "name": "018_DeployNewMorphoMarketForLidoARM",
+      "proposalId": "104193745767957728487777538680481562234753615557563590994770579038567345820296",
+      "tsDeployment": 1770716663,
+      "tsGovernance": 1771230167
+    },
+    {
+      "name": "019_DeployPendleAdaptor_EtherFi",
+      "proposalId": 1,
+      "tsDeployment": 1770793835,
+      "tsGovernance": 1
+    },
+    {
+      "name": "020_UpgradeEthenaARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1771799051,
+      "tsGovernance": 1
+    },
+    {
+      "name": "021_UpgradeEtherFiARMCrossPriceScript",
+      "proposalId": "114812379648161625831369461227769038450456221701260101122620166047089230034199",
+      "tsDeployment": 1774843907,
+      "tsGovernance": 1775301371
+    },
+    {
+      "name": "022_UpgradeEtherFiARMDepositScript",
+      "proposalId": 1,
+      "tsDeployment": 1763557667,
+      "tsGovernance": 1
+    },
+    {
+      "name": "023_UpgradeEthenaARMDepositScript",
+      "proposalId": 1,
+      "tsDeployment": 1771799087,
+      "tsGovernance": 1
+    },
+    {
+      "name": "026_UpgradeEthenaARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1775631059,
+      "tsGovernance": 1
+    },
+    {
+      "name": "027_UpgradeEthenaARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1777952339,
+      "tsGovernance": 1
+    },
+    {
+      "name": "028_UpgradeARMsPauseScript",
+      "proposalId": "107456588163205703004763727598618132346480115183205972270610010610877561869240",
+      "tsDeployment": 1780037867,
+      "tsGovernance": 1781164307
+    },
+    {
+      "name": "029_SetTalosKMSOperatorScript",
+      "proposalId": "12986865731251129814295460769943611973912941096599758191915201739619928664693",
+      "tsDeployment": 1781035763,
+      "tsGovernance": 1781594591
+    },
+    {
+      "name": "030_SetEthenaTalosKMSOperatorScript",
+      "proposalId": 1,
+      "tsDeployment": 1781035763,
+      "tsGovernance": 1
+    },
+    {
+      "name": "031_UpgradeEthenaARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1781612483,
+      "tsGovernance": 1
+    },
+    {
+      "name": "034_UpgradeEthenaARMGetBaseAssetsScript",
+      "proposalId": 1,
+      "tsDeployment": 1781855555,
+      "tsGovernance": 1
+    },
+    {
+      "name": "035_UnpauseEthenaARMScript",
+      "proposalId": "105952564920326880829480980653921695351704517467605619581569766325476268429476",
+      "tsDeployment": 1782206279,
+      "tsGovernance": 1
+    },
+    {
+      "name": "037_DeployUSDARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1783493495,
+      "tsGovernance": 1
+    },
+    {
+      "name": "036_DeployMultiAssetARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1783504775,
+      "tsGovernance": 1
+    },
+    {
+      "name": "038_DeployWETHARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1784724659,
+      "tsGovernance": 1
+    },
+    {
+      "name": "039_DeployUSDCARMScript",
+      "proposalId": 1,
+      "tsDeployment": 1784724659,
+      "tsGovernance": 1
+    },
+    {
+      "name": "040_UnpauseEtherFi",
+      "proposalId": 1,
+      "tsDeployment": 1784724659,
+      "tsGovernance": 1
+    },
+    {
+      "name": "041_RedeployEtherFiAdaptersScript",
+      "proposalId": 1,
+      "tsDeployment": 1785134531,
+      "tsGovernance": 1
+    },
+    {
+      "name": "042_DeployWETHMorphoMarketScript",
+      "proposalId": 1,
+      "tsDeployment": 1785160163,
+      "tsGovernance": 1
+    }
+  ]
 }

--- a/script/deploy/mainnet/042_DeployWETHMorphoMarketScript.s.sol
+++ b/script/deploy/mainnet/042_DeployWETHMorphoMarketScript.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+// Contracts
+import {Proxy} from "contracts/Proxy.sol";
+import {Mainnet} from "contracts/utils/Addresses.sol";
+import {MultiAssetARM} from "contracts/MultiAssetARM.sol";
+import {MorphoMarket} from "contracts/markets/MorphoMarket.sol";
+import {Abstract4626MarketWrapper} from "contracts/markets/Abstract4626MarketWrapper.sol";
+
+// Deployment
+import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";
+
+/// @title Deploy the WETH ARM Morpho market
+/// @notice Deploys a MorphoMarket wrapper for the WETH ARM using the same Morpho vault as the
+///         LidoARM and EtherFiARM wrappers. The mainnet 2/8 multisig owns the wrapper and acts as
+///         its harvester. It also adds and activates the wrapper on the WETH ARM.
+/// @dev The multisig actions are simulated in _fork(); on mainnet they are executed separately by
+///      the multisig after the proxy and implementation have been deployed.
+contract $042_DeployWETHMorphoMarketScript is AbstractDeployScript("042_DeployWETHMorphoMarketScript") {
+    function _execute() internal override {
+        address wethARM = resolver.resolve("WETH_ARM");
+
+        // 1. Deploy the MorphoMarket proxy.
+        Proxy morphoMarketProxy = new Proxy();
+        _recordDeployment("MORPHO_MARKET_WETH_ARM", address(morphoMarketProxy));
+
+        // 2. Deploy the implementation for the WETH ARM and the shared Morpho vault.
+        MorphoMarket morphoMarketImpl = new MorphoMarket(wethARM, Mainnet.MORPHO_WETH_VAULT);
+        _recordDeployment("MORPHO_MARKET_WETH_ARM_IMPL", address(morphoMarketImpl));
+
+        // 3. Initialize the wrapper and hand ownership to the WETH ARM's 2/8 multisig.
+        bytes memory data = abi.encodeWithSelector(
+            Abstract4626MarketWrapper.initialize.selector, Mainnet.MULTISIG_2_OF_8, Mainnet.MERKLE_DISTRIBUTOR
+        );
+        morphoMarketProxy.initialize(address(morphoMarketImpl), Mainnet.MULTISIG_2_OF_8, data);
+    }
+
+    function _fork() internal override {
+        MultiAssetARM wethARM = MultiAssetARM(payable(resolver.resolve("WETH_ARM")));
+        address morphoMarket = resolver.resolve("MORPHO_MARKET_WETH_ARM");
+
+        // Idempotent: the deployment runner can replay pending multisig actions on forks.
+        if (!wethARM.supportedMarkets(morphoMarket)) {
+            address[] memory markets = new address[](1);
+            markets[0] = morphoMarket;
+
+            vm.prank(Mainnet.MULTISIG_2_OF_8);
+            wethARM.addMarkets(markets);
+        }
+
+        if (wethARM.activeMarket() != morphoMarket) {
+            vm.prank(Mainnet.MULTISIG_2_OF_8);
+            wethARM.setActiveMarket(morphoMarket);
+        }
+    }
+}

--- a/src/contracts/utils/Addresses.sol
+++ b/src/contracts/utils/Addresses.sol
@@ -36,6 +36,9 @@ library Mainnet {
     // Tokens
     address public constant MORPHO = 0x58D97B57BB95320F9a05dC918Aef65434969c2B2;
 
+    // Morpho Vaults
+    address public constant MORPHO_WETH_VAULT = 0x3Dfe70B05657949A5dB340754aD664810ac63b21;
+
     // Origin
     address public constant OETH_VAULT = 0x39254033945AA2E4809Cc2977E7087BEE48bd7Ab;
 

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -58,16 +58,6 @@ contract Fork_EthenaARM_Smoke_Test is AbstractSmokeTest {
         assertEq(ethenaARM.liquidityAsset(), Mainnet.USDE, "liquidity asset");
         assertEq(ethenaARM.asset(), Mainnet.USDE, "ERC-4626 asset");
         assertEq(ethenaARM.claimDelay(), 10 minutes, "claim delay");
-        // The live Ethena ARM is still the 031 implementation (8-field `BaseAssetConfig`), while this
-        // branch compiles `EthenaARM` against the new 9-field struct. A typed getter call would decode
-        // 9 words from an 8-word return and revert, so read the config via a low-level staticcall and
-        // decode only the prefix up to `crossPrice` (index 4 / slot 2 — unchanged across both layouts).
-        (bool ok, bytes memory configData) =
-            address(ethenaARM).staticcall(abi.encodeWithSignature("baseAssetConfigs(address)", Mainnet.SUSDE));
-        require(ok, "baseAssetConfigs call failed");
-        (,,,, uint128 crossPrice) = abi.decode(configData, (uint128, uint128, uint128, uint128, uint128));
-        assertEq(crossPrice, 0.99996e36, "cross price");
-
         _assertBaseAssetListed(ethenaARM.getBaseAssets(), Mainnet.SUSDE, "sUSDe listed as base asset");
 
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -11,15 +11,6 @@ import {Proxy} from "contracts/Proxy.sol";
 import {Mainnet} from "contracts/utils/Addresses.sol";
 
 contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
-    /// @dev 0.998e36 = 0.998 USDC per base asset, the automation's minimum buy price.
-    uint256 internal constant MIN_BUY_PRICE = 0.998e36;
-    /// @dev 0.99995e36 = 0.99995 USDC per base asset, the automation's maximum buy price.
-    uint256 internal constant MAX_BUY_PRICE = 0.99995e36;
-    /// @dev 0.99997e36 = 0.99997 USDC per base asset, the automation's minimum sell price.
-    uint256 internal constant MIN_SELL_PRICE = 0.99997e36;
-    /// @dev 1e36 = 1 USDC per base asset, the automation's maximum sell price.
-    uint256 internal constant MAX_SELL_PRICE = 1e36;
-
     IERC20 usdc;
     IERC20 pyusd;
     IERC20 usdg;
@@ -97,20 +88,9 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
     }
 
     function _assertBaseAssetConfig(address baseAsset, address expectedAdapter, string memory label) internal view {
-        (
-            uint128 buyPrice,
-            uint128 sellPrice,,,
-            uint128 crossPrice,,
-            bool peggedToLiquidityAsset,
-            uint8 baseAssetDecimals,
-            address adapter
-        ) = usdcARM.baseAssetConfigs(baseAsset);
+        (,,,,,, bool peggedToLiquidityAsset, uint8 baseAssetDecimals, address adapter) =
+            usdcARM.baseAssetConfigs(baseAsset);
 
-        assertGe(buyPrice, MIN_BUY_PRICE, string.concat(label, " minimum buy price"));
-        assertLe(buyPrice, MAX_BUY_PRICE, string.concat(label, " maximum buy price"));
-        assertGe(sellPrice, MIN_SELL_PRICE, string.concat(label, " minimum sell price"));
-        assertLe(sellPrice, MAX_SELL_PRICE, string.concat(label, " maximum sell price"));
-        assertEq(crossPrice, 0.99997e36, string.concat(label, " cross price"));
         assertEq(peggedToLiquidityAsset, true, string.concat(label, " pegged"));
         assertEq(baseAssetDecimals, 6, string.concat(label, " base asset decimals"));
         assertEq(adapter, expectedAdapter, string.concat(label, " adapter"));

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -88,22 +88,17 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
 
     function _assertBaseAssetConfig(address baseAsset, string memory adapterName, bool pegged) internal view {
         (
-            uint128 buyPrice,
-            uint128 sellPrice,
+            ,,
             uint128 buyLiquidityRemaining,
-            uint128 sellLiquidityRemaining,
-            uint128 crossPrice,
+            uint128 sellLiquidityRemaining,,
             uint128 pendingRedeemAssets,
             bool peggedToLiquidityAsset,
             uint8 baseAssetDecimals,
             address adapter
         ) = wethARM.baseAssetConfigs(baseAsset);
 
-        assertEq(buyPrice, 0.9997e36, "buy price");
-        assertEq(sellPrice, 1e36, "sell price");
         assertEq(buyLiquidityRemaining, 0, "buy liquidity disabled");
         assertEq(sellLiquidityRemaining, 0, "sell liquidity disabled");
-        assertEq(crossPrice, 0.99996e36, "cross price");
         assertEq(pendingRedeemAssets, 0, "pending redeem assets");
         assertEq(peggedToLiquidityAsset, pegged, "pegged");
         assertEq(baseAssetDecimals, 18, "base asset decimals");

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -7,6 +7,7 @@ import {MultiAssetARM} from "contracts/MultiAssetARM.sol";
 import {CapManager} from "contracts/CapManager.sol";
 import {Proxy} from "contracts/Proxy.sol";
 import {Mainnet} from "contracts/utils/Addresses.sol";
+import {Abstract4626MarketWrapper} from "contracts/markets/Abstract4626MarketWrapper.sol";
 
 contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
     MultiAssetARM internal wethARM;
@@ -65,6 +66,24 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
             resolver.resolve("WETH_ARM_WEETH_ADAPTER_IMPL"),
             "weETH adapter implementation"
         );
+    }
+
+    function test_MorphoMarketConfig() external view {
+        Abstract4626MarketWrapper morphoMarket = Abstract4626MarketWrapper(resolver.resolve("MORPHO_MARKET_WETH_ARM"));
+        Abstract4626MarketWrapper lidoMarket = Abstract4626MarketWrapper(resolver.resolve("MORPHO_MARKET_LIDO"));
+        address etherFiActiveMarket = MultiAssetARM(payable(resolver.resolve("ETHER_FI_ARM"))).activeMarket();
+        Abstract4626MarketWrapper etherFiMarket = Abstract4626MarketWrapper(etherFiActiveMarket);
+
+        assertEq(morphoMarket.arm(), address(wethARM), "market arm");
+        assertEq(morphoMarket.asset(), Mainnet.WETH, "market asset");
+        assertEq(morphoMarket.market(), Mainnet.MORPHO_WETH_VAULT, "configured Morpho vault");
+        assertEq(morphoMarket.market(), lidoMarket.market(), "Lido Morpho vault");
+        assertEq(morphoMarket.market(), etherFiMarket.market(), "EtherFi Morpho vault");
+        assertEq(morphoMarket.owner(), Mainnet.MULTISIG_2_OF_8, "market owner");
+        assertEq(morphoMarket.harvester(), Mainnet.MULTISIG_2_OF_8, "market harvester");
+        assertEq(address(morphoMarket.merkleDistributor()), Mainnet.MERKLE_DISTRIBUTOR, "Merkle distributor");
+        assertTrue(wethARM.supportedMarkets(address(morphoMarket)), "market supported");
+        assertEq(wethARM.activeMarket(), address(morphoMarket), "active market");
     }
 
     function _assertBaseAssetConfig(address baseAsset, string memory adapterName, bool pegged) internal view {

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -33,7 +33,7 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
         assertEq(capManager.arm(), address(wethARM), "cap manager arm");
         assertEq(capManager.totalAssetsCap(), 250 ether, "total assets cap");
         assertTrue(capManager.accountCapEnabled(), "account cap enabled");
-        assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 250 ether, "liquidity provider cap");
+        assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 245 ether, "liquidity provider cap");
         assertEq(capManager.operator(), Mainnet.MULTISIG_2_OF_8, "cap manager operator");
         assertEq(capManager.owner(), Mainnet.MULTISIG_2_OF_8, "cap manager owner");
     }

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -87,19 +87,9 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
     }
 
     function _assertBaseAssetConfig(address baseAsset, string memory adapterName, bool pegged) internal view {
-        (
-            ,,
-            uint128 buyLiquidityRemaining,
-            uint128 sellLiquidityRemaining,,
-            uint128 pendingRedeemAssets,
-            bool peggedToLiquidityAsset,
-            uint8 baseAssetDecimals,
-            address adapter
-        ) = wethARM.baseAssetConfigs(baseAsset);
+        (,,,,,, bool peggedToLiquidityAsset, uint8 baseAssetDecimals, address adapter) =
+            wethARM.baseAssetConfigs(baseAsset);
 
-        assertEq(buyLiquidityRemaining, 0, "buy liquidity disabled");
-        assertEq(sellLiquidityRemaining, 0, "sell liquidity disabled");
-        assertEq(pendingRedeemAssets, 0, "pending redeem assets");
         assertEq(peggedToLiquidityAsset, pegged, "pegged");
         assertEq(baseAssetDecimals, 18, "base asset decimals");
         assertEq(adapter, resolver.resolve(adapterName), "adapter");


### PR DESCRIPTION
# Description

Record the mainnet deployment of a `MorphoMarket` wrapper for the WETH ARM. The wrapper uses the same WETH Morpho vault as the active LidoARM and EtherFiARM markets, and is owned by the mainnet 2/8 multisig.

The deployment file also marks the previously executed `041` WETH ARM EtherFi adapter upgrades as complete.

## Deployment

Script `script/deploy/mainnet/042_DeployWETHMorphoMarketScript.s.sol`

## Contracts

| Contract | Address |
| - | - |
| WETH ARM `MorphoMarket` proxy | [0xe192824f42ae3D643ac867774b45E8d233d86c72](https://etherscan.io/address/0xe192824f42ae3D643ac867774b45E8d233d86c72) |
| WETH ARM `MorphoMarket` implementation | [0x4E715556Cd84926FD5EAc206a016711E38273aD4](https://etherscan.io/address/0x4E715556Cd84926FD5EAc206a016711E38273aD4) |

## Contract diff

```bash
make match file=src/contracts/Proxy.sol addr=0xe192824f42ae3D643ac867774b45E8d233d86c72
make match file=src/contracts/markets/MorphoMarket.sol addr=0x4E715556Cd84926FD5EAc206a016711E38273aD4
```

## Configuration

| Param | Value | Note |
| - | - | - |
| `arm` | `0x68025A4615407993A680102b08a23A61D11C657C` | WETH ARM |
| `market` | `0x3Dfe70B05657949A5dB340754aD664810ac63b21` | Shared Morpho WETH vault |
| `asset` | `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2` | WETH |
| `owner` | `0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971` | Mainnet 2/8 multisig |
| `harvester` | `0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971` | Mainnet 2/8 multisig |
| `merkleDistributor` | `0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae` | Morpho rewards distributor |

The proxy points to the implementation recorded above.

## Governance

There is no `GovernorSix` proposal. The market proxy is owned directly by the mainnet 2/8 multisig.

`042_DeployWETHMorphoMarketScript` is recorded with `proposalId: 1` and `tsGovernance: 0` because the WETH ARM market registration and activation are pending manual execution by the 2/8 multisig.

## Required post-deployment actions (2/8 multisig)

The mainnet 2/8 multisig must execute:

1. `WETH_ARM.addMarkets([0xe192824f42ae3D643ac867774b45E8d233d86c72])`
2. `WETH_ARM.setActiveMarket(0xe192824f42ae3D643ac867774b45E8d233d86c72)`

On-chain verification currently reports the market as unsupported and `activeMarket` as the zero address. Once both actions are confirmed, update the deployment entry's `tsGovernance` to `1`.

## Tests

- `forge build`
- `make test-smoke` — 41/41 tests passed; the deployment framework simulated the pending multisig actions on the fork.
- Both `make match` checks above passed.
- Confirmed the proxy implementation, wrapper configuration, and pending WETH ARM actions on mainnet.
