### PR TITLE
fix: route the impersonated signer through the nonce queue

### DIFF
--- a/src/js/utils/signers.ts
+++ b/src/js/utils/signers.ts
@@ -132,7 +132,9 @@ export async function getSigner(address?: string): Promise<Signer> {
     log(
       `Impersonating account ${impersonateAddr} from IMPERSONATE environment variable`,
     );
-    return await impersonateAndFund(impersonateAddr);
+    // Wrapped like every other branch: without it the transaction bypasses the
+    // nonce queue, so Talos never records it and the run shows no transactions.
+    return maybeWrap(await impersonateAndFund(impersonateAddr));
   }
 
   const signers = await hre.ethers.getSigners();


### PR DESCRIPTION
`getSigner()` wraps every branch in `maybeWrap()` **except** `IMPERSONATE`:

| Branch | Wrapped |
|---|---|
| `DEPLOYER_PRIVATE_KEY` | `return maybeWrap(wallet)` ✅ |
| AWS KMS | `return maybeWrap(await getKmsSigner())` ✅ |
| `IMPERSONATE` | `return await impersonateAndFund(...)` ❌ |

Without the wrapper, `sendTransaction` never routes through `wrapSignerWithNonceQueueV6`, so Talos does not record the transaction. The visible symptom is a run that **completes successfully with an empty transaction list**.

```diff
-    return await impersonateAndFund(impersonateAddr);
+    return maybeWrap(await impersonateAndFund(impersonateAddr));
```

`DATABASE_URL` is present in the runner container, so `maybeWrap()` does attach the queue — nothing else was missing.

## Why now

[oplabs/talos#30](https://github.com/oplabs/talos/pull/30) makes an anvil mainnet fork with an impersonated relayer the **default** dev environment, which turns this branch from a rarely-exercised path into the one developers hit every day.

## Worth a reviewer's judgement

The nonce queue does real work — rebroadcasts, fee bumps, replacements, driven by the `NONCE_QUEUE_*` settings. On a fork that is arguably the point (you exercise the production path), but it does mean dev transactions are now managed rather than fire-and-forget. If you would rather impersonated runs stay lightweight, the alternative is recording them without the queue.

## Not verified

I could not typecheck — the worktree has no `node_modules`. The change is a one-line call into an existing generic `maybeWrap<S extends Signer>(s: S): S` already used twice in the same function, so it should be safe, but CI is the check.