### PR TITLE
Transient storage for claims gate

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,8 @@ extra_output_files = ["metadata"]
 ignored_warnings_from = ["src/contracts/Proxy.sol"]
 optimizer = true
 optimizer_runs = 200
+solc = "0.8.36"
+evm_version = "cancun"
 ffi = true
 
 # About remappings: 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -109,10 +109,13 @@ module.exports = {
       chainId: 1,
     },
   },
-  solidity: "0.8.23",
-  settings: {
-    optimizer: {
-      enabled: true,
+  solidity: {
+    version: "0.8.36",
+    settings: {
+      evmVersion: "cancun",
+      optimizer: {
+        enabled: true,
+      },
     },
   },
   tracer: {

--- a/script/automation/UpdateGovernanceMetadata.s.sol
+++ b/script/automation/UpdateGovernanceMetadata.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Script, console} from "forge-std/Script.sol";

--- a/script/deploy/Base.s.sol
+++ b/script/deploy/Base.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Vm} from "forge-std/Vm.sol";

--- a/script/deploy/DeployManager.s.sol
+++ b/script/deploy/DeployManager.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Vm} from "forge-std/Vm.sol";

--- a/script/deploy/helpers/AbstractDeployScript.s.sol
+++ b/script/deploy/helpers/AbstractDeployScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Helpers
 import {Logger} from "script/deploy/helpers/Logger.sol";

--- a/script/deploy/helpers/DeploymentTypes.sol
+++ b/script/deploy/helpers/DeploymentTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 /// @title DeploymentTypes
 /// @notice Core data structures and enums used throughout the deployment framework.

--- a/script/deploy/helpers/GovHelper.sol
+++ b/script/deploy/helpers/GovHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Vm} from "forge-std/Vm.sol";

--- a/script/deploy/helpers/Logger.sol
+++ b/script/deploy/helpers/Logger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Vm} from "forge-std/Vm.sol";
 import {console2} from "forge-std/console2.sol";

--- a/script/deploy/helpers/Resolver.sol
+++ b/script/deploy/helpers/Resolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {State, Execution, Contract, Position} from "script/deploy/helpers/DeploymentTypes.sol";
 

--- a/script/deploy/mainnet/000_Example.s.sol
+++ b/script/deploy/mainnet/000_Example.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // ==================== Example Deployment Script ==================== //
 //

--- a/script/deploy/mainnet/019_DeployPendleAdaptor_EtherFi.s.sol
+++ b/script/deploy/mainnet/019_DeployPendleAdaptor_EtherFi.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {PendleOriginARMSY} from "contracts/pendle/PendleOriginARMSY.sol";

--- a/script/deploy/mainnet/020_UpgradeEthenaARMScript.s.sol
+++ b/script/deploy/mainnet/020_UpgradeEthenaARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract imports
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/021_UpgradeEtherFiARMCrossPriceScript.s.sol
+++ b/script/deploy/mainnet/021_UpgradeEtherFiARMCrossPriceScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Deployment
 import {GovHelper, GovProposal} from "script/deploy/helpers/GovHelper.sol";

--- a/script/deploy/mainnet/022_UpgradeEtherFiARMDepositScript.s.sol
+++ b/script/deploy/mainnet/022_UpgradeEtherFiARMDepositScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/023_UpgradeEthenaARMDepositScript.s.sol
+++ b/script/deploy/mainnet/023_UpgradeEthenaARMDepositScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/024_UpgradeOETHARMDepositScript.s.sol
+++ b/script/deploy/mainnet/024_UpgradeOETHARMDepositScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {OriginARM} from "contracts/OriginARM.sol";

--- a/script/deploy/mainnet/025_UpgradeLidoARMDepositScript.s.sol
+++ b/script/deploy/mainnet/025_UpgradeLidoARMDepositScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {LidoARM} from "contracts/LidoARM.sol";

