### PR TITLE
ARM pricing changes

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -13,18 +13,18 @@ runner works.
 
 Cron times are UTC. Enable state is managed in the database, not here.
 
-The mainnet `setPrices*` actions use `--amount` as the DEX swap amount when
-fetching the reference price quote. This is separate from `--buy-amount` and
+The mainnet `setPrices*` actions use `--amount` as an explicit override for the
+DEX swap amount when fetching the reference price quote. This is separate from `--buy-amount` and
 `--sell-amount`, which set the buy-side liquidity-asset and sell-side base-asset
 liquidity remaining on the Ethena, USDC, and WETH ARMs. If omitted, each limit is
 set to the maximum `uint128` value. Liquidity amounts are integer native token
 units (for example, `100000000` is 100 tokens for an asset with 6 decimals).
+When `--amount` is omitted, the DEX quote amount is the smaller of the
+withdrawable ARM/market reserves and the corresponding price liquidity limit.
+An explicit `--amount` is used unchanged.
 
 `--buy-price` and `--sell-price` bypass DEX-derived pricing and set an exact
 pair. Both must be supplied together; `--amount` is not used in this mode.
-When the Ethena or USDC action derives `--amount` from withdrawable liquidity,
-it rounds the available amount up to the minimum DEX quote size of 1,000 USDe
-or 1,000 USDC respectively; an explicit `--amount` override is used as supplied.
 
 `setPricesWETH` uses the Lido pricing profile and 1Inch for `STETH,WSTETH`, and
 the EtherFi pricing profile and Kyber for `EETH,WEETH`. It processes all four

--- a/src/js/tasks/actions/setPricesEthena.ts
+++ b/src/js/tasks/actions/setPricesEthena.ts
@@ -4,7 +4,6 @@ import { types } from "hardhat/config";
 import { action } from "../lib/action";
 import { setPrices } from "../armPrices";
 import { setPricesForBases } from "../../utils/priceActionUtils";
-import { resolveEthenaAggregatorAmount } from "../../utils/ethenaPricing";
 import { mainnet } from "../../utils/addresses";
 const ethenaARMAbi = require("../../../abis/EthenaARM.json");
 
