### PR TITLE
ARM Allocate action params

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -42,6 +42,10 @@ range, tolerance, and quote-amount flags apply to every selected base.
 | `allocateLido`            | `38,08 * * * *`         | Allocate liquidity for Lido ARM        |
 | `setPricesLido`           | `*/30 * * * *`          | Set prices for Lido ARM                |
 
+`allocateLido` accepts an optional `--threshold` in WETH and defaults to
+`100`. The threshold skips small liquidity deltas; the ARM contract determines
+the actual amount allocated.
+
 ## EtherFi ARM — mainnet
 
 | Action                     | Cron           | Description                                |

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -38,6 +38,10 @@ liquidity asset and defaults to: Lido `100 WETH`, EtherFi `20 WETH`, Ethena
 Sonic `10,000 wS`. The threshold skips small liquidity
 deltas; the ARM contract determines the actual amount allocated.
 
+The allocation actions also accept an optional `--max-gas-price` in gwei. It
+defaults to `5` for Lido, EtherFi, Ethena, USDC, and WETH, and `500` for OETH
+and Sonic.
+
 ## Lido ARM — mainnet
 
 | Action                    | Cron                    | Description                            |

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -32,6 +32,12 @@ the EtherFi pricing profile and Kyber for `EETH,WEETH`. It processes all four
 bases unless `--bases` is supplied. Explicit price, liquidity, aggregator,
 range, tolerance, and quote-amount flags apply to every selected base.
 
+Every `allocate*` action accepts an optional `--threshold` in the ARM's
+liquidity asset and defaults to: Lido `100 WETH`, EtherFi `20 WETH`, Ethena
+`30,000 USDe`, USDC `15,000 USDC`, WETH `100 WETH`, OETH `100 WETH`, and
+Sonic `10,000 wS`. The threshold skips small liquidity
+deltas; the ARM contract determines the actual amount allocated.
+
 ## Lido ARM — mainnet
 
 | Action                    | Cron                    | Description                            |
@@ -41,10 +47,6 @@ range, tolerance, and quote-amount flags apply to every selected base.
 | `collectLidoFees`         | `30 12 * * *`           | Collect fees from Lido ARM             |
 | `allocateLido`            | `38,08 * * * *`         | Allocate liquidity for Lido ARM        |
 | `setPricesLido`           | `*/30 * * * *`          | Set prices for Lido ARM                |
-
-`allocateLido` accepts an optional `--threshold` in WETH and defaults to
-`100`. The threshold skips small liquidity deltas; the ARM contract determines
-the actual amount allocated.
 
 ## EtherFi ARM — mainnet
 

--- a/src/js/tasks/actions/allocateEthena.ts
+++ b/src/js/tasks/actions/allocateEthena.ts
@@ -11,12 +11,19 @@ action({
   description: "Allocate liquidity for Ethena ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "threshold",
-      "Liquidity-delta threshold used to skip small allocations, in USDe.",
-      30000,
-      types.float,
-    ),
+    t
+      .addOptionalParam(
+        "threshold",
+        "Liquidity-delta threshold used to skip small allocations, in USDe.",
+        30000,
+        types.float,
+      )
+      .addOptionalParam(
+        "maxGasPrice",
+        "Maximum gas price at which allocation may execute, in gwei.",
+        2,
+        types.float,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.ethenaARM, etherFiARMAbi, signer);
 
@@ -25,7 +32,7 @@ action({
       signer,
       arm,
       threshold: args.threshold,
-      maxGasPrice: 5,
+      maxGasPrice: args.maxGasPrice,
     });
   },
 });

