### PR TITLE
fix(pricing): prevent no-op updates at price bounds

### DIFF
--- a/src/js/utils/priceUpdate.js
+++ b/src/js/utils/priceUpdate.js
@@ -62,12 +62,18 @@ const shouldUpdatePrices = ({
   buyPriceWasCappedAtMax,
   sellPriceWasFlooredAtMin,
   swapCapsChanged,
-}) =>
-  diffSellPrice > toleranceScaled ||
-  diffBuyPrice > toleranceScaled ||
-  buyPriceWasCappedAtMax ||
-  sellPriceWasFlooredAtMin ||
-  swapCapsChanged;
+}) => {
+  const boundedPriceChanged =
+    (buyPriceWasCappedAtMax || sellPriceWasFlooredAtMin) &&
+    (diffSellPrice > 0n || diffBuyPrice > 0n);
+
+  return (
+    diffSellPrice > toleranceScaled ||
+    diffBuyPrice > toleranceScaled ||
+    boundedPriceChanged ||
+    swapCapsChanged
+  );
+};
 
 module.exports = {
   capDexAmountBySwapLiquidity,

--- a/test/js/armPrices.test.js
+++ b/test/js/armPrices.test.js
@@ -218,4 +218,30 @@ assert.strictEqual(
   "a sell price raised to the minimum should update despite being within tolerance",
 );
 
+assert.strictEqual(
+  shouldUpdatePrices({
+    diffSellPrice: 0n,
+    diffBuyPrice: 0n,
+    toleranceScaled: tolerance,
+    buyPriceWasCappedAtMax: true,
+    sellPriceWasFlooredAtMin: true,
+    swapCapsChanged: false,
+  }),
+  false,
+  "prices already at their configured bounds should not trigger a no-op update",
+);
+
+assert.strictEqual(
+  shouldUpdatePrices({
+    diffSellPrice: 0n,
+    diffBuyPrice: 0n,
+    toleranceScaled: tolerance,
+    buyPriceWasCappedAtMax: true,
+    sellPriceWasFlooredAtMin: false,
+    swapCapsChanged: true,
+  }),
+  true,
+  "changed swap caps should still update when bounded prices are unchanged",
+);
+
 console.log("ARM price tests passed");


### PR DESCRIPTION
## Summary

Prevent redundant `setPrices` transactions when ARM prices are already at their configured bounds.

Boundary conditions still bypass tolerance when the target price changes, and liquidity-cap changes continue to trigger updates.