--- a/script/deploy/mainnet/026_UpgradeEthenaARMScript.s.sol
+++ b/script/deploy/mainnet/026_UpgradeEthenaARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/027_UpgradeEthenaARMScript.s.sol
+++ b/script/deploy/mainnet/027_UpgradeEthenaARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
+++ b/script/deploy/mainnet/028_UpgradeARMsPauseScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
+++ b/script/deploy/mainnet/029_SetTalosKMSOperatorScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Mainnet} from "contracts/utils/Addresses.sol";

--- a/script/deploy/mainnet/030_SetEthenaTalosKMSOperatorScript.s.sol
+++ b/script/deploy/mainnet/030_SetEthenaTalosKMSOperatorScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Mainnet} from "contracts/utils/Addresses.sol";

--- a/script/deploy/mainnet/031_UpgradeEthenaARMScript.s.sol
+++ b/script/deploy/mainnet/031_UpgradeEthenaARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/034_UpgradeEthenaARMGetBaseAssetsScript.s.sol
+++ b/script/deploy/mainnet/034_UpgradeEthenaARMGetBaseAssetsScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/035_UnpauseEthenaARMScript.s.sol
+++ b/script/deploy/mainnet/035_UnpauseEthenaARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Deployment
 import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";

--- a/script/deploy/mainnet/036_DeployMultiAssetARMScript.s.sol
+++ b/script/deploy/mainnet/036_DeployMultiAssetARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {IWETH} from "contracts/Interfaces.sol";

--- a/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
+++ b/script/deploy/mainnet/037_DeployUSDARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {IERC20} from "contracts/Interfaces.sol";

--- a/script/deploy/mainnet/038_DeployWETHARMScript.s.sol
+++ b/script/deploy/mainnet/038_DeployWETHARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {IWETH} from "contracts/Interfaces.sol";

--- a/script/deploy/mainnet/039_DeployUSDCARMScript.s.sol
+++ b/script/deploy/mainnet/039_DeployUSDCARMScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {IERC20} from "contracts/Interfaces.sol";

--- a/script/deploy/mainnet/040_UnpauseEtherFi.s.sol
+++ b/script/deploy/mainnet/040_UnpauseEtherFi.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Deployment
 import {AbstractDeployScript} from "script/deploy/helpers/AbstractDeployScript.s.sol";

--- a/script/deploy/mainnet/041_RedeployEtherFiAdaptersScript.s.sol
+++ b/script/deploy/mainnet/041_RedeployEtherFiAdaptersScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/mainnet/042_DeployWETHMorphoMarketScript.s.sol
+++ b/script/deploy/mainnet/042_DeployWETHMorphoMarketScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/sonic/001_DeployOriginARMProxy.s.sol
+++ b/script/deploy/sonic/001_DeployOriginARMProxy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/sonic/002_DeployOriginARM.s.sol
+++ b/script/deploy/sonic/002_DeployOriginARM.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/sonic/003_UpgradeOriginARM.s.sol
+++ b/script/deploy/sonic/003_UpgradeOriginARM.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract imports
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/sonic/004_DeployPendleAdaptor.s.sol
+++ b/script/deploy/sonic/004_DeployPendleAdaptor.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract imports
 import {PendleOriginARMSY} from "contracts/pendle/PendleOriginARMSY.sol";

--- a/script/deploy/sonic/005_UpgradeOriginARMSetBufferScript.s.sol
+++ b/script/deploy/sonic/005_UpgradeOriginARMSetBufferScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contract imports
 import {Proxy} from "contracts/Proxy.sol";

--- a/script/deploy/sonic/006_SetOriginARMTalosOperatorScript.s.sol
+++ b/script/deploy/sonic/006_SetOriginARMTalosOperatorScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Sonic} from "contracts/utils/Addresses.sol";

--- a/script/deploy/sonic/006_UpgradeOriginARMSwapFeeScript.s.sol
+++ b/script/deploy/sonic/006_UpgradeOriginARMSwapFeeScript.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Proxy} from "contracts/Proxy.sol";
 import {OriginARM} from "contracts/OriginARM.sol";

--- a/src/contracts/AbstractARM.sol
+++ b/src/contracts/AbstractARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";

