### PR TITLE
Allow batch withdrawal claims in Talos actions

### DIFF
--- a/src/js/tasks/actions/autoClaimLidoWithdraw.ts
+++ b/src/js/tasks/actions/autoClaimLidoWithdraw.ts
@@ -13,12 +13,19 @@ action({
   description: "Claim Lido withdrawals from Lido ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "id",
-      "Specific Lido withdrawal request identifier to claim. (default: all)",
-      undefined,
-      types.string,
-    ),
+    t
+      .addOptionalParam(
+        "id",
+        "Specific Lido withdrawal request identifier to claim. (deprecated: use ids)",
+        undefined,
+        types.string,
+      )
+      .addOptionalParam(
+        "ids",
+        "Comma-separated Lido withdrawal request identifiers to claim. (default: all)",
+        undefined,
+        types.string,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.lidoARM, lidoARMAbi, signer);
     const withdrawalQueue = new ethers.Contract(
@@ -38,6 +45,7 @@ action({
         armName: "Lido",
         withdrawalQueue,
         id: args.id,
+        ids: args.ids,
       },
     });
   },

--- a/src/js/tasks/actions/autoClaimWETHEtherFiWithdraw.ts
+++ b/src/js/tasks/actions/autoClaimWETHEtherFiWithdraw.ts
@@ -12,12 +12,19 @@ action({
   description: "Claim EtherFi withdrawals from WETH ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "id",
-      "Specific EtherFi withdrawal request identifier to claim. (default: all)",
-      undefined,
-      types.string,
-    ),
+    t
+      .addOptionalParam(
+        "id",
+        "Specific EtherFi withdrawal request identifier to claim. (deprecated: use ids)",
+        undefined,
+        types.string,
+      )
+      .addOptionalParam(
+        "ids",
+        "Comma-separated EtherFi withdrawal request identifiers to claim. (default: all)",
+        undefined,
+        types.string,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.wethARM, multiAssetARMAbi, signer);
 
@@ -31,6 +38,7 @@ action({
         arm,
         armName: "WETH",
         id: args.id,
+        ids: args.ids,
       },
     });
   },

--- a/src/js/tasks/actions/autoClaimWETHLidoWithdraw.ts
+++ b/src/js/tasks/actions/autoClaimWETHLidoWithdraw.ts
@@ -12,12 +12,19 @@ action({
   description: "Claim Lido withdrawals from WETH ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "id",
-      "Specific Lido withdrawal request identifier to claim. (default: all)",
-      undefined,
-      types.string,
-    ),
+    t
+      .addOptionalParam(
+        "id",
+        "Specific Lido withdrawal request identifier to claim. (deprecated: use ids)",
+        undefined,
+        types.string,
+      )
+      .addOptionalParam(
+        "ids",
+        "Comma-separated Lido withdrawal request identifiers to claim. (default: all)",
+        undefined,
+        types.string,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.wethARM, multiAssetARMAbi, signer);
 
@@ -31,6 +38,7 @@ action({
         arm,
         armName: "WETH",
         id: args.id,
+        ids: args.ids,
       },
     });
   },

--- a/src/js/tasks/etherfiQueue.js
+++ b/src/js/tasks/etherfiQueue.js
@@ -10,6 +10,7 @@ const {
 } = require("../utils/arm");
 const addresses = require("../utils/addresses");
 const { createApolloClient } = require("../utils/apollo");
+const { parseRequestIds } = require("../utils/requestIds");
 const { logTxDetails } = require("../utils/txLogger");
 
 const log = require("../utils/logger")("task:etherfiQueue");
