### PR TITLE
fix(pricing): bypass tolerance when prices hit configured bounds

### DIFF
--- a/src/js/tasks/armPrices.js
+++ b/src/js/tasks/armPrices.js
@@ -19,8 +19,11 @@ const {
   rangeBuyPrice,
 } = require("../utils/pricing");
 const {
+  exceedsMaxBuyPrice,
+  fallsBelowMinSellPrice,
   haveSwapCapsChanged,
   resolveDexQuoteAmount,
+  shouldUpdatePrices,
 } = require("../utils/priceUpdate");
 
 const log = require("../utils/logger")("task:prices");
@@ -109,6 +112,8 @@ const setPrices = async (options) => {
   let targetBuyPrice;
   let targetSellPrice;
   let offsetSellSpread;
+  let buyPriceWasCappedAtMax = false;
+  let sellPriceWasFlooredAtMin = false;
   // 2. If no buy/sell prices are provided, calculate them using midPrice/1Inch/Curve
   if (!buyPrice && !sellPrice && (midPrice || curve || inch || kyber)) {
     // Set asset options
@@ -333,6 +338,7 @@ const setPrices = async (options) => {
     }
 
     // 2.4 Adjust target buy price based on min/max limits
+    buyPriceWasCappedAtMax = exceedsMaxBuyPrice(targetBuyPrice, maxBuyPrice);
     targetBuyPrice = rangeBuyPrice(targetBuyPrice, minBuyPrice, maxBuyPrice);
 
     // 2.5 Adjust target buy price based on cross price
@@ -365,6 +371,10 @@ const setPrices = async (options) => {
     }
 
     // 2.7 Adjust target sell price based on min/max limits
+    sellPriceWasFlooredAtMin = fallsBelowMinSellPrice(
+      targetSellPrice,
+      minSellPrice,
+    );
     targetSellPrice = rangeSellPrice(
       targetSellPrice,
       minSellPrice,
@@ -421,13 +431,24 @@ const setPrices = async (options) => {
 
   // decide if rates need to be updated
   if (
-    diffSellPrice > toleranceScaled ||
-    diffBuyPrice > toleranceScaled ||
-    swapCapsChanged
+    shouldUpdatePrices({
+      diffSellPrice,
+      diffBuyPrice,
+      toleranceScaled,
+      buyPriceWasCappedAtMax,
+      sellPriceWasFlooredAtMin,
+      swapCapsChanged,
+    })
   ) {
     console.log(`About to update ARM prices`);
     console.log(`sell: ${formatUnits(targetSellPrice, 36)}`);
     console.log(`buy : ${formatUnits(targetBuyPrice, 36)}`);
+    if (buyPriceWasCappedAtMax) {
+      console.log(`Buy price exceeded the maximum and was capped`);
+    }
+    if (sellPriceWasFlooredAtMin) {
+      console.log(`Sell price fell below the minimum and was raised`);
+    }
     if (swapCapsChanged) {
       console.log(`Buy or sell amount has changed`);
     }

--- a/src/js/utils/priceUpdate.js
+++ b/src/js/utils/priceUpdate.js
@@ -45,8 +45,35 @@ const haveSwapCapsChanged = (baseContext, buyAmount, sellAmount) =>
   (buyAmount !== baseContext.config.buyLiquidityRemaining ||
     sellAmount !== baseContext.config.sellLiquidityRemaining);
 
+const exceedsMaxBuyPrice = (targetBuyPrice, maxBuyPrice) =>
+  maxBuyPrice !== undefined &&
+  maxBuyPrice !== null &&
+  targetBuyPrice > parseUnits(maxBuyPrice.toString(), 36);
+
+const fallsBelowMinSellPrice = (targetSellPrice, minSellPrice) =>
+  minSellPrice !== undefined &&
+  minSellPrice !== null &&
+  targetSellPrice < parseUnits(minSellPrice.toString(), 36);
+
+const shouldUpdatePrices = ({
+  diffSellPrice,
+  diffBuyPrice,
+  toleranceScaled,
+  buyPriceWasCappedAtMax,
+  sellPriceWasFlooredAtMin,
+  swapCapsChanged,
+}) =>
+  diffSellPrice > toleranceScaled ||
+  diffBuyPrice > toleranceScaled ||
+  buyPriceWasCappedAtMax ||
+  sellPriceWasFlooredAtMin ||
+  swapCapsChanged;
+
 module.exports = {
   capDexAmountBySwapLiquidity,
+  exceedsMaxBuyPrice,
+  fallsBelowMinSellPrice,
   haveSwapCapsChanged,
   resolveDexQuoteAmount,
+  shouldUpdatePrices,
 };

--- a/test/js/armPrices.test.js
+++ b/test/js/armPrices.test.js
@@ -2,10 +2,14 @@ const assert = require("assert");
 
 const {
   capDexAmountBySwapLiquidity,
+  exceedsMaxBuyPrice,
+  fallsBelowMinSellPrice,
   haveSwapCapsChanged,
   resolveDexQuoteAmount,
+  shouldUpdatePrices,
 } = require("../../src/js/utils/priceUpdate");
 const { parseSwapCap } = require("../../src/js/utils/arm");
+const { parseUnits } = require("ethers");
 
 assert.strictEqual(
   parseSwapCap("1", 18),
@@ -130,6 +134,88 @@ assert.strictEqual(
   }),
   "20.0",
   "an automatic quote amount should use the smallest reserve or price liquidity limit",
+);
+
+const currentBuyPrice = parseUnits("0.99985", 36);
+const cappedBuyPrice = parseUnits("0.99986", 36);
+const currentSellPrice = parseUnits("1.00015", 36);
+const flooredSellPrice = parseUnits("1.00014", 36);
+const tolerance = parseUnits("0.2", 32);
+
+assert.strictEqual(
+  exceedsMaxBuyPrice(parseUnits("0.99991", 36), "0.99986"),
+  true,
+  "a 0.99991 calculated buy price should be capped at the 0.99986 maximum",
+);
+
+assert.strictEqual(
+  exceedsMaxBuyPrice(cappedBuyPrice, "0.99986"),
+  false,
+  "a buy price already at the maximum should not be treated as newly capped",
+);
+
+assert.strictEqual(
+  shouldUpdatePrices({
+    diffSellPrice: 0n,
+    diffBuyPrice: cappedBuyPrice - currentBuyPrice,
+    toleranceScaled: tolerance,
+    buyPriceWasCappedAtMax: false,
+    sellPriceWasFlooredAtMin: false,
+    swapCapsChanged: false,
+  }),
+  false,
+  "a 0.1 bps buy-price change should remain below the 0.2 bps tolerance",
+);
+
+assert.strictEqual(
+  shouldUpdatePrices({
+    diffSellPrice: 0n,
+    diffBuyPrice: cappedBuyPrice - currentBuyPrice,
+    toleranceScaled: tolerance,
+    buyPriceWasCappedAtMax: true,
+    sellPriceWasFlooredAtMin: false,
+    swapCapsChanged: false,
+  }),
+  true,
+  "a buy price capped at the maximum should update despite being within tolerance",
+);
+
+assert.strictEqual(
+  fallsBelowMinSellPrice(parseUnits("1.0001", 36), "1.00014"),
+  true,
+  "a 1.0001 calculated sell price should be raised to the 1.00014 minimum",
+);
+
+assert.strictEqual(
+  fallsBelowMinSellPrice(flooredSellPrice, "1.00014"),
+  false,
+  "a sell price already at the minimum should not be treated as newly floored",
+);
+
+assert.strictEqual(
+  shouldUpdatePrices({
+    diffSellPrice: currentSellPrice - flooredSellPrice,
+    diffBuyPrice: 0n,
+    toleranceScaled: tolerance,
+    buyPriceWasCappedAtMax: false,
+    sellPriceWasFlooredAtMin: false,
+    swapCapsChanged: false,
+  }),
+  false,
+  "a 0.1 bps sell-price change should remain below the 0.2 bps tolerance",
+);
+
+assert.strictEqual(
+  shouldUpdatePrices({
+    diffSellPrice: currentSellPrice - flooredSellPrice,
+    diffBuyPrice: 0n,
+    toleranceScaled: tolerance,
+    buyPriceWasCappedAtMax: false,
+    sellPriceWasFlooredAtMin: true,
+    swapCapsChanged: false,
+  }),
+  true,
+  "a sell price raised to the minimum should update despite being within tolerance",
 );
 
 console.log("ARM price tests passed");


### PR DESCRIPTION
## Summary

- Force a price update when the calculated buy price exceeds `maxBuyPrice` and is capped, even if the final price difference is within tolerance.
- Force a price update when the calculated sell price falls below `minSellPrice` and is raised, even if the final price difference is within tolerance.
- Preserve the existing tolerance behavior for ordinary price movements.
- Add regression coverage for both configured price bounds.

## Example

Given:

- Current buy price: `0.99985`
- Calculated buy price: `0.99991`
- Maximum buy price: `0.99986`
- Tolerance: `0.2 bps`

The calculated price is capped at `0.99986`. The difference from the current price is only `0.1 bps`, so it was previously ignored because it was within tolerance.

This change applies the capped price because the calculated price exceeded the configured maximum.

The same behavior applies to the sell side: when a calculated sell price falls below `minSellPrice`, the minimum sell price is applied regardless of tolerance.