--- a/src/js/tasks/actions/allocateEthena.ts
+++ b/src/js/tasks/actions/allocateEthena.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { allocate } from "../admin";
@@ -9,14 +10,21 @@ action({
   name: "allocateEthena",
   description: "Allocate liquidity for Ethena ARM",
   chains: [1],
-  run: async ({ signer, log }) => {
+  params: (t) =>
+    t.addOptionalParam(
+      "threshold",
+      "Liquidity-delta threshold used to skip small allocations, in USDe.",
+      30000,
+      types.float,
+    ),
+  run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.ethenaARM, etherFiARMAbi, signer);
 
     log.info("Allocating liquidity for Ethena ARM");
     await allocate({
       signer,
       arm,
-      threshold: 500,
+      threshold: args.threshold,
       maxGasPrice: 5,
     });
   },

--- a/src/js/tasks/actions/allocateEtherFi.ts
+++ b/src/js/tasks/actions/allocateEtherFi.ts
@@ -11,12 +11,19 @@ action({
   description: "Allocate liquidity for EtherFi ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "threshold",
-      "Liquidity-delta threshold used to skip small allocations, in WETH.",
-      20,
-      types.float,
-    ),
+    t
+      .addOptionalParam(
+        "threshold",
+        "Liquidity-delta threshold used to skip small allocations, in WETH.",
+        20,
+        types.float,
+      )
+      .addOptionalParam(
+        "maxGasPrice",
+        "Maximum gas price at which allocation may execute, in gwei.",
+        2,
+        types.float,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.etherfiARM, etherFiARMAbi, signer);
 
@@ -25,7 +32,7 @@ action({
       signer,
       arm,
       threshold: args.threshold,
-      maxGasPrice: 5,
+      maxGasPrice: args.maxGasPrice,
     });
   },
 });

--- a/src/js/tasks/actions/allocateEtherFi.ts
+++ b/src/js/tasks/actions/allocateEtherFi.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { allocate } from "../admin";
@@ -9,14 +10,21 @@ action({
   name: "allocateEtherFi",
   description: "Allocate liquidity for EtherFi ARM",
   chains: [1],
-  run: async ({ signer, log }) => {
+  params: (t) =>
+    t.addOptionalParam(
+      "threshold",
+      "Liquidity-delta threshold used to skip small allocations, in WETH.",
+      20,
+      types.float,
+    ),
+  run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.etherfiARM, etherFiARMAbi, signer);
 
     log.info("Allocating liquidity for EtherFi ARM");
     await allocate({
       signer,
       arm,
-      threshold: 20,
+      threshold: args.threshold,
       maxGasPrice: 5,
     });
   },

--- a/src/js/tasks/actions/allocateLido.ts
+++ b/src/js/tasks/actions/allocateLido.ts
@@ -11,12 +11,19 @@ action({
   description: "Allocate liquidity for Lido ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "threshold",
-      "Liquidity-delta threshold used to skip small allocations, in WETH.",
-      100,
-      types.float,
-    ),
+    t
+      .addOptionalParam(
+        "threshold",
+        "Liquidity-delta threshold used to skip small allocations, in WETH.",
+        100,
+        types.float,
+      )
+      .addOptionalParam(
+        "maxGasPrice",
+        "Maximum gas price at which allocation may execute, in gwei.",
+        2,
+        types.float,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.lidoARM, lidoARMAbi, signer);
 
@@ -25,7 +32,7 @@ action({
       signer,
       arm,
       threshold: args.threshold,
-      maxGasPrice: 5,
+      maxGasPrice: args.maxGasPrice,
     });
   },
 });