--- a/src/contracts/CapManager.sol
+++ b/src/contracts/CapManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/EthenaARM.sol
+++ b/src/contracts/EthenaARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/EthenaUnstaker.sol
+++ b/src/contracts/EthenaUnstaker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IStakedUSDe} from "./Interfaces.sol";
 

--- a/src/contracts/EtherFiARM.sol
+++ b/src/contracts/EtherFiARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/Interfaces.sol
+++ b/src/contracts/Interfaces.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 

--- a/src/contracts/LidoARM.sol
+++ b/src/contracts/LidoARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/MultiAssetARM.sol
+++ b/src/contracts/MultiAssetARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {AbstractARM} from "./AbstractARM.sol";
 

--- a/src/contracts/OriginARM.sol
+++ b/src/contracts/OriginARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/Ownable.sol
+++ b/src/contracts/Ownable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 /**
  * @title Base contract that provides ownership control

--- a/src/contracts/OwnableOperable.sol
+++ b/src/contracts/OwnableOperable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Ownable} from "./Ownable.sol";
 

--- a/src/contracts/Proxy.sol
+++ b/src/contracts/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Ownable} from "./Ownable.sol";
 

--- a/src/contracts/SonicHarvester.sol
+++ b/src/contracts/SonicHarvester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/src/contracts/ZapperARM.sol
+++ b/src/contracts/ZapperARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Ownable} from "./Ownable.sol";

--- a/src/contracts/ZapperLidoARM.sol
+++ b/src/contracts/ZapperLidoARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Ownable} from "./Ownable.sol";

--- a/src/contracts/adapters/AbstractLidoAssetAdapter.sol
+++ b/src/contracts/adapters/AbstractLidoAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/adapters/EthenaAssetAdapter.sol
+++ b/src/contracts/adapters/EthenaAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {EthenaUnstaker} from "../EthenaUnstaker.sol";
 import {IAssetAdapter, IERC20, IStakedUSDe, UserCooldown} from "../Interfaces.sol";

--- a/src/contracts/adapters/EtherFiAssetAdapter.sol
+++ b/src/contracts/adapters/EtherFiAssetAdapter.sol
@@ -30,7 +30,7 @@ contract EtherFiAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
     uint256 internal nextPendingIndex;
 
     /// @dev True only while the adapter is actively claiming Ether.fi withdrawal NFTs.
-    bool internal claimingEtherFi;
+    bool internal transient claimingEtherFi;
 
     /// @notice Thrown when Ether.fi claim proceeds arrive without an adapter-initiated claim.
     error UnauthorizedEtherFiClaim(); // 0x7b2b45a4

--- a/src/contracts/adapters/EtherFiAssetAdapter.sol
+++ b/src/contracts/adapters/EtherFiAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/src/contracts/adapters/OriginAssetAdapter.sol
+++ b/src/contracts/adapters/OriginAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/adapters/PaxosAssetAdapter.sol
+++ b/src/contracts/adapters/PaxosAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/contracts/adapters/StETHAssetAdapter.sol
+++ b/src/contracts/adapters/StETHAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC20} from "../Interfaces.sol";
 import {AbstractLidoAssetAdapter} from "./AbstractLidoAssetAdapter.sol";

--- a/src/contracts/adapters/WeETHAssetAdapter.sol
+++ b/src/contracts/adapters/WeETHAssetAdapter.sol
@@ -34,7 +34,7 @@ contract WeETHAssetAdapter is Initializable, IAssetAdapter, IERC721Receiver {
     uint256 internal nextPendingIndex;
 
     /// @dev True only while the adapter is actively claiming Ether.fi withdrawal NFTs.
-    bool internal claimingEtherFi;
+    bool internal transient claimingEtherFi;
 
     /// @notice Thrown when Ether.fi claim proceeds arrive without an adapter-initiated claim.
     error UnauthorizedEtherFiClaim(); // 0x7b2b45a4

--- a/src/contracts/adapters/WeETHAssetAdapter.sol
+++ b/src/contracts/adapters/WeETHAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/src/contracts/adapters/WrappedOriginAssetAdapter.sol
+++ b/src/contracts/adapters/WrappedOriginAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/src/contracts/adapters/WstETHAssetAdapter.sol
+++ b/src/contracts/adapters/WstETHAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC20, IWstETH} from "../Interfaces.sol";
 import {AbstractLidoAssetAdapter} from "./AbstractLidoAssetAdapter.sol";

--- a/src/contracts/markets/Abstract4626MarketWrapper.sol
+++ b/src/contracts/markets/Abstract4626MarketWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/src/contracts/markets/MorphoMarket.sol
+++ b/src/contracts/markets/MorphoMarket.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {Abstract4626MarketWrapper} from "./Abstract4626MarketWrapper.sol";

--- a/src/contracts/markets/SiloMarket.sol
+++ b/src/contracts/markets/SiloMarket.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {IDistributionManager, SiloIncentivesControllerGaugeLike} from "../Interfaces.sol";
 import {Abstract4626MarketWrapper} from "./Abstract4626MarketWrapper.sol";

--- a/src/contracts/utils/Addresses.sol
+++ b/src/contracts/utils/Addresses.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 library Common {
     address public constant ZERO = address(0);

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/fork/Abstract4626MarketWrapper/MerkleClaim.sol
+++ b/test/fork/Abstract4626MarketWrapper/MerkleClaim.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Mainnet} from "contracts/utils/Addresses.sol";
 // Test

--- a/test/fork/Abstract4626MarketWrapper/shared/Shared.sol
+++ b/test/fork/Abstract4626MarketWrapper/shared/Shared.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_Test_} from "test/Base.sol";

--- a/test/fork/EthenaARM/ClaimBaseWithdrawals.t.sol
+++ b/test/fork/EthenaARM/ClaimBaseWithdrawals.t.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/EthenaARM/shared/Shared.sol";

--- a/test/fork/EthenaARM/RequestWithdraw.t.sol
+++ b/test/fork/EthenaARM/RequestWithdraw.t.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/EthenaARM/shared/Shared.sol";

--- a/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/EthenaARM/SwapExactTokensForTokens.t.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/EthenaARM/shared/Shared.sol";

--- a/test/fork/EthenaARM/SwapTokensForExactTokens.t.sol
+++ b/test/fork/EthenaARM/SwapTokensForExactTokens.t.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/EthenaARM/shared/Shared.sol";

--- a/test/fork/EthenaARM/shared/Shared.sol
+++ b/test/fork/EthenaARM/shared/Shared.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_Test_} from "test/Base.sol";

--- a/test/fork/Harvester/Collect.sol
+++ b/test/fork/Harvester/Collect.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Interfaces
 import {SonicHarvester} from "contracts/SonicHarvester.sol";

--- a/test/fork/Harvester/Setters.sol
+++ b/test/fork/Harvester/Setters.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {SonicHarvester} from "contracts/SonicHarvester.sol";
 

--- a/test/fork/Harvester/Swap.sol
+++ b/test/fork/Harvester/Swap.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Sonic} from "contracts/utils/Addresses.sol";
 import {SonicHarvester} from "contracts/SonicHarvester.sol";

--- a/test/fork/Harvester/shared/Helpers.sol
+++ b/test/fork/Harvester/shared/Helpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Base_Test_} from "test/Base.sol";
 

--- a/test/fork/Harvester/shared/Shared.sol
+++ b/test/fork/Harvester/shared/Shared.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_Test_} from "test/Base.sol";

--- a/test/fork/MultiAssetARM/ClaimBaseWithdrawals.t.sol
+++ b/test/fork/MultiAssetARM/ClaimBaseWithdrawals.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/MultiAssetARM/shared/Shared.sol";

--- a/test/fork/MultiAssetARM/RequestWithdraw.t.sol
+++ b/test/fork/MultiAssetARM/RequestWithdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/MultiAssetARM/shared/Shared.sol";

--- a/test/fork/MultiAssetARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/MultiAssetARM/SwapExactTokensForTokens.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/MultiAssetARM/shared/Shared.sol";

--- a/test/fork/MultiAssetARM/SwapTokensForExactTokens.t.sol
+++ b/test/fork/MultiAssetARM/SwapTokensForExactTokens.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/MultiAssetARM/shared/Shared.sol";

--- a/test/fork/MultiAssetARM/shared/Shared.sol
+++ b/test/fork/MultiAssetARM/shared/Shared.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_Test_} from "test/Base.sol";

--- a/test/fork/PaxosARM/DepositClaimRedeem.t.sol
+++ b/test/fork/PaxosARM/DepositClaimRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/PaxosARM/shared/Shared.sol";

--- a/test/fork/PaxosARM/PaxosRedeem.t.sol
+++ b/test/fork/PaxosARM/PaxosRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/PaxosARM/shared/Shared.sol";

--- a/test/fork/PaxosARM/SwapExactTokensForTokens.t.sol
+++ b/test/fork/PaxosARM/SwapExactTokensForTokens.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/PaxosARM/shared/Shared.sol";

--- a/test/fork/PaxosARM/SwapTokensForExactTokens.t.sol
+++ b/test/fork/PaxosARM/SwapTokensForExactTokens.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Fork_Shared_Test} from "test/fork/PaxosARM/shared/Shared.sol";

--- a/test/fork/PaxosARM/shared/Shared.sol
+++ b/test/fork/PaxosARM/shared/Shared.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_Test_} from "test/Base.sol";

--- a/test/fork/Zapper/Deposit.t.sol
+++ b/test/fork/Zapper/Deposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";

--- a/test/fork/Zapper/RescueToken.sol
+++ b/test/fork/Zapper/RescueToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Fork_Shared_Test_} from "test/fork/shared/Shared.sol";

--- a/test/fork/shared/Shared.sol
+++ b/test/fork/shared/Shared.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Modifiers} from "test/fork/utils/Modifiers.sol";

--- a/test/fork/utils/Helpers.sol
+++ b/test/fork/utils/Helpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Base_Test_} from "test/Base.sol";

--- a/test/fork/utils/MockCall.sol
+++ b/test/fork/utils/MockCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Vm} from "forge-std/Vm.sol";

--- a/test/fork/utils/Modifiers.sol
+++ b/test/fork/utils/Modifiers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {VmSafe} from "forge-std/Vm.sol";

--- a/test/invariants/EthenaARM/Base.sol
+++ b/test/invariants/EthenaARM/Base.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Contracts
 import {Proxy} from "contracts/Proxy.sol";

--- a/test/invariants/EthenaARM/FuzzerFoundry_EthenaARM.sol
+++ b/test/invariants/EthenaARM/FuzzerFoundry_EthenaARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Properties} from "./Properties.sol";

--- a/test/invariants/EthenaARM/FuzzerMedusa_EthenaARM.sol
+++ b/test/invariants/EthenaARM/FuzzerMedusa_EthenaARM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Properties} from "./Properties.sol";

--- a/test/invariants/EthenaARM/Properties.sol
+++ b/test/invariants/EthenaARM/Properties.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {console} from "forge-std/console.sol";

--- a/test/invariants/EthenaARM/Setup.sol
+++ b/test/invariants/EthenaARM/Setup.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Base_Test_} from "./Base.sol";

--- a/test/invariants/EthenaARM/TargetFunctions.sol
+++ b/test/invariants/EthenaARM/TargetFunctions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Setup} from "./Setup.sol";

--- a/test/invariants/EthenaARM/helpers/Find.sol
+++ b/test/invariants/EthenaARM/helpers/Find.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {AbstractARM} from "contracts/AbstractARM.sol";
 

--- a/test/invariants/EthenaARM/helpers/Math.sol
+++ b/test/invariants/EthenaARM/helpers/Math.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 library Math {
     //////////////////////////////////////////////////////

--- a/test/invariants/EthenaARM/helpers/Test.sol
+++ b/test/invariants/EthenaARM/helpers/Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/invariants/EthenaARM/helpers/Vm.sol
+++ b/test/invariants/EthenaARM/helpers/Vm.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 /// @notice Medusa StdCheats interface
 interface Vm {

--- a/test/invariants/EthenaARM/mocks/MockMorpho.sol
+++ b/test/invariants/EthenaARM/mocks/MockMorpho.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Solmate
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/test/invariants/EthenaARM/mocks/MockSUSDE.sol
+++ b/test/invariants/EthenaARM/mocks/MockSUSDE.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Solmate
 import {Owned} from "@solmate/auth/Owned.sol";

--- a/test/invariants/LidoARM/FuzzerFoundry.t.sol
+++ b/test/invariants/LidoARM/FuzzerFoundry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test imports
 import {Properties} from "./Properties.t.sol";

--- a/test/invariants/LidoARM/Properties.t.sol
+++ b/test/invariants/LidoARM/Properties.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";

--- a/test/invariants/LidoARM/TargetFunction.t.sol
+++ b/test/invariants/LidoARM/TargetFunction.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {console} from "forge-std/console.sol";
 import {MockERC20} from "@solmate/test/utils/mocks/MockERC20.sol";

--- a/test/invariants/LidoARM/base/Base.t.sol
+++ b/test/invariants/LidoARM/base/Base.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/invariants/LidoARM/base/Setup.t.sol
+++ b/test/invariants/LidoARM/base/Setup.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_Test_} from "./Base.t.sol";

--- a/test/invariants/LidoARM/helpers/Helpers.t.sol
+++ b/test/invariants/LidoARM/helpers/Helpers.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Vm} from "forge-std/Vm.sol";
 import {Base_Test_} from "../base/Base.t.sol";

--- a/test/invariants/LidoARM/mocks/MockLidoWithdraw.sol
+++ b/test/invariants/LidoARM/mocks/MockLidoWithdraw.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Vm} from "forge-std/Vm.sol";

--- a/test/invariants/LidoARM/mocks/MockMorpho.sol
+++ b/test/invariants/LidoARM/mocks/MockMorpho.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Solmate
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/test/invariants/LidoARM/mocks/MockWstETH.sol
+++ b/test/invariants/LidoARM/mocks/MockWstETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC20} from "contracts/Interfaces.sol";
 import {ERC20, MockERC4626} from "@solmate/test/utils/mocks/MockERC4626.sol";

--- a/test/smoke/AbstractSmokeTest.sol
+++ b/test/smoke/AbstractSmokeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry imports
 import {Test} from "forge-std/Test.sol";

--- a/test/smoke/EthenaARMSmokeTest.t.sol
+++ b/test/smoke/EthenaARMSmokeTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {AbstractSmokeTest} from "./AbstractSmokeTest.sol";
 

--- a/test/smoke/EtherFiARMSmokeTest.t.sol
+++ b/test/smoke/EtherFiARMSmokeTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {AbstractSmokeTest} from "./AbstractSmokeTest.sol";
 

--- a/test/smoke/LidoARMSmokeTest.t.sol
+++ b/test/smoke/LidoARMSmokeTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {AbstractSmokeTest} from "./AbstractSmokeTest.sol";
 

--- a/test/smoke/PaxosARMSmokeTest.t.sol
+++ b/test/smoke/PaxosARMSmokeTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {AbstractSmokeTest} from "./AbstractSmokeTest.sol";
 

--- a/test/smoke/WETHARMSmokeTest.t.sol
+++ b/test/smoke/WETHARMSmokeTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.36;
 
 import {AbstractSmokeTest} from "./AbstractSmokeTest.sol";
 

--- a/test/unit/MultiAssetARM/Base.t.sol
+++ b/test/unit/MultiAssetARM/Base.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/unit/MultiAssetARM/Shared.t.sol
+++ b/test/unit/MultiAssetARM/Shared.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_MultiAssetARM_Test} from "./Base.t.sol";

--- a/test/unit/MultiAssetARM/concrete/Accounting.t.sol
+++ b/test/unit/MultiAssetARM/concrete/Accounting.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 

--- a/test/unit/MultiAssetARM/concrete/Admin.t.sol
+++ b/test/unit/MultiAssetARM/concrete/Admin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/concrete/Allocate.t.sol
+++ b/test/unit/MultiAssetARM/concrete/Allocate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/concrete/BaseAssetRedeem.t.sol
+++ b/test/unit/MultiAssetARM/concrete/BaseAssetRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 import {AbstractARM} from "contracts/AbstractARM.sol";

--- a/test/unit/MultiAssetARM/concrete/ClaimRedeem.t.sol
+++ b/test/unit/MultiAssetARM/concrete/ClaimRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 import {AbstractARM} from "contracts/AbstractARM.sol";

--- a/test/unit/MultiAssetARM/concrete/Decimals.t.sol
+++ b/test/unit/MultiAssetARM/concrete/Decimals.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 

--- a/test/unit/MultiAssetARM/concrete/Deposit.t.sol
+++ b/test/unit/MultiAssetARM/concrete/Deposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 

--- a/test/unit/MultiAssetARM/concrete/ManageMarket.t.sol
+++ b/test/unit/MultiAssetARM/concrete/ManageMarket.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/concrete/Pause.t.sol
+++ b/test/unit/MultiAssetARM/concrete/Pause.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/concrete/RequestRedeem.t.sol
+++ b/test/unit/MultiAssetARM/concrete/RequestRedeem.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 import {AbstractARM} from "contracts/AbstractARM.sol";

--- a/test/unit/MultiAssetARM/concrete/SwapExactTokensForTokens.t.sol
+++ b/test/unit/MultiAssetARM/concrete/SwapExactTokensForTokens.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 import {IERC20} from "contracts/Interfaces.sol";

--- a/test/unit/MultiAssetARM/concrete/SwapGas.t.sol
+++ b/test/unit/MultiAssetARM/concrete/SwapGas.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 import {IERC20} from "contracts/Interfaces.sol";

--- a/test/unit/MultiAssetARM/concrete/SwapTokensForExactTokens.t.sol
+++ b/test/unit/MultiAssetARM/concrete/SwapTokensForExactTokens.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 import {IERC20} from "contracts/Interfaces.sol";

--- a/test/unit/MultiAssetARM/fuzz/ClaimRedeem.fuzz.t.sol
+++ b/test/unit/MultiAssetARM/fuzz/ClaimRedeem.fuzz.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/fuzz/Deposit.fuzz.t.sol
+++ b/test/unit/MultiAssetARM/fuzz/Deposit.fuzz.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/fuzz/RequestRedeem.fuzz.t.sol
+++ b/test/unit/MultiAssetARM/fuzz/RequestRedeem.fuzz.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/fuzz/Scaling.fuzz.t.sol
+++ b/test/unit/MultiAssetARM/fuzz/Scaling.fuzz.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";
 

--- a/test/unit/MultiAssetARM/fuzz/Swap.fuzz.t.sol
+++ b/test/unit/MultiAssetARM/fuzz/Swap.fuzz.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_MultiAssetARM_Shared_Test} from "../Shared.t.sol";

--- a/test/unit/MultiAssetARM/mocks/MockAssetAdapter.sol
+++ b/test/unit/MultiAssetARM/mocks/MockAssetAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {IAssetAdapter, IERC20} from "contracts/Interfaces.sol";
 

--- a/test/unit/MultiAssetARM/mocks/MockERC4626Market.sol
+++ b/test/unit/MultiAssetARM/mocks/MockERC4626Market.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC20} from "contracts/Interfaces.sol";
 import {ERC20, MockERC4626} from "@solmate/test/utils/mocks/MockERC4626.sol";

--- a/test/unit/adapters/concrete/AbstractLidoAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/AbstractLidoAssetAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_Lido_Shared_Test} from "../shared/Shared.t.sol";

--- a/test/unit/adapters/concrete/EthenaAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/EthenaAssetAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/unit/adapters/concrete/EtherFiAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/EtherFiAssetAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/unit/adapters/concrete/PaxosAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/PaxosAssetAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/unit/adapters/concrete/StETHAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/StETHAssetAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_Lido_Shared_Test} from "../shared/Shared.t.sol";

--- a/test/unit/adapters/concrete/WeETHAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/WeETHAssetAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/unit/adapters/concrete/WstETHAssetAdapter.t.sol
+++ b/test/unit/adapters/concrete/WstETHAssetAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_Lido_Shared_Test} from "../shared/Shared.t.sol";

--- a/test/unit/adapters/fuzz/Split.fuzz.t.sol
+++ b/test/unit/adapters/fuzz/Split.fuzz.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Unit_Lido_Shared_Test} from "../shared/Shared.t.sol";

--- a/test/unit/adapters/mocks/MockERC4626Market.sol
+++ b/test/unit/adapters/mocks/MockERC4626Market.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC20} from "contracts/Interfaces.sol";
 import {ERC20, MockERC4626} from "@solmate/test/utils/mocks/MockERC4626.sol";

--- a/test/unit/adapters/mocks/MockEtherFiWithdraw.sol
+++ b/test/unit/adapters/mocks/MockEtherFiWithdraw.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Solmate
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/test/unit/adapters/mocks/MockLidoWithdraw.sol
+++ b/test/unit/adapters/mocks/MockLidoWithdraw.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Vm} from "forge-std/Vm.sol";

--- a/test/unit/adapters/mocks/MockStakedUSDe.sol
+++ b/test/unit/adapters/mocks/MockStakedUSDe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Solmate
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/test/unit/adapters/mocks/MockWeETH.sol
+++ b/test/unit/adapters/mocks/MockWeETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Solmate
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/test/unit/adapters/mocks/MockWstETH.sol
+++ b/test/unit/adapters/mocks/MockWstETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 import {IERC20} from "contracts/Interfaces.sol";
 import {ERC20, MockERC4626} from "@solmate/test/utils/mocks/MockERC4626.sol";

--- a/test/unit/adapters/shared/Base.t.sol
+++ b/test/unit/adapters/shared/Base.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Foundry
 import {Test} from "forge-std/Test.sol";

--- a/test/unit/adapters/shared/Shared.t.sol
+++ b/test/unit/adapters/shared/Shared.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.36;
 
 // Test
 import {Base_Lido_Test} from "./Base.t.sol";


### PR DESCRIPTION
## Summary

- Upgrade Solidity from `0.8.23` to `0.8.36`.
- Target the Cancun EVM version.
- Use transient storage for the `claimingEtherFi` guard in:
  - `EtherFiAssetAdapter`
  - `WeETHAssetAdapter`

The guard is declared as:

```solidity
bool internal transient claimingEtherFi;
```

It is only needed while `redeem` calls Ether.fi's `batchClaimWithdraw`:

```solidity
claimingEtherFi = true;
etherfiWithdrawalNFT.batchClaimWithdraw(requestIds);
claimingEtherFi = false;
```

The adapters’ `receive` functions use it to reject ETH sent outside an adapter-initiated claim:

```solidity
receive() external payable {
    if (!claimingEtherFi) {
        revert UnauthorizedEtherFiClaim();
    }
}
```

Using transient storage avoids writing and clearing a persistent storage slot while preserving the existing authorization behavior.

## Gas savings

Gas was measured with Solidity `0.8.36`, targeting Cancun, using `gasleft()` immediately before and after the `redeem` call. Request setup was excluded from the measurement.

| Adapter | Requests claimed | Persistent storage | Transient storage | Gas saved |
|---|---:|---:|---:|---:|
| EtherFi | 1 | 140,456 | 118,560 | 21,896 |
| EtherFi | 2 | 150,306 | 128,409 | 21,897 |
| EtherFi | 5 | 179,865 | 157,965 | 21,900 |
| weETH | 1 | 140,857 | 118,964 | 21,893 |
| weETH | 2 | 151,111 | 129,217 | 21,894 |
| weETH | 5 | 181,882 | 159,985 | 21,897 |

This saves approximately **21,900 gas per Ether.fi redemption transaction**, independent of the number of requests claimed in the batch.

## Testing

- Full Foundry build with Solidity 0.8.36
- `EtherFiAssetAdapter` unit tests
- `WeETHAssetAdapter` unit tests
- Hardhat compilation targeting Cancun