@@ -42,12 +43,13 @@ const requestEtherFiWithdrawals = async (options) => {
 };
 
 const claimEtherFiWithdrawals = async (options) => {
-  const { signer, id } = options;
+  const { signer } = options;
   const baseContext = await resolveArmBase(options);
 
-  const requestIds = id
-    ? // If an id is provided, just claim that one
-      [id]
+  const selectedRequestIds = parseRequestIds(options);
+  const requestIds = selectedRequestIds
+    ? // If ids are provided, claim exactly those requests.
+      selectedRequestIds
     : // Get the outstanding EtherFi withdrawal requests for the ARM
       await claimableEtherFiRequests(signer);
 

--- a/src/js/tasks/lidoQueue.js
+++ b/src/js/tasks/lidoQueue.js
@@ -7,6 +7,7 @@ const {
   requestBaseAssetWithdrawal,
   resolveArmBase,
 } = require("../utils/arm");
+const { parseRequestIds } = require("../utils/requestIds");
 const { logTxDetails } = require("../utils/txLogger");
 
 const log = require("../utils/logger")("task:lidoQueue");
@@ -83,9 +84,10 @@ const requestLidoWithdrawals = async (options) => {
 };
 
 const claimLidoWithdrawals = async (options) => {
-  const { signer, id, withdrawalQueue } = options;
+  const { signer, withdrawalQueue } = options;
   const baseContext = await resolveArmBase(options);
   const { config } = baseContext;
+  const selectedRequestIds = parseRequestIds(options);
 
   if (baseContext.version === "legacy") {
     if (!withdrawalQueue) {
@@ -93,8 +95,8 @@ const claimLidoWithdrawals = async (options) => {
     }
 
     const finalizedIds = [];
-    if (id) {
-      finalizedIds.push(id);
+    if (selectedRequestIds) {
+      finalizedIds.push(...selectedRequestIds);
     } else {
       const requestIds = await withdrawalQueue.getWithdrawalRequests(
         await baseContext.arm.getAddress(),
@@ -150,11 +152,21 @@ const claimLidoWithdrawals = async (options) => {
   const adapter = await adapterContract(config.adapter, signer);
 
   let shares;
-  if (id) {
-    shares = await adapter["requestShares(uint256)"](id);
+  if (selectedRequestIds) {
+    shares = 0n;
+    for (const requestId of selectedRequestIds) {
+      const requestShares = await adapter["requestShares(uint256)"](requestId);
+      if (requestShares === 0n) {
+        log(
+          `Withdrawal request ${requestId} does not belong to the ${baseContext.baseSymbol} adapter`,
+        );
+        continue;
+      }
+      shares += requestShares;
+    }
     if (shares === 0n) {
       log(
-        `Withdrawal request ${id} does not belong to the ${baseContext.baseSymbol} adapter`,
+        `No selected withdrawal requests belong to the ${baseContext.baseSymbol} adapter`,
       );
       return;
     }

--- a/src/js/utils/requestIds.js
+++ b/src/js/utils/requestIds.js
@@ -1,0 +1,34 @@
+const parseRequestIds = ({ id, ids }) => {
+  if (id !== undefined && ids !== undefined) {
+    throw new Error("Specify either id or ids, not both");
+  }
+
+  const requestIdInputs = ids ?? id;
+  if (requestIdInputs === undefined) return undefined;
+
+  const values = Array.isArray(requestIdInputs)
+    ? requestIdInputs
+    : requestIdInputs.toString().split(",");
+
+  if (values.length === 0) {
+    throw new Error("At least one withdrawal request id is required");
+  }
+
+  const requestIds = values.map((value) => {
+    const requestId = value.toString().trim();
+    if (!/^\d+$/.test(requestId)) {
+      throw new Error(`Invalid withdrawal request id: ${value}`);
+    }
+    return BigInt(requestId);
+  });
+
+  for (let index = 1; index < requestIds.length; index++) {
+    if (requestIds[index - 1] >= requestIds[index]) {
+      throw new Error("Withdrawal request ids must be in ascending FIFO order");
+    }
+  }
+
+  return requestIds;
+};
+
+module.exports = { parseRequestIds };

--- a/test/js/requestIds.test.js
+++ b/test/js/requestIds.test.js
@@ -1,0 +1,30 @@
+const assert = require("assert");
+
+const { parseRequestIds } = require("../../src/js/utils/requestIds");
+
+const run = () => {
+  assert.deepStrictEqual(parseRequestIds({}), undefined);
+  assert.deepStrictEqual(parseRequestIds({ id: "81143" }), [81143n]);
+  assert.deepStrictEqual(parseRequestIds({ ids: "81143, 81155,81158" }), [
+    81143n,
+    81155n,
+    81158n,
+  ]);
+  assert.throws(
+    () => parseRequestIds({ id: "81143", ids: "81155" }),
+    /either id or ids/,
+  );
+  assert.throws(() => parseRequestIds({ ids: "81143,invalid" }), /Invalid/);
+  assert.throws(
+    () => parseRequestIds({ ids: "81155,81143" }),
+    /ascending FIFO order/,
+  );
+};
+
+try {
+  run();
+  console.log("requestIds tests passed");
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -75,11 +75,15 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         _assertBaseAssetListed(baseAssets, Mainnet.USDG, "USDG listed as base asset");
 
         assertEq(capManager.arm(), address(usdcARM), "cap manager arm");
-        assertEq(capManager.totalAssetsCap(), 100_000e6, "total assets cap");
+        assertEq(capManager.totalAssetsCap(), 1_000_000e18, "total assets cap");
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
-        assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 100_000e6, "liquidity provider cap");
+        assertEq(
+            capManager.liquidityProviderCaps(Mainnet.TREASURY_LP),
+            1_000_000e18 - 100_000e6,
+            "liquidity provider cap"
+        );
         assertEq(capManager.operator(), operator, "cap manager operator");
-        assertEq(capManager.owner(), Mainnet.MULTISIG_5_OF_8, "cap manager owner");
+        assertEq(capManager.owner(), Mainnet.MULTISIG_2_OF_8, "cap manager owner");
     }
 
     function test_baseAssetConfigs() external view {
@@ -181,7 +185,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
 
         // 2. Owner configures the Paxos deposit address (mocked as a test address).
         address paxosRecipient = makeAddr("paxosRecipient");
-        vm.prank(Mainnet.MULTISIG_2_OF_8);
+        vm.prank(Mainnet.MULTISIG_5_OF_8);
         adapter.setPaxosRecipient(paxosRecipient);
 
         // 3. Operator submits the queued base assets to Paxos.

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -43,7 +43,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
     function test_initialConfig() external view {
         assertEq(usdcARM.name(), "USDC ARM", "Name");
         assertEq(usdcARM.symbol(), "ARM-USDC", "Symbol");
-        assertEq(usdcARM.owner(), Mainnet.MULTISIG_2_OF_8, "Owner");
+        assertEq(usdcARM.owner(), Mainnet.MULTISIG_5_OF_8, "Owner");
         assertEq(usdcARM.operator(), operator, "Operator");
         assertEq(usdcARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "Fee collector");
         assertEq(usdcARM.fee(), 2000, "Performance fee");
@@ -54,7 +54,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(pyusdAdapter.arm(), address(usdcARM), "PYUSD adapter arm");
         assertEq(address(pyusdAdapter.baseAsset()), Mainnet.PYUSD, "PYUSD adapter base asset");
         assertEq(pyusdAdapter.asset(), Mainnet.USDC, "PYUSD adapter liquidity asset");
-        assertEq(pyusdAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "PYUSD adapter owner");
+        assertEq(pyusdAdapter.owner(), Mainnet.MULTISIG_5_OF_8, "PYUSD adapter owner");
         assertEq(pyusdAdapter.operator(), operator, "PYUSD adapter operator");
         assertNotEq(pyusdAdapter.paxosRecipient(), address(0), "PYUSD adapter paxos recipient");
         assertEq(
@@ -65,7 +65,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(usdgAdapter.arm(), address(usdcARM), "USDG adapter arm");
         assertEq(address(usdgAdapter.baseAsset()), Mainnet.USDG, "USDG adapter base asset");
         assertEq(usdgAdapter.asset(), Mainnet.USDC, "USDG adapter liquidity asset");
-        assertEq(usdgAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "USDG adapter owner");
+        assertEq(usdgAdapter.owner(), Mainnet.MULTISIG_5_OF_8, "USDG adapter owner");
         assertEq(usdgAdapter.operator(), operator, "USDG adapter operator");
         assertNotEq(usdgAdapter.paxosRecipient(), address(0), "USDG adapter paxos recipient");
         assertEq(address(usdgAdapter), resolver.resolve("USDC_ARM_USDG_ADAPTER"), "USDG adapter proxy used by USDC ARM");
@@ -79,7 +79,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
         assertEq(capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 100_000e6, "liquidity provider cap");
         assertEq(capManager.operator(), operator, "cap manager operator");
-        assertEq(capManager.owner(), Mainnet.MULTISIG_2_OF_8, "cap manager owner");
+        assertEq(capManager.owner(), Mainnet.MULTISIG_5_OF_8, "cap manager owner");
     }
 
     function test_baseAssetConfigs() external view {

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -78,9 +78,7 @@ contract Fork_PaxosARM_Smoke_Test is AbstractSmokeTest {
         assertEq(capManager.totalAssetsCap(), 1_000_000e18, "total assets cap");
         assertEq(capManager.accountCapEnabled(), true, "account cap enabled");
         assertEq(
-            capManager.liquidityProviderCaps(Mainnet.TREASURY_LP),
-            1_000_000e18 - 100_000e6,
-            "liquidity provider cap"
+            capManager.liquidityProviderCaps(Mainnet.TREASURY_LP), 1_000_000e18 - 100_000e6, "liquidity provider cap"
         );
         assertEq(capManager.operator(), operator, "cap manager operator");
         assertEq(capManager.owner(), Mainnet.MULTISIG_2_OF_8, "cap manager owner");

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -23,7 +23,7 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
     function test_InitialConfig() external view {
         assertEq(wethARM.name(), "WETH ARM", "name");
         assertEq(wethARM.symbol(), "ARM-WETH", "symbol");
-        assertEq(wethARM.owner(), Mainnet.MULTISIG_2_OF_8, "owner");
+        assertEq(wethARM.owner(), Mainnet.MULTISIG_5_OF_8, "owner");
         assertEq(wethARM.operator(), Mainnet.ARM_TALOS_RELAYER, "operator");
         assertEq(wethARM.feeCollector(), Mainnet.BUYBACK_OPERATOR, "fee collector");
         assertEq(wethARM.fee(), 2000, "performance fee");
@@ -56,8 +56,8 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
         Proxy eethAdapter = Proxy(payable(resolver.resolve("WETH_ARM_EETH_ADAPTER")));
         Proxy weethAdapter = Proxy(payable(resolver.resolve("WETH_ARM_WEETH_ADAPTER")));
 
-        assertEq(eethAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "eETH adapter owner");
-        assertEq(weethAdapter.owner(), Mainnet.MULTISIG_2_OF_8, "weETH adapter owner");
+        assertEq(eethAdapter.owner(), Mainnet.MULTISIG_5_OF_8, "eETH adapter owner");
+        assertEq(weethAdapter.owner(), Mainnet.MULTISIG_5_OF_8, "weETH adapter owner");
         assertEq(
             eethAdapter.implementation(), resolver.resolve("WETH_ARM_EETH_ADAPTER_IMPL"), "eETH adapter implementation"
         );
@@ -79,7 +79,7 @@ contract Fork_WETHARM_Smoke_Test is AbstractSmokeTest {
         assertEq(morphoMarket.market(), Mainnet.MORPHO_WETH_VAULT, "configured Morpho vault");
         assertEq(morphoMarket.market(), lidoMarket.market(), "Lido Morpho vault");
         assertEq(morphoMarket.market(), etherFiMarket.market(), "EtherFi Morpho vault");
-        assertEq(morphoMarket.owner(), Mainnet.MULTISIG_2_OF_8, "market owner");
+        assertEq(morphoMarket.owner(), Mainnet.MULTISIG_5_OF_8, "market owner");
         assertEq(morphoMarket.harvester(), Mainnet.MULTISIG_2_OF_8, "market harvester");
         assertEq(address(morphoMarket.merkleDistributor()), Mainnet.MERKLE_DISTRIBUTOR, "Merkle distributor");
         assertTrue(wethARM.supportedMarkets(address(morphoMarket)), "market supported");


### PR DESCRIPTION
## Summary

Adds support for claiming multiple Lido and EtherFi withdrawal requests from Talos actions.

- Adds comma-separated `--ids` support to:
  - `autoClaimLidoWithdraw`
  - `autoClaimWETHLidoWithdraw`
  - `autoClaimWETHEtherFiWithdraw`
- Retains `--id` as a backwards-compatible alias.
- Validates IDs are numeric, mutually exclusive with `--id`, and supplied in ascending FIFO order.
- Updates Lido and EtherFi claim paths to aggregate selected adapter request shares.
- Refreshes smoke-test expectations to match the live deployments:
  - Updates the Paxos ARM ownership and cap configuration assertions.
  - Updates the WETH ARM, eETH/weETH adapter, and Morpho market owner assertions to the 5-of-8 multisig.
  - Fixes the Paxos settlement tests to impersonate the deployed adapter owner.

## Testing

- `node test/js/requestIds.test.js`
- `node test/js/etherfiQueue.test.js`
- Verified `--ids` appears in Hardhat help for all updated actions.
- Smoke tests:
  - WETH: 4 passed
  - Paxos: 4 passed
  - Lido: 8 passed
  - Ethena: 2 passed
  - EtherFi: 1 passed
- `forge fmt --check`
- `git diff --check`
