### PR TITLE
Fix concurrency issue with Ethena claims

### DIFF
--- a/src/js/tasks/ethenaQueue.js
+++ b/src/js/tasks/ethenaQueue.js
@@ -76,22 +76,27 @@ const legacyEthenaUnstakers = async (legacyArm) => {
 // Fetches data for a list of addresses in PARALLEL (much faster)
 const fetchUnstakerStates = async (signer, adapter, addresses) => {
   const contract = new ethers.Contract(SUSDE_ADDRESS, SUSDE_ABI, signer);
+  // Pin all queue reads to one block. Reading each value at `latest` can mix
+  // state from a concurrent request or claim and produce an impossible FIFO
+  // snapshot.
+  const blockNumber = await signer.provider.getBlockNumber();
+  const blockTag = { blockTag: blockNumber };
   const { timestamp: currentTimestamp } =
-    await signer.provider.getBlock("latest");
+    await signer.provider.getBlock(blockNumber);
   let requestCount;
   let maxUnstakers;
 
   if (!addresses) {
     [requestCount, maxUnstakers] = await Promise.all([
-      adapter.totalRequests(),
-      adapter.MAX_UNSTAKERS(),
+      adapter.totalRequests(blockTag),
+      adapter.MAX_UNSTAKERS(blockTag),
     ]);
     const unstakerCount = Number(
       requestCount < maxUnstakers ? requestCount : maxUnstakers,
     );
     addresses = await Promise.all(
       Array.from({ length: unstakerCount }, async (_, index) => {
-        const address = await adapter.unstakers(index);
+        const address = await adapter.unstakers(index, blockTag);
         return { address, index };
       }),
     );
@@ -109,12 +114,15 @@ const fetchUnstakerStates = async (signer, adapter, addresses) => {
   // Promise.all executes all RPC calls simultaneously
   const states = await Promise.all(
     addresses.map(async ({ address, index }) => {
-      const [cooldownEnd, underlyingAmount] = await contract.cooldowns(address);
+      const [cooldownEnd, underlyingAmount] = await contract.cooldowns(
+        address,
+        blockTag,
+      );
       const shares = adapter
-        ? await adapter["requestShares(address)"](address)
+        ? await adapter["requestShares(address)"](address, blockTag)
         : underlyingAmount;
       const expectedAssets = adapter
-        ? await adapter["requestAssets(address)"](address)
+        ? await adapter["requestAssets(address)"](address, blockTag)
         : underlyingAmount;
       const amountStr = formatUnits(underlyingAmount, 18);
       const isBalancePositive = underlyingAmount > 0 || shares > 0;
@@ -149,7 +157,12 @@ const fetchUnstakerStates = async (signer, adapter, addresses) => {
 
   if (!adapter) return states;
 
-  return orderPendingUnstakerStates(states, requestCount, maxUnstakers);
+  return orderPendingUnstakerStates(
+    states,
+    requestCount,
+    maxUnstakers,
+    blockNumber,
+  );
 };
 
 // --- MAIN FUNCTIONS ---

--- a/src/js/utils/ethenaQueue.js
+++ b/src/js/utils/ethenaQueue.js
@@ -1,4 +1,9 @@
-const orderPendingUnstakerStates = (states, totalRequests, maxUnstakers) => {
+const orderPendingUnstakerStates = (
+  states,
+  totalRequests,
+  maxUnstakers,
+  blockNumber,
+) => {
   const activeStates = states.filter((state) => state.shares > 0n);
   if (activeStates.length === 0) return [];
 
@@ -19,8 +24,10 @@ const orderPendingUnstakerStates = (states, totalRequests, maxUnstakers) => {
     const unstakerIndex = Number(requestIndex % maxUnstakers);
     const state = statesByIndex.get(unstakerIndex);
     if (!state) {
+      const blockContext =
+        blockNumber === undefined ? "" : ` at block ${blockNumber}`;
       throw new Error(
-        `Missing Ethena unstaker ${unstakerIndex} for pending request ${requestIndex}`,
+        `Missing Ethena unstaker ${unstakerIndex} for pending request ${requestIndex}${blockContext}`,
       );
     }
     return state;

--- a/test/js/ethenaQueue.test.js
+++ b/test/js/ethenaQueue.test.js
@@ -60,8 +60,8 @@ const run = async () => {
 
   {
     assert.throws(
-      () => orderPendingUnstakerStates([state(0)], 45n, 42n),
-      /Missing Ethena unstaker 2 for pending request 44/,
+      () => orderPendingUnstakerStates([state(0)], 45n, 42n, 123456),
+      /Missing Ethena unstaker 2 for pending request 44 at block 123456/,
     );
   }
 };


### PR DESCRIPTION
## Summary

Fixes a race condition in the automated Ethena withdrawal claim action.

The action previously fetched `totalRequests` and individual unstaker states using separate `latest` RPC calls. A concurrent request or claim could therefore produce a mixed snapshot, causing the action to infer an invalid FIFO position and fail with errors such as:

> Missing Ethena unstaker 28 for pending request 238

## Changes

- Pin all Ethena queue reads to a single block
- Use the same block for adapter state, unstaker mappings, cooldown data, and timestamp checks
- Include the snapshot block number in queue consistency errors
- Update the queue consistency test