--- a/src/js/tasks/actions/allocateLido.ts
+++ b/src/js/tasks/actions/allocateLido.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { allocate } from "../admin";
@@ -9,14 +10,21 @@ action({
   name: "allocateLido",
   description: "Allocate liquidity for Lido ARM",
   chains: [1],
-  run: async ({ signer, log }) => {
+  params: (t) =>
+    t.addOptionalParam(
+      "threshold",
+      "Liquidity-delta threshold used to skip small allocations, in WETH.",
+      100,
+      types.float,
+    ),
+  run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.lidoARM, lidoARMAbi, signer);
 
     log.info("Allocating liquidity for Lido ARM");
     await allocate({
       signer,
       arm,
-      threshold: 100,
+      threshold: args.threshold,
       maxGasPrice: 5,
     });
   },

--- a/src/js/tasks/actions/allocateOETH.ts
+++ b/src/js/tasks/actions/allocateOETH.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { allocate } from "../admin";
@@ -9,14 +10,21 @@ action({
   name: "allocateOETH",
   description: "Allocate liquidity for OETH ARM",
   chains: [1],
-  run: async ({ signer, log }) => {
+  params: (t) =>
+    t.addOptionalParam(
+      "threshold",
+      "Liquidity-delta threshold used to skip small allocations, in WETH.",
+      100,
+      types.float,
+    ),
+  run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.OethARM, armAbi, signer);
 
     log.info("Allocating liquidity for OETH ARM");
     await allocate({
       signer,
       arm,
-      threshold: 10000,
+      threshold: args.threshold,
       maxGasPrice: 500,
     });
   },

--- a/src/js/tasks/actions/allocateOETH.ts
+++ b/src/js/tasks/actions/allocateOETH.ts
@@ -11,12 +11,19 @@ action({
   description: "Allocate liquidity for OETH ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "threshold",
-      "Liquidity-delta threshold used to skip small allocations, in WETH.",
-      100,
-      types.float,
-    ),
+    t
+      .addOptionalParam(
+        "threshold",
+        "Liquidity-delta threshold used to skip small allocations, in WETH.",
+        100,
+        types.float,
+      )
+      .addOptionalParam(
+        "maxGasPrice",
+        "Maximum gas price at which allocation may execute, in gwei.",
+        2,
+        types.float,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.OethARM, armAbi, signer);
 
@@ -25,7 +32,7 @@ action({
       signer,
       arm,
       threshold: args.threshold,
-      maxGasPrice: 500,
+      maxGasPrice: args.maxGasPrice,
     });
   },
 });

