### PR TITLE
Pin Foundry to v1.8.1

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: stable
+        version: v1.8.1
         cache: true
 
     - name: Show Forge version

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ default:
 	forge build
 
 install:
-	foundryup --version 1.7.1
+	foundryup --install v1.8.1
 	forge soldeer install
 	pnpm install
 

--- a/dockerfile-actions
+++ b/dockerfile-actions
@@ -3,9 +3,9 @@
 # Foundry binaries (forge/cast/anvil) — pulled from the official image
 # at a digest pin instead of curl-pipe-bash from foundry.paradigm.xyz.
 # Replaces the previous `curl … | bash` install (security/M-011).
-# Bump by re-resolving `ghcr.io/foundry-rs/foundry:stable` and updating
+# Bump by resolving the desired immutable Foundry release tag and updating
 # the digest below; review the published Foundry release notes.
-FROM ghcr.io/foundry-rs/foundry@sha256:043752653d5be351c71709091b3db97c4421c907eb40ea294195e7f532aadf46 AS foundry
+FROM ghcr.io/foundry-rs/foundry:v1.8.1@sha256:0c00cb0bda1ab1b91c9a6bf60f4c76c09c1a8870824b6d4718afbabacf6f9a17 AS foundry
 
 FROM oven/bun:1
 

--- a/script/deploy/ARCHITECTURE.md
+++ b/script/deploy/ARCHITECTURE.md
@@ -643,7 +643,7 @@ Copy `.env.example` to `.env` and fill in the required values.
 
 `.github/actions/setup/action.yml` provides a reusable environment setup:
 1. Checkout with submodules
-2. Install Foundry (stable, with cache)
+2. Install Foundry (v1.8.1, with cache)
 3. Install Soldeer dependencies (with cache)
 4. Optionally install Yarn dependencies (with cache)
 


### PR DESCRIPTION
## Summary

- Pin Foundry v1.8.1 for local installation and GitHub Actions.
- Pin the Docker Foundry stage to the immutable v1.8.1 multi-architecture digest.
- Correct the foundryup install command and align the architecture documentation.

## Verification

- `git diff --check`
- Parsed `.github/actions/setup/action.yml` as YAML
- `make -n install`
- Verified the v1.8.1 manifest digest and image metadata against GHCR