@@ -118,17 +117,6 @@ action({
     const arm = new ethers.Contract(mainnet.ethenaARM, ethenaARMAbi, signer);
 
     log.info("Setting prices for Ethena ARM");
-    const exactPrices =
-      args.buyPrice !== undefined && args.sellPrice !== undefined;
-    let amount = args.amount;
-    if (!exactPrices && amount === undefined) {
-      amount = await resolveEthenaAggregatorAmount({
-        arm,
-        log,
-        blockTag: "latest",
-      });
-    }
-
     await setPricesForBases({
       setPrices,
       bases: ["SUSDE"],
@@ -146,7 +134,7 @@ action({
         minBuyPrice: args.minBuyPrice,
         kyber: args.kyber,
         inch: args.inch,
-        amount,
+        amount: args.amount,
         tolerance: args.tolerance,
         fee: args.fee,
         offset: args.offset,

--- a/src/js/tasks/actions/setPricesEtherFi.ts
+++ b/src/js/tasks/actions/setPricesEtherFi.ts
@@ -55,8 +55,8 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "DEX swap amount used to fetch the reference price quote.",
-        20,
+        "Override the automatically detected DEX swap amount used to fetch the reference price quote.",
+        undefined,
         types.float,
       )
       .addOptionalParam(

--- a/src/js/tasks/actions/setPricesLido.ts
+++ b/src/js/tasks/actions/setPricesLido.ts
@@ -55,8 +55,8 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "DEX swap amount used to fetch the reference price quote.",
-        20,
+        "Override the automatically detected DEX swap amount used to fetch the reference price quote.",
+        undefined,
         types.float,
       )
       .addOptionalParam(

--- a/src/js/tasks/actions/setPricesOETH.ts
+++ b/src/js/tasks/actions/setPricesOETH.ts
@@ -55,8 +55,8 @@ action({
       )
       .addOptionalParam(
         "amount",
-        "DEX swap amount used to fetch the reference price quote.",
-        10,
+        "Override the automatically detected DEX swap amount used to fetch the reference price quote.",
+        undefined,
         types.float,
       )
       .addOptionalParam(

--- a/src/js/tasks/actions/setPricesUSDC.ts
+++ b/src/js/tasks/actions/setPricesUSDC.ts
@@ -4,7 +4,6 @@ import { types } from "hardhat/config";
 import { action } from "../lib/action";
 import { setPrices } from "../armPrices";
 import { setPricesForBases } from "../../utils/priceActionUtils";
-import { resolveUsdAggregatorAmount } from "../../utils/usdPricing";
 import { mainnet } from "../../utils/addresses";
 const multiAssetARMAbi = require("../../../abis/MultiAssetARM.json");
 
@@ -122,17 +121,6 @@ action({
     const arm = new ethers.Contract(mainnet.usdcARM, multiAssetARMAbi, signer);
 
     log.info("Setting prices for USDC ARM");
-    const exactPrices =
-      args.buyPrice !== undefined && args.sellPrice !== undefined;
-    let amount = args.amount;
-    if (!exactPrices && amount === undefined) {
-      amount = await resolveUsdAggregatorAmount({
-        arm,
-        log,
-        blockTag: "latest",
-      });
-    }
-
     await setPricesForBases({
       setPrices,
       bases: String(args.bases).split(","),
@@ -150,7 +138,7 @@ action({
         minBuyPrice: args.minBuyPrice,
         kyber: args.kyber,
         inch: args.inch,
-        amount,
+        amount: args.amount,
         tolerance: args.tolerance,
         fee: args.fee,
         offset: args.offset,

--- a/src/js/tasks/actions/setPricesWETH.ts
+++ b/src/js/tasks/actions/setPricesWETH.ts
@@ -178,7 +178,7 @@ action({
           minBuyPrice: args.minBuyPrice ?? defaults.minBuyPrice,
           kyber: aggregatorOverridden ? Boolean(args.kyber) : defaults.kyber,
           inch: aggregatorOverridden ? Boolean(args.inch) : defaults.inch,
-          amount: args.amount ?? 20,
+          amount: args.amount,
           tolerance: args.tolerance ?? defaults.tolerance,
           fee: args.fee,
           offset: args.offset,

--- a/src/js/tasks/armPrices.js
+++ b/src/js/tasks/armPrices.js
@@ -18,7 +18,10 @@ const {
   rangeSellPrice,
   rangeBuyPrice,
 } = require("../utils/pricing");
-const { haveSwapCapsChanged } = require("../utils/priceUpdate");
+const {
+  haveSwapCapsChanged,
+  resolveDexQuoteAmount,
+} = require("../utils/priceUpdate");
 
 const log = require("../utils/logger")("task:prices");
 
@@ -133,11 +136,38 @@ const setPrices = async (options) => {
       if (curve && options.armName !== "Lido")
         throw new Error(`Curve prices only available for Lido`);
 
+      let reserves;
+      if (options.amount === undefined || options.amount === null) {
+        if (baseContext.version !== "multiBase") {
+          throw new Error(
+            `--amount is required when pricing a legacy ${options.armName} ARM`,
+          );
+        }
+        reserves = await baseContext.arm.getReserves(baseAddress, {
+          blockTag: options.blockTag ?? "latest",
+        });
+      }
+
+      const dexAmount = resolveDexQuoteAmount({
+        amount: options.amount,
+        liquidityAssets: reserves?.liquidityAssets ?? reserves?.[0],
+        baseAssetReserve: reserves?.baseAssetReserve ?? reserves?.[1],
+        buyLiquidity: parseSwapCap(buyAmount),
+        sellLiquidity: parseSwapCap(sellAmount),
+        liquidityDecimals,
+        baseDecimals,
+      });
+      if (options.amount === undefined || options.amount === null) {
+        log(
+          `Using ${dexAmount} as the DEX quote amount based on available reserves and price liquidity`,
+        );
+      }
+
       // 2.1 Get latest market prices if no midPrice is provided
       referencePrices = inch
         ? // 2.1.b Otherwise, get prices from 1Inch
           await get1InchPrices(
-            options.amount,
+            dexAmount,
             assets,
             inchFee,
             1,
@@ -147,7 +177,7 @@ const setPrices = async (options) => {
         : kyber
           ? // 2.1.c Or from Kyber if specified
             await getKyberPrices(
-              options.amount,
+              dexAmount,
               assets,
               baseDecimals,
               liquidityDecimals,
@@ -155,17 +185,18 @@ const setPrices = async (options) => {
           : // 2.1.d Or from Curve if specified
             await getCurvePrices({
               ...options,
+              amount: dexAmount,
               poolAddress: addresses.mainnet.CurveNgStEthPool,
             });
 
       // Adjust price down if a wrapped asset like sUSDe or wstETH
       if (shouldAdjustWrapped) {
-        const amountIn = parseUnits(options.amount.toString(), baseDecimals);
+        const amountIn = parseUnits(dexAmount, baseDecimals);
         // The legacy convertToAsset path returns 18 decimals while the adapter
         // converts a base decimals input to liquidity decimals
         const convertedAssets =
           config.adapter === ZeroAddress
-            ? await convertToAsset(baseAddress, options.amount, signer)
+            ? await convertToAsset(baseAddress, dexAmount, signer)
             : await (
                 await adapterContract(config.adapter, signer)
               ).convertToAssets(amountIn);

--- a/src/js/utils/priceUpdate.js
+++ b/src/js/utils/priceUpdate.js
@@ -1,8 +1,52 @@
+const { formatUnits, parseUnits } = require("ethers");
+
+const capDexAmountBySwapLiquidity = ({
+  amount,
+  buyLiquidity,
+  sellLiquidity,
+  liquidityDecimals,
+  baseDecimals,
+}) => {
+  let cappedAmount = amount.toString();
+
+  if (parseUnits(cappedAmount, liquidityDecimals) > buyLiquidity) {
+    cappedAmount = formatUnits(buyLiquidity, liquidityDecimals);
+  }
+  if (parseUnits(cappedAmount, baseDecimals) > sellLiquidity) {
+    cappedAmount = formatUnits(sellLiquidity, baseDecimals);
+  }
+
+  return cappedAmount;
+};
+
+const resolveDexQuoteAmount = ({
+  amount,
+  liquidityAssets,
+  baseAssetReserve,
+  buyLiquidity,
+  sellLiquidity,
+  liquidityDecimals,
+  baseDecimals,
+}) => {
+  if (amount !== undefined && amount !== null) return amount.toString();
+
+  return capDexAmountBySwapLiquidity({
+    amount: formatUnits(liquidityAssets, liquidityDecimals),
+    buyLiquidity,
+    sellLiquidity:
+      baseAssetReserve < sellLiquidity ? baseAssetReserve : sellLiquidity,
+    liquidityDecimals,
+    baseDecimals,
+  });
+};
+
 const haveSwapCapsChanged = (baseContext, buyAmount, sellAmount) =>
   baseContext.version === "multiBase" &&
   (buyAmount !== baseContext.config.buyLiquidityRemaining ||
     sellAmount !== baseContext.config.sellLiquidityRemaining);
 
 module.exports = {
+  capDexAmountBySwapLiquidity,
   haveSwapCapsChanged,
+  resolveDexQuoteAmount,
 };

--- a/test/js/armPrices.test.js
+++ b/test/js/armPrices.test.js
@@ -1,6 +1,10 @@
 const assert = require("assert");
 
-const { haveSwapCapsChanged } = require("../../src/js/utils/priceUpdate");
+const {
+  capDexAmountBySwapLiquidity,
+  haveSwapCapsChanged,
+  resolveDexQuoteAmount,
+} = require("../../src/js/utils/priceUpdate");
 
 const multiBaseContext = (buyLiquidityRemaining, sellLiquidityRemaining) => ({
   version: "multiBase",
@@ -32,6 +36,81 @@ assert.strictEqual(
   haveSwapCapsChanged({ version: "legacy" }, 10n, 20n),
   false,
   "legacy ARMs do not support buy and sell amounts",
+);
+
+assert.strictEqual(
+  capDexAmountBySwapLiquidity({
+    amount: 100,
+    buyLiquidity: 50000000n,
+    sellLiquidity: (1n << 128n) - 1n,
+    liquidityDecimals: 6,
+    baseDecimals: 18,
+  }),
+  "50.0",
+  "buy quote amount should not exceed buy liquidity",
+);
+
+assert.strictEqual(
+  capDexAmountBySwapLiquidity({
+    amount: 100,
+    buyLiquidity: (1n << 128n) - 1n,
+    sellLiquidity: 25000000000000000000n,
+    liquidityDecimals: 6,
+    baseDecimals: 18,
+  }),
+  "25.0",
+  "sell quote amount should not exceed sell liquidity",
+);
+
+assert.strictEqual(
+  capDexAmountBySwapLiquidity({
+    amount: 20,
+    buyLiquidity: 30000000n,
+    sellLiquidity: 10000000000000000000n,
+    liquidityDecimals: 6,
+    baseDecimals: 18,
+  }),
+  "10.0",
+  "quote amount should use the lower of buy and sell liquidity",
+);
+
+assert.strictEqual(
+  capDexAmountBySwapLiquidity({
+    amount: 20,
+    buyLiquidity: 30000000n,
+    sellLiquidity: 40000000000000000000n,
+    liquidityDecimals: 6,
+    baseDecimals: 18,
+  }),
+  "20",
+  "quote amount within both liquidity limits should be unchanged",
+);
+
+assert.strictEqual(
+  resolveDexQuoteAmount({
+    amount: 100,
+    liquidityAssets: 50000000n,
+    baseAssetReserve: 25000000000000000000n,
+    buyLiquidity: 30000000n,
+    sellLiquidity: 10000000000000000000n,
+    liquidityDecimals: 6,
+    baseDecimals: 18,
+  }),
+  "100",
+  "an explicit quote amount should override reserves and price liquidity",
+);
+
+assert.strictEqual(
+  resolveDexQuoteAmount({
+    liquidityAssets: 50000000n,
+    baseAssetReserve: 40000000000000000000n,
+    buyLiquidity: 30000000n,
+    sellLiquidity: 20000000000000000000n,
+    liquidityDecimals: 6,
+    baseDecimals: 18,
+  }),
+  "20.0",
+  "an automatic quote amount should use the smallest reserve or price liquidity limit",
 );
 
 console.log("ARM price tests passed");

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -78,7 +78,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(capManager.totalAssetsCap(), 1_000_000e18, "total assets cap");
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
         assertEq(
-            capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 1_000_000e18 - 100_000e6, "liquidity provider cap"
+            capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 1_000_000e18 - 200_000e6, "liquidity provider cap"
         );
         assertEq(capManager.operator(), operator, "cap manager operator");
         assertEq(capManager.owner(), Mainnet.MULTISIG_2_OF_8, "cap manager owner");


### PR DESCRIPTION
## Summary

- Automatically size DEX quotes using the smaller of available ARM/market reserves and configured price liquidity limits.
- Allow an explicit `--amount` to override automatic sizing unchanged.
- Apply the shared sizing logic across all `setPrices*` actions and DEX sources.
- Remove hardcoded quote-size defaults and the Ethena/USDC-specific sizing paths.
- Handle differing base and liquidity asset decimals.
- Require `--amount` when pricing legacy ARMs that do not expose reserve and liquidity-limit data.
- Update action documentation and unit coverage.

## Testing

- `node test/js/armPrices.test.js`
- ESLint
- Prettier
- `git diff --check`