--- a/src/js/tasks/actions/allocateSonic.ts
+++ b/src/js/tasks/actions/allocateSonic.ts
@@ -12,12 +12,19 @@ action({
   description: "Allocate liquidity for Origin ARM on Sonic",
   chains: [146],
   params: (t) =>
-    t.addOptionalParam(
-      "threshold",
-      "Liquidity-delta threshold used to skip small allocations, in wS.",
-      10000,
-      types.float,
-    ),
+    t
+      .addOptionalParam(
+        "threshold",
+        "Liquidity-delta threshold used to skip small allocations, in wS.",
+        10000,
+        types.float,
+      )
+      .addOptionalParam(
+        "maxGasPrice",
+        "Maximum gas price at which allocation may execute, in gwei.",
+        500,
+        types.float,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(sonic.OriginARM, armAbi, signer);
 
@@ -26,7 +33,7 @@ action({
       signer,
       arm,
       threshold: args.threshold,
-      maxGasPrice: 500,
+      maxGasPrice: args.maxGasPrice,
       armContractVersion: "v1",
     });
   },

--- a/src/js/tasks/actions/allocateSonic.ts
+++ b/src/js/tasks/actions/allocateSonic.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { allocate } from "../admin";
@@ -10,14 +11,21 @@ action({
   name: "allocateSonic",
   description: "Allocate liquidity for Origin ARM on Sonic",
   chains: [146],
-  run: async ({ signer, log }) => {
+  params: (t) =>
+    t.addOptionalParam(
+      "threshold",
+      "Liquidity-delta threshold used to skip small allocations, in wS.",
+      10000,
+      types.float,
+    ),
+  run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(sonic.OriginARM, armAbi, signer);
 
     log.info("Allocating liquidity for Origin ARM on Sonic");
     await allocate({
       signer,
       arm,
-      threshold: 10000,
+      threshold: args.threshold,
       maxGasPrice: 500,
       armContractVersion: "v1",
     });

--- a/src/js/tasks/actions/allocateUSDC.ts
+++ b/src/js/tasks/actions/allocateUSDC.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { allocate } from "../admin";
@@ -9,14 +10,21 @@ action({
   name: "allocateUSDC",
   description: "Allocate liquidity for USDC ARM",
   chains: [1],
-  run: async ({ signer, log }) => {
+  params: (t) =>
+    t.addOptionalParam(
+      "threshold",
+      "Liquidity-delta threshold used to skip small allocations, in USDC.",
+      15000,
+      types.float,
+    ),
+  run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.usdcARM, multiAssetARMAbi, signer);
 
     log.info("Allocating liquidity for USDC ARM");
     await allocate({
       signer,
       arm,
-      threshold: 500,
+      threshold: args.threshold,
       maxGasPrice: 5,
     });
   },

--- a/src/js/tasks/actions/allocateUSDC.ts
+++ b/src/js/tasks/actions/allocateUSDC.ts
@@ -11,12 +11,19 @@ action({
   description: "Allocate liquidity for USDC ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "threshold",
-      "Liquidity-delta threshold used to skip small allocations, in USDC.",
-      15000,
-      types.float,
-    ),
+    t
+      .addOptionalParam(
+        "threshold",
+        "Liquidity-delta threshold used to skip small allocations, in USDC.",
+        15000,
+        types.float,
+      )
+      .addOptionalParam(
+        "maxGasPrice",
+        "Maximum gas price at which allocation may execute, in gwei.",
+        2,
+        types.float,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.usdcARM, multiAssetARMAbi, signer);
 
@@ -25,7 +32,7 @@ action({
       signer,
       arm,
       threshold: args.threshold,
-      maxGasPrice: 5,
+      maxGasPrice: args.maxGasPrice,
     });
   },
 });

--- a/src/js/tasks/actions/allocateWETH.ts
+++ b/src/js/tasks/actions/allocateWETH.ts
@@ -11,12 +11,19 @@ action({
   description: "Allocate liquidity for WETH ARM",
   chains: [1],
   params: (t) =>
-    t.addOptionalParam(
-      "threshold",
-      "Liquidity-delta threshold used to skip small allocations, in WETH.",
-      100,
-      types.float,
-    ),
+    t
+      .addOptionalParam(
+        "threshold",
+        "Liquidity-delta threshold used to skip small allocations, in WETH.",
+        100,
+        types.float,
+      )
+      .addOptionalParam(
+        "maxGasPrice",
+        "Maximum gas price at which allocation may execute, in gwei.",
+        2,
+        types.float,
+      ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.wethARM, multiAssetARMAbi, signer);
 
@@ -25,7 +32,7 @@ action({
       signer,
       arm,
       threshold: args.threshold,
-      maxGasPrice: 5,
+      maxGasPrice: args.maxGasPrice,
     });
   },
 });

--- a/src/js/tasks/actions/allocateWETH.ts
+++ b/src/js/tasks/actions/allocateWETH.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { types } from "hardhat/config";
 
 import { action } from "../lib/action";
 import { allocate } from "../admin";
@@ -9,14 +10,21 @@ action({
   name: "allocateWETH",
   description: "Allocate liquidity for WETH ARM",
   chains: [1],
-  run: async ({ signer, log }) => {
+  params: (t) =>
+    t.addOptionalParam(
+      "threshold",
+      "Liquidity-delta threshold used to skip small allocations, in WETH.",
+      100,
+      types.float,
+    ),
+  run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.wethARM, multiAssetARMAbi, signer);
 
     log.info("Allocating liquidity for WETH ARM");
     await allocate({
       signer,
       arm,
-      threshold: 100,
+      threshold: args.threshold,
       maxGasPrice: 5,
     });
   },


### PR DESCRIPTION
## Summary

- Add configurable `--threshold` and `--max-gas-price` parameters to all ARM allocation actions.
- Set ARM-specific default allocation thresholds:
  - Lido: `100 WETH`
  - EtherFi: `20 WETH`
  - Ethena: `30,000 USDe`
  - USDC: `15,000 USDC`
  - WETH: `100 WETH`
  - OETH: `100 WETH`
  - Sonic: `10,000 wS`
- Default mainnet allocation actions to a maximum gas price of `2 gwei`; retain `500 gwei` for Sonic.
