### PR TITLE
fix: chunk EtherFi withdrawal requests at 1,000 eETH

### DIFF
--- a/src/js/tasks/etherfiQueue.js
+++ b/src/js/tasks/etherfiQueue.js
@@ -16,11 +16,38 @@ const { logTxDetails } = require("../utils/txLogger");
 const log = require("../utils/logger")("task:etherfiQueue");
 
 const uri = "https://origin.squids.live/ops-squid/graphql";
+const MAX_EETH_WITHDRAW_AMOUNT = parseUnits("1000");
 
 const ETHERFI_WITHDRAWAL_NFT_ABI = [
   "function isFinalized(uint256 requestId) view returns (bool)",
   "function getRequest(uint256 requestId) view returns (tuple(uint96 amountOfEEth, uint96 shareOfEEth, bool isValid, uint32 feeGwei))",
 ];
+
+const splitEtherFiWithdrawAmount = (
+  withdrawAmount,
+  maxAmount = MAX_EETH_WITHDRAW_AMOUNT,
+) => {
+  if (maxAmount <= 0n) throw new Error("maxAmount must be greater than zero");
+
+  const requestAmounts = [];
+  let remainingAmount = withdrawAmount;
+  while (remainingAmount > 0n) {
+    const requestAmount =
+      remainingAmount > maxAmount ? maxAmount : remainingAmount;
+    requestAmounts.push(requestAmount);
+    remainingAmount -= requestAmount;
+  }
+  return requestAmounts;
+};
+
+const maxEtherFiWithdrawShares = async (baseContext, signer) => {
+  if (baseContext.version === "legacy" || baseContext.baseSymbol !== "WEETH") {
+    return MAX_EETH_WITHDRAW_AMOUNT;
+  }
+
+  const adapter = await adapterContract(baseContext.config.adapter, signer);
+  return adapter.convertToShares(MAX_EETH_WITHDRAW_AMOUNT);
+};
 
 const requestEtherFiWithdrawals = async (options) => {
   const { signer, amount } = options;
@@ -32,14 +59,21 @@ const requestEtherFiWithdrawals = async (options) => {
     : await baseWithdrawAmount(options);
   if (!withdrawAmount || withdrawAmount === 0n) return;
 
-  log(`Requesting withdrawal for ${withdrawAmount} ${baseSymbol}...`);
-  const tx = await requestBaseAssetWithdrawal({
-    baseContext,
-    signer,
-    amount: withdrawAmount,
-  });
+  const maxWithdrawShares = await maxEtherFiWithdrawShares(baseContext, signer);
+  const requestAmounts = splitEtherFiWithdrawAmount(
+    withdrawAmount,
+    maxWithdrawShares,
+  );
+  for (const requestAmount of requestAmounts) {
+    log(`Requesting withdrawal for ${requestAmount} ${baseSymbol}...`);
+    const tx = await requestBaseAssetWithdrawal({
+      baseContext,
+      signer,
+      amount: requestAmount,
+    });
 
-  await logTxDetails(tx, "requestEtherFiWithdrawal");
+    await logTxDetails(tx, "requestEtherFiWithdrawal");
+  }
 };
 
 const claimEtherFiWithdrawals = async (options) => {
@@ -176,4 +210,5 @@ module.exports = {
   claimEtherFiWithdrawals,
   etherFiRequestStatuses,
   selectClaimableEtherFiRequests,
+  splitEtherFiWithdrawAmount,
 };

--- a/test/js/etherfiQueue.test.js
+++ b/test/js/etherfiQueue.test.js
@@ -1,10 +1,11 @@
 const assert = require("assert");
 
-const { AbiCoder, Contract, id } = require("ethers");
+const { AbiCoder, Contract, id, parseUnits } = require("ethers");
 
 const {
   etherFiRequestStatuses,
   selectClaimableEtherFiRequests,
+  splitEtherFiWithdrawAmount,
 } = require("../../src/js/tasks/etherfiQueue");
 
 const coder = AbiCoder.defaultAbiCoder();
@@ -12,6 +13,24 @@ const coder = AbiCoder.defaultAbiCoder();
 const selector = (signature) => id(signature).slice(0, 10);
 
 const run = async () => {
+  // Ether.fi rejects individual withdrawal requests above 1,000 eETH.
+  assert.deepStrictEqual(splitEtherFiWithdrawAmount(parseUnits("1000")), [
+    parseUnits("1000"),
+  ]);
+  assert.deepStrictEqual(splitEtherFiWithdrawAmount(parseUnits("1971.5")), [
+    parseUnits("1000"),
+    parseUnits("971.5"),
+  ]);
+  assert.deepStrictEqual(splitEtherFiWithdrawAmount(parseUnits("2000")), [
+    parseUnits("1000"),
+    parseUnits("1000"),
+  ]);
+  // weETH uses the adapter-provided share amount equivalent to 1,000 eETH.
+  assert.deepStrictEqual(
+    splitEtherFiWithdrawAmount(parseUnits("1800"), parseUnits("950")),
+    [parseUnits("950"), parseUnits("850")],
+  );
+
   // Pure filter: finalized AND still valid on-chain is the only claimable state.
   {
     const statuses = [


### PR DESCRIPTION
## Summary

- Split Ether.fi withdrawals into sequential requests capped at 1,000 eETH
- Convert the 1,000 eETH limit into weETH shares using the configured WETH ARM adapter
- Prevent the automated eETH and weETH withdrawal actions from reverting when balances exceed Ether.fi’s per-request limit
- Add coverage for exact-limit, remainder, exact-multiple, and weETH-converted chunking

## Testing

- `node test/js/etherfiQueue.test.js`
- Prettier
- `git diff --check`