### PR TITLE
feat(pricing): tranche pricing with utilisation ladder for EthenaARM

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -27,6 +27,22 @@ An explicit `--amount` is used unchanged.
 `--buy-price` and `--sell-price` bypass DEX-derived pricing and set an exact
 pair. Both must be supplied together; `--amount` is not used in this mode.
 
+`setPricesEthena --tranche true` enables tranche pricing on the Ethena ARM:
+the buy-side liquidity limit and the aggregator quote size are one tranche of
+the available liquidity (`--tranche-pct` of `getReserves`, rounded to
+`--tranche-step`, at least `--tranche-min`, or the whole liquidity below it),
+and the maximum buy price follows a utilisation ladder. Utilisation is
+`1 - available liquidity / total assets`; `--ladder` lists the minimum discount
+below NAV in basis points at each utilisation level (`50:2.5,70:3.5,85:5` =
+2.5 bps below 50% deployed, 3.5 bps at 70%, 5 bps from 85%), linearly
+interpolated and quantised to `--ladder-step`. The aggregator quote can only
+widen the discount beyond the ladder; `--max-buy-price` stays as an absolute
+guard and must be looser than the ladder floor or the ladder is inert.
+`--buy-amount` and `--amount` are ignored in this mode. The buy limit alone only
+triggers a transaction once `--cap-tolerance` of the tranche has been consumed
+or the tranche shrank; an uncapped sell limit decremented by swaps is left
+alone. `--dryrun true` logs the targets without sending the transaction.
+
 `setPricesWETH` uses the Lido pricing profile and 1Inch for `STETH,WSTETH`, and
 the EtherFi pricing profile and Kyber for `EETH,WEETH`. It processes all four
 bases unless `--bases` is supplied. Explicit price, liquidity, aggregator,
@@ -63,13 +79,13 @@ and Sonic.
 
 ## Ethena ARM — mainnet
 
-| Action                      | Cron          | Description                                |
-| --------------------------- | ------------- | ------------------------------------------ |
-| `autoRequestEthenaWithdraw` | `12 * * * *`  | Request Ethena withdrawals from Ethena ARM |
-| `autoClaimEthenaWithdraw`   | `40 * * * *`  | Claim Ethena withdrawals from Ethena ARM   |
-| `collectEthenaFees`         | `45 23 * * *` | Collect fees from Ethena ARM               |
-| `allocateEthena`            | `28 * * * *`  | Allocate liquidity for Ethena ARM          |
-| `setPricesEthena`           | `4 * * * *`   | Set prices for Ethena ARM                  |
+| Action                      | Cron           | Description                                 |
+| --------------------------- | -------------- | ------------------------------------------- |
+| `autoRequestEthenaWithdraw` | `12 * * * *`   | Request Ethena withdrawals from Ethena ARM  |
+| `autoClaimEthenaWithdraw`   | `40 * * * *`   | Claim Ethena withdrawals from Ethena ARM    |
+| `collectEthenaFees`         | `45 23 * * *`  | Collect fees from Ethena ARM                |
+| `allocateEthena`            | `28 * * * *`   | Allocate liquidity for Ethena ARM           |
+| `setPricesEthena`           | `*/10 * * * *` | Set prices for Ethena ARM (tranche pricing) |
 
 ## USDC ARM — mainnet
 

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -42,6 +42,11 @@ guard and must be looser than the ladder floor or the ladder is inert.
 triggers a transaction once `--cap-tolerance` of the tranche has been consumed
 or the tranche shrank; an uncapped sell limit decremented by swaps is left
 alone. `--dryrun true` logs the targets without sending the transaction.
+The schedule runs every 2 minutes: there is no on-chain watcher yet, so the
+cron is what reopens a consumed tranche and moves the ladder after a burst of
+fills (39% of the historical volume lands within 10 minutes of the previous
+fill, 22% within 2). The cadence does not drive the number of transactions;
+the price tolerance, the ladder quantisation and `--cap-tolerance` do.
 
 `setPricesWETH` uses the Lido pricing profile and 1Inch for `STETH,WSTETH`, and
 the EtherFi pricing profile and Kyber for `EETH,WEETH`. It processes all four
@@ -79,13 +84,13 @@ and Sonic.
 
 ## Ethena ARM — mainnet
 
-| Action                      | Cron           | Description                                 |
-| --------------------------- | -------------- | ------------------------------------------- |
-| `autoRequestEthenaWithdraw` | `12 * * * *`   | Request Ethena withdrawals from Ethena ARM  |
-| `autoClaimEthenaWithdraw`   | `40 * * * *`   | Claim Ethena withdrawals from Ethena ARM    |
-| `collectEthenaFees`         | `45 23 * * *`  | Collect fees from Ethena ARM                |
-| `allocateEthena`            | `28 * * * *`   | Allocate liquidity for Ethena ARM           |
-| `setPricesEthena`           | `*/10 * * * *` | Set prices for Ethena ARM (tranche pricing) |
+| Action                      | Cron          | Description                                 |
+| --------------------------- | ------------- | ------------------------------------------- |
+| `autoRequestEthenaWithdraw` | `12 * * * *`  | Request Ethena withdrawals from Ethena ARM  |
+| `autoClaimEthenaWithdraw`   | `40 * * * *`  | Claim Ethena withdrawals from Ethena ARM    |
+| `collectEthenaFees`         | `45 23 * * *` | Collect fees from Ethena ARM                |
+| `allocateEthena`            | `28 * * * *`  | Allocate liquidity for Ethena ARM           |
+| `setPricesEthena`           | `*/2 * * * *` | Set prices for Ethena ARM (tranche pricing) |
 
 ## USDC ARM — mainnet
 

--- a/migrations/seed_schedules.sql
+++ b/migrations/seed_schedules.sql
@@ -42,7 +42,7 @@ INSERT INTO schedules (product, name, command, cron_expr, timezone, enabled, not
 ('arm-oeth', 'mainnet_allocate_usdc',                'cd /app && pnpm hardhat allocateUSDC --network mainnet',                    '26 * * * *',            'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_lido',              'cd /app && pnpm hardhat setPricesLido --network mainnet',                   '*/30 * * * *',          'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_etherfi',           'cd /app && pnpm hardhat setPricesEtherFi --network mainnet',                '2,32 * * * *',          'UTC', false, NULL),
-('arm-oeth', 'mainnet_set_prices_ethena',            'cd /app && pnpm hardhat setPricesEthena --network mainnet',                 '4 * * * *',             'UTC', false, NULL),
+('arm-oeth', 'mainnet_set_prices_ethena',            'cd /app && pnpm hardhat setPricesEthena --network mainnet --tranche true --tolerance 0.3 --max-sell-price 0.99996 --offset 0.6 --fee 0.5 --kyber true', '*/10 * * * *',          'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_usdc_pyusd',        'cd /app && pnpm hardhat setPricesUSDCPYUSD --network mainnet',              '6 * * * *',             'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_usdc_usdg',         'cd /app && pnpm hardhat setPricesUSDCUSDG --network mainnet',               '6 * * * *',             'UTC', false, NULL),
 ('arm-oeth', 'mainnet_auto_request_weth_lido_withdraw',   'cd /app && pnpm hardhat autoRequestWETHLidoWithdraw --network mainnet',    '29,58 12-23,0-8 * * *', 'UTC', false, NULL),

--- a/migrations/seed_schedules.sql
+++ b/migrations/seed_schedules.sql
@@ -42,7 +42,7 @@ INSERT INTO schedules (product, name, command, cron_expr, timezone, enabled, not
 ('arm-oeth', 'mainnet_allocate_usdc',                'cd /app && pnpm hardhat allocateUSDC --network mainnet',                    '26 * * * *',            'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_lido',              'cd /app && pnpm hardhat setPricesLido --network mainnet',                   '*/30 * * * *',          'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_etherfi',           'cd /app && pnpm hardhat setPricesEtherFi --network mainnet',                '2,32 * * * *',          'UTC', false, NULL),
-('arm-oeth', 'mainnet_set_prices_ethena',            'cd /app && pnpm hardhat setPricesEthena --network mainnet --tranche true --tolerance 0.3 --max-sell-price 0.99996 --offset 0.6 --fee 0.5 --kyber true', '*/2 * * * *',           'UTC', false, NULL),
+('arm-oeth', 'mainnet_set_prices_ethena',            'cd /app && pnpm hardhat setPricesEthena --network mainnet',                 '4 * * * *',             'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_usdc_pyusd',        'cd /app && pnpm hardhat setPricesUSDCPYUSD --network mainnet',              '6 * * * *',             'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_usdc_usdg',         'cd /app && pnpm hardhat setPricesUSDCUSDG --network mainnet',               '6 * * * *',             'UTC', false, NULL),
 ('arm-oeth', 'mainnet_auto_request_weth_lido_withdraw',   'cd /app && pnpm hardhat autoRequestWETHLidoWithdraw --network mainnet',    '29,58 12-23,0-8 * * *', 'UTC', false, NULL),

--- a/migrations/seed_schedules.sql
+++ b/migrations/seed_schedules.sql
@@ -42,7 +42,7 @@ INSERT INTO schedules (product, name, command, cron_expr, timezone, enabled, not
 ('arm-oeth', 'mainnet_allocate_usdc',                'cd /app && pnpm hardhat allocateUSDC --network mainnet',                    '26 * * * *',            'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_lido',              'cd /app && pnpm hardhat setPricesLido --network mainnet',                   '*/30 * * * *',          'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_etherfi',           'cd /app && pnpm hardhat setPricesEtherFi --network mainnet',                '2,32 * * * *',          'UTC', false, NULL),
-('arm-oeth', 'mainnet_set_prices_ethena',            'cd /app && pnpm hardhat setPricesEthena --network mainnet --tranche true --tolerance 0.3 --max-sell-price 0.99996 --offset 0.6 --fee 0.5 --kyber true', '*/10 * * * *',          'UTC', false, NULL),
+('arm-oeth', 'mainnet_set_prices_ethena',            'cd /app && pnpm hardhat setPricesEthena --network mainnet --tranche true --tolerance 0.3 --max-sell-price 0.99996 --offset 0.6 --fee 0.5 --kyber true', '*/2 * * * *',           'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_usdc_pyusd',        'cd /app && pnpm hardhat setPricesUSDCPYUSD --network mainnet',              '6 * * * *',             'UTC', false, NULL),
 ('arm-oeth', 'mainnet_set_prices_usdc_usdg',         'cd /app && pnpm hardhat setPricesUSDCUSDG --network mainnet',               '6 * * * *',             'UTC', false, NULL),
 ('arm-oeth', 'mainnet_auto_request_weth_lido_withdraw',   'cd /app && pnpm hardhat autoRequestWETHLidoWithdraw --network mainnet',    '29,58 12-23,0-8 * * *', 'UTC', false, NULL),

--- a/src/js/tasks/actions/setPricesEthena.ts
+++ b/src/js/tasks/actions/setPricesEthena.ts
@@ -5,7 +5,11 @@ import { action } from "../lib/action";
 import { setPrices } from "../armPrices";
 import { setPricesForBases } from "../../utils/priceActionUtils";
 import { mainnet } from "../../utils/addresses";
+import { resolveEthenaTranche } from "../../utils/ethenaPricing";
+import { scaledInt } from "../../utils/tranchePricing";
 const ethenaARMAbi = require("../../../abis/EthenaARM.json");
+
+const DEFAULT_LADDER = "50:2.5,70:3.5,85:5";
 
 action({
   name: "setPricesEthena",
@@ -112,13 +116,106 @@ action({
         "Swap fee in basis points used by setPrices when computing target prices.",
         2,
         types.float,
+      )
+      .addOptionalParam(
+        "tranche",
+        "Tranche pricing: the buy liquidity limit and the aggregator quote size are one tranche of the available liquidity, and the max buy price follows the utilisation ladder. Overrides --buy-amount, --amount and tightens --max-buy-price.",
+        false,
+        types.boolean,
+      )
+      .addOptionalParam(
+        "tranchePct",
+        "Tranche as a percentage of the available liquidity (35 = 35%).",
+        35,
+        types.float,
+      )
+      .addOptionalParam(
+        "trancheStep",
+        "Rounding step of the tranche in USDe (25000 = round to 25k).",
+        25000,
+        types.float,
+      )
+      .addOptionalParam(
+        "trancheMin",
+        "Minimum tranche in USDe; below it the whole liquidity is the tranche.",
+        25000,
+        types.float,
+      )
+      .addOptionalParam(
+        "ladder",
+        "Utilisation ladder as 'u%:bps,...': minimum discount below NAV in basis points at each utilisation level, linearly interpolated (50:2.5,70:3.5,85:5 = 2.5 bps below 50% deployed, 3.5 bps at 70%, 5 bps from 85%).",
+        DEFAULT_LADDER,
+        types.string,
+      )
+      .addOptionalParam(
+        "ladderStep",
+        "Quantisation of the ladder discount in basis points (0.25 = the max buy price moves in 0.25 bps notches).",
+        0.25,
+        types.float,
+      )
+      .addOptionalParam(
+        "capTolerance",
+        "Share of the tranche that must be consumed before the buy limit alone triggers an update (0.25 = 25%).",
+        0.25,
+        types.float,
+      )
+      .addOptionalParam(
+        "dryrun",
+        "Compute and log the target prices without sending the transaction.",
+        false,
+        types.boolean,
       ),
   run: async ({ signer, log, args }) => {
     const arm = new ethers.Contract(mainnet.ethenaARM, ethenaARMAbi, signer);
+    // Pin the block so the tranche, the utilisation and the on-chain limits
+    // compared in setPrices all come from the same state.
+    const blockTag = await signer.provider!.getBlockNumber();
 
     log.info("Setting prices for Ethena ARM");
+
+    const trancheParams = args.tranche
+      ? {
+          tranchePctBps: scaledInt(args.tranchePct, 100, "tranche percentage"),
+          trancheStepWei: ethers.parseUnits(args.trancheStep.toString(), 18),
+          trancheMinWei: ethers.parseUnits(args.trancheMin.toString(), 18),
+          ladder: args.ladder,
+          ladderStepBps100: scaledInt(args.ladderStep, 100, "ladder step"),
+          buyCapToleranceBps: scaledInt(args.capTolerance, 10000, "cap tolerance"),
+        }
+      : undefined;
+
+    if (trancheParams) {
+      if (args.buyAmount !== undefined || args.amount !== undefined) {
+        log.warn(
+          "--tranche is set: --buy-amount and --amount are ignored, the tranche sets both",
+        );
+      }
+      log.info(
+        `Tranche pricing: ${args.tranchePct}% of liquidity (step ${args.trancheStep}, min ${args.trancheMin}), ladder ${args.ladder} quantised to ${args.ladderStep} bps, cap tolerance ${args.capTolerance}`,
+      );
+    }
+
+    const setPricesFn = trancheParams
+      ? async (options: any) => {
+          const overrides = await resolveEthenaTranche({
+            arm,
+            armName: options.armName,
+            base: options.base,
+            blockTag,
+            maxBuyPrice: options.maxBuyPrice,
+            ...trancheParams,
+          });
+          return setPrices({
+            ...options,
+            buyAmount: overrides.buyAmount,
+            amount: overrides.amount,
+            maxBuyPrice: overrides.maxBuyPrice,
+          });
+        }
+      : setPrices;
+
     await setPricesForBases({
-      setPrices,
+      setPrices: setPricesFn,
       bases: ["SUSDE"],
       options: {
         signer,
@@ -141,8 +238,10 @@ action({
         dynamicOffset: args.dynamicOffset,
         dynamicOffsetFullSpreadPrice: args.dynamicOffsetFullSpreadPrice,
         priceOffset: true,
-        blockTag: "latest",
+        blockTag,
         wrapped: true,
+        dryrun: args.dryrun,
+        buyCapToleranceBps: trancheParams?.buyCapToleranceBps,
       },
     });
   },

--- a/src/js/tasks/armPrices.js
+++ b/src/js/tasks/armPrices.js
@@ -51,6 +51,7 @@ const scaleTo18 = (value, decimals) => value * 10n ** BigInt(18 - decimals);
  * dryrun - if true, will not actually call setPrices on the ARM, just log the target prices
  * base - base asset symbol. eg STETH, WSTETH, EETH, WEETH, SUSDE, OETH, WOETH, OS
  * wrapped - adjust market prices by the adapter conversion rate
+ * buyCapToleranceBps - optional, share of the buy liquidity limit (2500 = 25%) that must be consumed before the limit alone triggers an update
  * @returns
  */
 const setPrices = async (options) => {
@@ -421,6 +422,7 @@ const setPrices = async (options) => {
     baseContext,
     targetBuyAmount,
     targetSellAmount,
+    { buyCapToleranceBps: options.buyCapToleranceBps },
   );
   if (baseContext.version === "multiBase") {
     log(`current buy amount : ${config.buyLiquidityRemaining}`);

--- a/src/js/utils/ethenaPricing.js
+++ b/src/js/utils/ethenaPricing.js
@@ -1,62 +1,136 @@
 const { formatUnits, parseUnits } = require("ethers");
 
-const { resolveArmBase } = require("./arm");
+const { adapterContract, resolveArmBase } = require("./arm");
+const {
+  computeTranche,
+  computeUtilisationBps,
+  ladderDiscountBps100,
+  ladderMaxBuyPrice,
+  parseLadder,
+  resolveQuoteAmount,
+} = require("./tranchePricing");
+
+const log = require("./logger")("task:prices:tranche");
 
 const MIN_ETHENA_AGGREGATOR_AMOUNT = parseUnits("1000", 18); // 1,000 USDe
 
-const hasAmountOverride = (amount) => amount !== undefined && amount !== null;
-
-const readReserveLiquidity = (reserves) =>
-  reserves.liquidityAssets ?? reserves[0];
-
-const resolveEthenaAggregatorAmount = async ({
+/**
+ * Compute the tranche pricing overrides for the Ethena ARM: the buy liquidity
+ * limit, the aggregator quote size and the ladder-driven max buy price.
+ *
+ * All three are derived from the same block so the cap refresh decision in
+ * setPrices compares like with like.
+ *
+ * @param {object} params
+ * @param {import("ethers").Contract} params.arm Ethena ARM contract (full ABI)
+ * @param {string} [params.armName="Ethena"]
+ * @param {string} [params.base="SUSDE"]
+ * @param {number|string} [params.blockTag="latest"] block to read state at
+ * @param {number} params.tranchePctBps share of liquidity per tranche, 3500 = 35%
+ * @param {bigint} params.trancheStepWei rounding step in liquidity wei, eg 25,000e18
+ * @param {bigint} params.trancheMinWei minimum tranche in liquidity wei, eg 25,000e18
+ * @param {string} params.ladder "u%:bps,..." eg "50:2.5,70:3.5,85:5"
+ * @param {number} params.ladderStepBps100 quantisation of the ladder, 25 = 0.25 bps
+ * @param {number|string} [params.maxBuyPrice] absolute guard, eg 0.99985; the
+ *   tighter of the guard and the ladder is used
+ * @param {bigint} [params.minQuoteAmount] floor for the aggregator quote size
+ * @param {function} [params.resolveArmBaseFn] test hook
+ * @param {function} [params.adapterContractFn] test hook
+ * @returns {Promise<{buyAmount: bigint, amount: string, maxBuyPrice: string,
+ *   utilisationBps: number, ladderBps100: number, tranche: bigint,
+ *   liquidityAssets: bigint, totalAssets: bigint}>}
+ *   `buyAmount`, `amount` and `maxBuyPrice` are in the shapes setPrices expects.
+ */
+const resolveEthenaTranche = async ({
   arm,
-  amount,
-  log,
+  armName = "Ethena",
+  base = "SUSDE",
   blockTag = "latest",
+  tranchePctBps,
+  trancheStepWei,
+  trancheMinWei,
+  ladder,
+  ladderStepBps100,
+  maxBuyPrice,
+  minQuoteAmount = MIN_ETHENA_AGGREGATOR_AMOUNT,
   resolveArmBaseFn = resolveArmBase,
-  minAmount = MIN_ETHENA_AGGREGATOR_AMOUNT,
+  adapterContractFn = adapterContract,
 }) => {
-  if (hasAmountOverride(amount)) {
-    log?.info?.(`Using configured aggregator quote amount: ${amount} USDe`);
-    return amount;
-  }
+  const knots = parseLadder(ladder);
 
-  const baseContext = await resolveArmBaseFn({
-    arm,
-    armName: "Ethena",
-    base: "SUSDE",
-    blockTag,
-  });
-
+  const baseContext = await resolveArmBaseFn({ arm, armName, base, blockTag });
   if (baseContext.version !== "multiBase") {
-    const formattedMinAmount = formatUnits(minAmount, 18);
-    log?.info?.(
-      `Using minimum aggregator quote amount for legacy Ethena ARM: ${formattedMinAmount} USDe`,
-    );
-    return formattedMinAmount;
+    throw new Error(`Tranche pricing requires a multi-base ${armName} ARM`);
   }
+  const { baseAddress, config } = baseContext;
+  const baseDecimals = Number(config.baseAssetDecimals ?? 18);
 
-  const reserves = await arm.getReserves(baseContext.baseAddress, {
-    blockTag,
-  });
-  const liquidityAssets = readReserveLiquidity(reserves);
+  const reserves = await arm.getReserves(baseAddress, { blockTag });
+  const liquidityAssets = reserves.liquidityAssets ?? reserves[0];
+  const totalAssets = await arm.totalAssets({ blockTag });
 
-  if (liquidityAssets < minAmount) {
-    log?.info?.(
-      `Using minimum aggregator quote amount of ${formatUnits(minAmount, 18)} USDe; only ${formatUnits(liquidityAssets, 18)} USDe is withdrawable in ARM and lending market`,
-    );
-    return formatUnits(minAmount, 18);
-  }
-
-  const resolvedAmount = formatUnits(liquidityAssets, 18);
-  log?.info?.(
-    `Using ${resolvedAmount} USDe available in ARM and lending market as aggregator quote amount`,
+  const utilisationBps = computeUtilisationBps(liquidityAssets, totalAssets);
+  const ladderBps100 = ladderDiscountBps100(
+    utilisationBps,
+    knots,
+    ladderStepBps100,
   );
-  return resolvedAmount;
+  const ladderPrice = ladderMaxBuyPrice(ladderBps100);
+
+  const guardPrice =
+    maxBuyPrice === undefined || maxBuyPrice === null
+      ? undefined
+      : parseUnits(maxBuyPrice.toString(), 36);
+  const guardIsTighter = guardPrice !== undefined && guardPrice < ladderPrice;
+  const maxPrice = guardIsTighter ? guardPrice : ladderPrice;
+
+  const tranche = computeTranche({
+    liquidityAssets,
+    pctBps: tranchePctBps,
+    stepWei: trancheStepWei,
+    minWei: trancheMinWei,
+  });
+  const quoteAssets = resolveQuoteAmount(tranche, minQuoteAmount);
+  // The wrapped pricing path quotes in base asset units (sUSDe), so convert
+  // the tranche in liquidity assets (USDe) to shares.
+  const adapter = await adapterContractFn(config.adapter, arm.runner);
+  const quoteShares = await adapter.convertToShares(quoteAssets, { blockTag });
+
+  log(`Tranche pricing at block ${blockTag}:`);
+  log(`liquidity assets   : ${formatUnits(liquidityAssets, 18)}`);
+  log(`total assets       : ${formatUnits(totalAssets, 18)}`);
+  log(`utilisation        : ${(utilisationBps / 100).toFixed(2)}%`);
+  log(`ladder discount    : ${(ladderBps100 / 100).toFixed(2)} bps`);
+  log(`ladder max price   : ${formatUnits(ladderPrice, 36)}`);
+  log(`tranche            : ${formatUnits(tranche, 18)}`);
+  log(
+    `quote size         : ${formatUnits(quoteAssets, 18)} = ${formatUnits(quoteShares, baseDecimals)} shares`,
+  );
+
+  if (guardIsTighter) {
+    console.warn(
+      `Max buy price guard ${maxBuyPrice} is tighter than the ladder price ${formatUnits(ladderPrice, 36)}; the ladder is not in control`,
+    );
+  }
+  if (maxPrice >= config.crossPrice) {
+    console.warn(
+      `Ladder max buy price ${formatUnits(maxPrice, 36)} is not below the cross price ${formatUnits(config.crossPrice, 36)}; setPrices will clamp it`,
+    );
+  }
+
+  return {
+    buyAmount: tranche,
+    amount: formatUnits(quoteShares, baseDecimals),
+    maxBuyPrice: formatUnits(maxPrice, 36),
+    utilisationBps,
+    ladderBps100,
+    tranche,
+    liquidityAssets,
+    totalAssets,
+  };
 };
 
 module.exports = {
   MIN_ETHENA_AGGREGATOR_AMOUNT,
-  resolveEthenaAggregatorAmount,
+  resolveEthenaTranche,
 };

--- a/src/js/utils/priceUpdate.js
+++ b/src/js/utils/priceUpdate.js
@@ -1,5 +1,13 @@
 const { formatUnits, parseUnits } = require("ethers");
 
+const { MAX_SWAP_LIQUIDITY } = require("./arm");
+const { shouldRefreshBuyCap } = require("./tranchePricing");
+
+// An on-chain liquidity limit at or above this is treated as "uncapped": the
+// contract decrements the limit on every swap, so a MAX_SWAP_LIQUIDITY target
+// never matches exactly once a swap has happened.
+const UNCAPPED_THRESHOLD = 1n << 127n;
+
 const capDexAmountBySwapLiquidity = ({
   amount,
   buyLiquidity,
@@ -40,10 +48,41 @@ const resolveDexQuoteAmount = ({
   });
 };
 
-const haveSwapCapsChanged = (baseContext, buyAmount, sellAmount) =>
-  baseContext.version === "multiBase" &&
-  (buyAmount !== baseContext.config.buyLiquidityRemaining ||
-    sellAmount !== baseContext.config.sellLiquidityRemaining);
+/**
+ * Whether the target buy/sell liquidity limits differ from the on-chain ones.
+ * Without options the comparison is strict (any difference triggers an update).
+ * With `buyCapToleranceBps` (eg 2500 = 25%), the buy limit is only refreshed
+ * when the tranche shrank or more than the tolerance was consumed, and an
+ * uncapped sell limit is left alone even after swaps decremented it.
+ */
+const haveSwapCapsChanged = (
+  baseContext,
+  buyAmount,
+  sellAmount,
+  { buyCapToleranceBps } = {},
+) => {
+  if (baseContext.version !== "multiBase") return false;
+  const { buyLiquidityRemaining, sellLiquidityRemaining } = baseContext.config;
+
+  if (buyCapToleranceBps === undefined || buyCapToleranceBps === null) {
+    return (
+      buyAmount !== buyLiquidityRemaining ||
+      sellAmount !== sellLiquidityRemaining
+    );
+  }
+
+  const buyChanged = shouldRefreshBuyCap({
+    remaining: buyLiquidityRemaining,
+    target: buyAmount,
+    toleranceBps: buyCapToleranceBps,
+  });
+  const sellUncapped =
+    sellAmount === MAX_SWAP_LIQUIDITY &&
+    sellLiquidityRemaining >= UNCAPPED_THRESHOLD;
+  const sellChanged = !sellUncapped && sellAmount !== sellLiquidityRemaining;
+
+  return buyChanged || sellChanged;
+};
 
 const exceedsMaxBuyPrice = (targetBuyPrice, maxBuyPrice) =>
   maxBuyPrice !== undefined &&

--- a/src/js/utils/tranchePricing.js
+++ b/src/js/utils/tranchePricing.js
@@ -1,0 +1,202 @@
+/**
+ * Pure helpers for tranche pricing with a utilisation ladder.
+ *
+ * The ARM quotes one buy price for a tranche S of its liquidity: S is both the
+ * on-chain `buyLiquidityRemaining` cap and the size of the aggregator quote.
+ * The ladder gives the minimum discount below NAV the ARM charges as a function
+ * of utilisation u = 1 - available liquidity / total assets.
+ *
+ * Units used throughout (integers only, no floats for on-chain values):
+ * - utilisation in basis points of total assets: 0 = idle, 10000 = fully deployed
+ * - discount in hundredths of a basis point (bps100): 250 = 2.5 bps, 500 = 5 bps
+ * - token amounts as BigInt in the token's smallest unit (wei)
+ * - prices as BigInt scaled to 1e36 (ARM PRICE_SCALE)
+ */
+
+const PRICE_SCALE = 10n ** 36n;
+// 1 bps = 1e32 at 36 decimals, so 0.01 bps = 1e30
+const BPS100_PRICE_UNIT = 10n ** 30n;
+const UTILISATION_SCALE = 10000n;
+
+/**
+ * Parse a decimal string/number into an integer after scaling.
+ * Rejects values that need more precision than the scale allows.
+ * @example scaledInt("2.5", 100, "bps") = 250; scaledInt("50", 100, "u") = 5000
+ */
+const scaledInt = (value, scale, label) => {
+  const number = Number(value);
+  if (typeof value === "string" && value.trim() === "") {
+    throw new Error(`Missing ${label} value`);
+  }
+  if (!Number.isFinite(number)) {
+    throw new Error(`Invalid ${label} value "${value}"`);
+  }
+  const scaled = number * scale;
+  const rounded = Math.round(scaled);
+  if (Math.abs(scaled - rounded) > 1e-6) {
+    throw new Error(
+      `${label} value "${value}" has more precision than supported (1/${scale})`,
+    );
+  }
+  return rounded;
+};
+
+/**
+ * Parse a ladder definition "u%:bps,u%:bps,..." into sorted knots.
+ * @param {string} ladder eg "50:2.5,70:3.5,85:5" = 2.5 bps below 50% utilisation,
+ *   3.5 bps at 70%, 5 bps from 85% up
+ * @returns {{uBps: number, bps100: number}[]} knots with strictly increasing uBps
+ */
+const parseLadder = (ladder) => {
+  if (typeof ladder !== "string" || ladder.trim() === "") {
+    throw new Error(
+      `Invalid ladder "${ladder}": expected "u%:bps,u%:bps", eg "50:2.5,70:3.5,85:5"`,
+    );
+  }
+
+  const knots = ladder.split(",").map((pair) => {
+    const parts = pair.split(":").map((part) => part.trim());
+    if (parts.length !== 2) {
+      throw new Error(`Invalid ladder knot "${pair}": expected "u%:bps"`);
+    }
+    const uBps = scaledInt(parts[0], 100, "ladder utilisation");
+    const bps100 = scaledInt(parts[1], 100, "ladder discount");
+    if (uBps < 0 || uBps > Number(UTILISATION_SCALE)) {
+      throw new Error(
+        `Invalid ladder utilisation "${parts[0]}": must be between 0 and 100`,
+      );
+    }
+    if (bps100 < 0) {
+      throw new Error(`Invalid ladder discount "${parts[1]}": must be >= 0`);
+    }
+    return { uBps, bps100 };
+  });
+
+  for (let i = 1; i < knots.length; i++) {
+    if (knots[i].uBps <= knots[i - 1].uBps) {
+      throw new Error(
+        `Invalid ladder "${ladder}": utilisation levels must be strictly increasing`,
+      );
+    }
+  }
+
+  return knots;
+};
+
+/**
+ * Discount (bps100) for a utilisation level: linear interpolation between knots,
+ * flat outside the first and last knot, then rounded to the nearest multiple of
+ * `stepBps100` (ties round up).
+ * @param {number} uBps utilisation, 0..10000
+ * @param {{uBps: number, bps100: number}[]} knots from parseLadder
+ * @param {number} stepBps100 quantisation step, eg 25 = 0.25 bps
+ * @example u=6000 with knots 50:2.5,70:3.5 -> 300 (3.0 bps)
+ */
+const ladderDiscountBps100 = (uBps, knots, stepBps100 = 25) => {
+  if (!Array.isArray(knots) || knots.length === 0) {
+    throw new Error("Ladder must have at least one knot");
+  }
+  if (!Number.isInteger(stepBps100) || stepBps100 <= 0) {
+    throw new Error(
+      `Invalid ladder step ${stepBps100}: must be a positive integer`,
+    );
+  }
+
+  let raw;
+  const first = knots[0];
+  const last = knots[knots.length - 1];
+  if (uBps <= first.uBps) {
+    raw = first.bps100;
+  } else if (uBps >= last.uBps) {
+    raw = last.bps100;
+  } else {
+    let i = 1;
+    while (knots[i].uBps < uBps) i++;
+    const lo = knots[i - 1];
+    const hi = knots[i];
+    raw =
+      lo.bps100 +
+      ((hi.bps100 - lo.bps100) * (uBps - lo.uBps)) / (hi.uBps - lo.uBps);
+  }
+
+  return Math.floor(raw / stepBps100 + 0.5) * stepBps100;
+};
+
+/**
+ * Buy price (36 decimals) for a discount below NAV, with NAV = 1 in the
+ * ARM's "per share" price space.
+ * @param {number} bps100 eg 250 = 2.5 bps -> 0.99975e36
+ */
+const ladderMaxBuyPrice = (bps100) =>
+  PRICE_SCALE - BigInt(bps100) * BPS100_PRICE_UNIT;
+
+/**
+ * Utilisation in basis points: share of total assets that is not available as
+ * liquidity right now (in cooldown, reserved for LP withdrawals, ...).
+ * @param {bigint} liquidityAssets withdrawable liquidity asset (getReserves)
+ * @param {bigint} totalAssets ARM total assets
+ * @returns {number} 0..10000; 10000 when totalAssets is 0, 0 when liquidity >= total
+ */
+const computeUtilisationBps = (liquidityAssets, totalAssets) => {
+  if (totalAssets <= 0n) return Number(UTILISATION_SCALE);
+  if (liquidityAssets >= totalAssets) return 0;
+  const availableBps = (liquidityAssets * UTILISATION_SCALE) / totalAssets;
+  return Number(UTILISATION_SCALE - availableBps);
+};
+
+/**
+ * Tranche size S: a share of the available liquidity rounded to a step and
+ * bounded to [minWei, liquidityAssets]. When less than minWei is available the
+ * whole liquidity is the tranche.
+ * @param {bigint} liquidityAssets available liquidity asset in wei
+ * @param {number} pctBps share of liquidity, 3500 = 35%
+ * @param {bigint} stepWei rounding step, eg 25,000e18
+ * @param {bigint} minWei minimum tranche, eg 25,000e18
+ * @example 200k liquidity, 35%, step 25k -> 75k; 20k liquidity -> 20k
+ */
+const computeTranche = ({ liquidityAssets, pctBps, stepWei, minWei }) => {
+  if (stepWei <= 0n) throw new Error("Tranche step must be > 0");
+  if (pctBps <= 0 || pctBps > Number(UTILISATION_SCALE)) {
+    throw new Error(
+      `Invalid tranche percentage ${pctBps}: must be 1..10000 bps`,
+    );
+  }
+  if (liquidityAssets <= minWei) return liquidityAssets;
+
+  const raw = (liquidityAssets * BigInt(pctBps)) / UTILISATION_SCALE;
+  let tranche = ((raw + stepWei / 2n) / stepWei) * stepWei;
+  if (tranche < minWei) tranche = minWei;
+  if (tranche > liquidityAssets) tranche = liquidityAssets;
+  return tranche;
+};
+
+/**
+ * Aggregator quote size: the tranche, floored so tiny tranches still get a
+ * meaningful quote.
+ */
+const resolveQuoteAmount = (tranche, minWei) =>
+  tranche < minWei ? minWei : tranche;
+
+/**
+ * Whether the on-chain buy cap should be re-sent: the tranche shrank below
+ * what is still open on-chain, or more than `toleranceBps` of it was consumed.
+ * @param {bigint} remaining on-chain buyLiquidityRemaining
+ * @param {bigint} target computed tranche
+ * @param {number} toleranceBps 2500 = refresh once 25% of the tranche is used
+ */
+const shouldRefreshBuyCap = ({ remaining, target, toleranceBps }) => {
+  if (remaining > target) return true;
+  const floor = target - (target * BigInt(toleranceBps)) / UTILISATION_SCALE;
+  return remaining < floor;
+};
+
+module.exports = {
+  computeTranche,
+  computeUtilisationBps,
+  ladderDiscountBps100,
+  ladderMaxBuyPrice,
+  parseLadder,
+  resolveQuoteAmount,
+  scaledInt,
+  shouldRefreshBuyCap,
+};

--- a/test/js/armPrices.test.js
+++ b/test/js/armPrices.test.js
@@ -61,6 +61,79 @@ assert.strictEqual(
   "legacy ARMs do not support buy and sell amounts",
 );
 
+// With a buy cap tolerance, the buy limit is only refreshed once the tranche
+// shrank or more than the tolerance was consumed.
+const MAX_SWAP_LIQUIDITY = (1n << 128n) - 1n;
+const buyCapTolerance = { buyCapToleranceBps: 2500 };
+
+assert.strictEqual(
+  haveSwapCapsChanged(multiBaseContext(100n, 20n), 100n, 20n, buyCapTolerance),
+  false,
+  "unchanged limits with a buyCapTolerance should not trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(multiBaseContext(80n, 20n), 100n, 20n, buyCapTolerance),
+  false,
+  "a buy limit consumed within the buyCapTolerance should not trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(multiBaseContext(74n, 20n), 100n, 20n, buyCapTolerance),
+  true,
+  "a buy limit consumed beyond the buyCapTolerance should trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(multiBaseContext(100n, 20n), 90n, 20n, buyCapTolerance),
+  true,
+  "a tranche smaller than the on-chain buy limit should trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(
+    multiBaseContext(100n, MAX_SWAP_LIQUIDITY - 5n),
+    100n,
+    MAX_SWAP_LIQUIDITY,
+    buyCapTolerance,
+  ),
+  false,
+  "an uncapped sell limit decremented by swaps should not trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(
+    multiBaseContext(100n, MAX_SWAP_LIQUIDITY - 5n),
+    100n,
+    MAX_SWAP_LIQUIDITY,
+  ),
+  true,
+  "without a buyCapTolerance the sell limit comparison stays strict",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(multiBaseContext(100n, 19n), 100n, 20n, buyCapTolerance),
+  true,
+  "a capped sell limit is still compared strictly",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(
+    multiBaseContext(100n, 20n),
+    100n,
+    MAX_SWAP_LIQUIDITY,
+    buyCapTolerance,
+  ),
+  true,
+  "moving a capped sell limit to uncapped should trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged({ version: "legacy" }, 10n, 20n, buyCapTolerance),
+  false,
+  "legacy ARMs ignore the buyCapTolerance too",
+);
+
 assert.strictEqual(
   capDexAmountBySwapLiquidity({
     amount: 100,
@@ -140,7 +213,7 @@ const currentBuyPrice = parseUnits("0.99985", 36);
 const cappedBuyPrice = parseUnits("0.99986", 36);
 const currentSellPrice = parseUnits("1.00015", 36);
 const flooredSellPrice = parseUnits("1.00014", 36);
-const tolerance = parseUnits("0.2", 32);
+const capTolerance = parseUnits("0.2", 32);
 
 assert.strictEqual(
   exceedsMaxBuyPrice(parseUnits("0.99991", 36), "0.99986"),
@@ -158,39 +231,39 @@ assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: 0n,
     diffBuyPrice: cappedBuyPrice - currentBuyPrice,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: false,
     sellPriceWasFlooredAtMin: false,
     swapCapsChanged: false,
   }),
   false,
-  "a 0.1 bps buy-price change should remain below the 0.2 bps tolerance",
+  "a 0.1 bps buy-price change should remain below the 0.2 bps capTolerance",
 );
 
 assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: 0n,
     diffBuyPrice: cappedBuyPrice - currentBuyPrice,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: true,
     sellPriceWasFlooredAtMin: false,
     swapCapsChanged: false,
   }),
   true,
-  "a buy price capped at the maximum should update despite being within tolerance",
+  "a buy price capped at the maximum should update despite being within capTolerance",
 );
 
 assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: currentSellPrice - flooredSellPrice,
     diffBuyPrice: 0n,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: true,
     sellPriceWasFlooredAtMin: false,
     swapCapsChanged: false,
   }),
   false,
-  "a capped buy price should not bypass tolerance for a sell-only price change",
+  "a capped buy price should not bypass capTolerance for a sell-only price change",
 );
 
 assert.strictEqual(
@@ -209,46 +282,46 @@ assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: currentSellPrice - flooredSellPrice,
     diffBuyPrice: 0n,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: false,
     sellPriceWasFlooredAtMin: false,
     swapCapsChanged: false,
   }),
   false,
-  "a 0.1 bps sell-price change should remain below the 0.2 bps tolerance",
+  "a 0.1 bps sell-price change should remain below the 0.2 bps capTolerance",
 );
 
 assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: currentSellPrice - flooredSellPrice,
     diffBuyPrice: 0n,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: false,
     sellPriceWasFlooredAtMin: true,
     swapCapsChanged: false,
   }),
   true,
-  "a sell price raised to the minimum should update despite being within tolerance",
+  "a sell price raised to the minimum should update despite being within capTolerance",
 );
 
 assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: 0n,
     diffBuyPrice: cappedBuyPrice - currentBuyPrice,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: false,
     sellPriceWasFlooredAtMin: true,
     swapCapsChanged: false,
   }),
   false,
-  "a floored sell price should not bypass tolerance for a buy-only price change",
+  "a floored sell price should not bypass capTolerance for a buy-only price change",
 );
 
 assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: 0n,
     diffBuyPrice: 0n,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: true,
     sellPriceWasFlooredAtMin: true,
     swapCapsChanged: false,
@@ -261,7 +334,7 @@ assert.strictEqual(
   shouldUpdatePrices({
     diffSellPrice: 0n,
     diffBuyPrice: 0n,
-    toleranceScaled: tolerance,
+    toleranceScaled: capTolerance,
     buyPriceWasCappedAtMax: true,
     sellPriceWasFlooredAtMin: false,
     swapCapsChanged: true,

--- a/test/js/ethenaPricing.test.js
+++ b/test/js/ethenaPricing.test.js
@@ -1,138 +1,225 @@
 const assert = require("assert");
 
-const { parseUnits } = require("ethers");
+const { formatUnits, parseUnits } = require("ethers");
 
 const {
   MIN_ETHENA_AGGREGATOR_AMOUNT,
-  resolveEthenaAggregatorAmount,
+  resolveEthenaTranche,
 } = require("../../src/js/utils/ethenaPricing");
 
 const sUSDe = "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497";
+const adapterAddress = "0xe620AfB67223AE03C260112AE21A717Af94C90F0";
+const usde = (amount) => parseUnits(amount.toString(), 18);
+const NAV = parseUnits("1.24", 18);
 
-const logger = () => {
-  const messages = [];
-  return {
-    messages,
-    info: (message) => messages.push(message),
-  };
+const defaults = {
+  tranchePctBps: 3500,
+  trancheStepWei: usde(25000),
+  trancheMinWei: usde(25000),
+  ladder: "50:2.5,70:3.5,85:5",
+  ladderStepBps100: 25,
 };
 
-const multiBaseResolver = async () => ({
-  version: "multiBase",
-  baseAddress: sUSDe,
+const makeArm = ({ liquidity, total, calls = {} }) => ({
+  runner: "runner",
+  getReserves: async (baseAddress, overrides) => {
+    calls.getReserves = { baseAddress, overrides };
+    return [liquidity, 0n];
+  },
+  totalAssets: async (overrides) => {
+    calls.totalAssets = { overrides };
+    return total;
+  },
 });
 
-const legacyResolver = async () => ({
-  version: "legacy",
+const resolver = async ({ blockTag }) => ({
+  version: "multiBase",
   baseAddress: sUSDe,
+  liquidityAddress: "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+  config: {
+    adapter: adapterAddress,
+    baseAssetDecimals: 18,
+    crossPrice: parseUnits("0.99996", 36),
+    buyLiquidityRemaining: 0n,
+  },
+  blockTag,
 });
+
+const adapterFactory =
+  (calls = {}) =>
+  async (address, runner) => {
+    calls.adapter = { address, runner };
+    return {
+      convertToShares: async (assets, overrides) => {
+        calls.convertToShares = { assets, overrides };
+        return (assets * parseUnits("1", 18)) / NAV;
+      },
+    };
+  };
 
 const run = async () => {
   {
-    let getReservesCalled = false;
-    const log = logger();
-    const amount = await resolveEthenaAggregatorAmount({
-      amount: 123,
-      log,
-      arm: {
-        getReserves: async () => {
-          getReservesCalled = true;
-          return [parseUnits("456", 18), 0n];
-        },
-      },
-      resolveArmBaseFn: multiBaseResolver,
+    // 200k liquid of 1M total: u = 80%, ladder 4.5 bps, tranche 75k
+    const calls = {};
+    const result = await resolveEthenaTranche({
+      arm: makeArm({ liquidity: usde(200000), total: usde(1000000), calls }),
+      blockTag: 123,
+      maxBuyPrice: 0.99985,
+      resolveArmBaseFn: resolver,
+      adapterContractFn: adapterFactory(calls),
+      ...defaults,
     });
 
-    assert.strictEqual(amount, 123);
-    assert.strictEqual(getReservesCalled, false);
-    assert.deepStrictEqual(log.messages, [
-      "Using configured aggregator quote amount: 123 USDe",
-    ]);
+    assert.strictEqual(result.utilisationBps, 8000);
+    assert.strictEqual(result.ladderBps100, 450);
+    assert.strictEqual(result.buyAmount, usde(75000));
+    assert.strictEqual(typeof result.buyAmount, "bigint");
+    assert.strictEqual(result.maxBuyPrice, "0.99955");
+    assert.strictEqual(
+      parseUnits(result.maxBuyPrice, 36),
+      parseUnits("0.99955", 36),
+      "max buy price round-trips exactly through parseUnits",
+    );
+    assert.strictEqual(
+      result.amount,
+      formatUnits((usde(75000) * parseUnits("1", 18)) / NAV, 18),
+      "quote size is the tranche converted to sUSDe shares",
+    );
+    assert.strictEqual(calls.getReserves.baseAddress, sUSDe);
+    assert.deepStrictEqual(calls.getReserves.overrides, { blockTag: 123 });
+    assert.deepStrictEqual(calls.totalAssets.overrides, { blockTag: 123 });
+    assert.deepStrictEqual(calls.convertToShares.overrides, { blockTag: 123 });
+    assert.strictEqual(calls.convertToShares.assets, usde(75000));
+    assert.deepStrictEqual(calls.adapter, {
+      address: adapterAddress,
+      runner: "runner",
+    });
   }
 
   {
-    let requestedBaseAddress;
-    const amount = await resolveEthenaAggregatorAmount({
-      arm: {
-        getReserves: async (baseAddress) => {
-          requestedBaseAddress = baseAddress;
-          return [parseUnits("2789.123", 18), 0n];
-        },
-      },
-      resolveArmBaseFn: multiBaseResolver,
+    // idle ARM: u = 0, ladder floor 2.5 bps, tranche 35% of 1M = 350k
+    const result = await resolveEthenaTranche({
+      arm: makeArm({ liquidity: usde(1000000), total: usde(1000000) }),
+      maxBuyPrice: 0.99985,
+      resolveArmBaseFn: resolver,
+      adapterContractFn: adapterFactory(),
+      ...defaults,
     });
-
-    assert.strictEqual(requestedBaseAddress, sUSDe);
-    assert.strictEqual(amount, "2789.123");
+    assert.strictEqual(result.utilisationBps, 0);
+    assert.strictEqual(result.maxBuyPrice, "0.99975");
+    assert.strictEqual(result.buyAmount, usde(350000));
   }
 
   {
-    const amount = await resolveEthenaAggregatorAmount({
+    // a guard tighter than the ladder wins
+    const result = await resolveEthenaTranche({
+      arm: makeArm({ liquidity: usde(1000000), total: usde(1000000) }),
+      maxBuyPrice: 0.9997,
+      resolveArmBaseFn: resolver,
+      adapterContractFn: adapterFactory(),
+      ...defaults,
+    });
+    assert.strictEqual(result.maxBuyPrice, "0.9997");
+  }
+
+  {
+    // no guard: the ladder alone
+    const result = await resolveEthenaTranche({
+      arm: makeArm({ liquidity: usde(1000000), total: usde(1000000) }),
+      resolveArmBaseFn: resolver,
+      adapterContractFn: adapterFactory(),
+      ...defaults,
+    });
+    assert.strictEqual(result.maxBuyPrice, "0.99975");
+  }
+
+  {
+    // nearly empty ARM: tranche is the whole 5k, quote floored at 1,000 USDe
+    const calls = {};
+    const result = await resolveEthenaTranche({
+      arm: makeArm({ liquidity: usde(500), total: usde(1000000), calls }),
+      resolveArmBaseFn: resolver,
+      adapterContractFn: adapterFactory(calls),
+      ...defaults,
+    });
+    assert.strictEqual(result.utilisationBps, 9995);
+    assert.strictEqual(result.ladderBps100, 500);
+    assert.strictEqual(result.buyAmount, usde(500));
+    assert.strictEqual(
+      calls.convertToShares.assets,
+      MIN_ETHENA_AGGREGATOR_AMOUNT,
+    );
+  }
+
+  {
+    // empty ARM: zero tranche, quote still floored
+    const calls = {};
+    const result = await resolveEthenaTranche({
+      arm: makeArm({ liquidity: 0n, total: usde(1000000), calls }),
+      resolveArmBaseFn: resolver,
+      adapterContractFn: adapterFactory(calls),
+      ...defaults,
+    });
+    assert.strictEqual(result.buyAmount, 0n);
+    assert.strictEqual(
+      calls.convertToShares.assets,
+      MIN_ETHENA_AGGREGATOR_AMOUNT,
+    );
+  }
+
+  {
+    // named reserve tuple fields are supported
+    const result = await resolveEthenaTranche({
       arm: {
+        runner: "runner",
         getReserves: async () => ({
-          liquidityAssets: MIN_ETHENA_AGGREGATOR_AMOUNT,
+          liquidityAssets: usde(400000),
           baseAssetReserve: 0n,
         }),
+        totalAssets: async () => usde(1000000),
       },
-      resolveArmBaseFn: multiBaseResolver,
+      resolveArmBaseFn: resolver,
+      adapterContractFn: adapterFactory(),
+      ...defaults,
     });
-
-    assert.strictEqual(amount, "1000.0");
+    assert.strictEqual(result.utilisationBps, 6000);
+    assert.strictEqual(result.ladderBps100, 300);
+    assert.strictEqual(result.buyAmount, usde(150000));
   }
 
   {
-    const log = logger();
-    const amount = await resolveEthenaAggregatorAmount({
-      arm: {
-        getReserves: async () => [parseUnits("999.999", 18), 0n],
-      },
-      log,
-      resolveArmBaseFn: multiBaseResolver,
-    });
-
-    assert.strictEqual(amount, "1000.0");
-    assert.deepStrictEqual(log.messages, [
-      "Using minimum aggregator quote amount of 1000.0 USDe; only 999.999 USDe is withdrawable in ARM and lending market",
-    ]);
+    // legacy ARM is rejected
+    await assert.rejects(
+      resolveEthenaTranche({
+        arm: makeArm({ liquidity: usde(1), total: usde(1) }),
+        resolveArmBaseFn: async () => ({ version: "legacy" }),
+        adapterContractFn: adapterFactory(),
+        ...defaults,
+      }),
+      /requires a multi-base/,
+    );
   }
 
   {
-    let getReservesCalled = false;
-    const amount = await resolveEthenaAggregatorAmount({
-      arm: {
-        getReserves: async () => {
-          getReservesCalled = true;
-          return [parseUnits("456", 18), 0n];
+    // a bad ladder fails before any chain read
+    let read = false;
+    await assert.rejects(
+      resolveEthenaTranche({
+        arm: {
+          getReserves: async () => {
+            read = true;
+            return [0n, 0n];
+          },
+          totalAssets: async () => 0n,
         },
-      },
-      resolveArmBaseFn: legacyResolver,
-    });
-
-    assert.strictEqual(amount, "1000.0");
-    assert.strictEqual(getReservesCalled, false);
-  }
-
-  {
-    let commonPricingAmount;
-    const resolvedAmount = await resolveEthenaAggregatorAmount({
-      arm: {
-        getReserves: async () => [parseUnits("2654", 18), 0n],
-      },
-      resolveArmBaseFn: multiBaseResolver,
-    });
-
-    const setPricesForBases = async ({ options }) => {
-      commonPricingAmount = options.amount;
-    };
-    await setPricesForBases({
-      options: {
-        amount: resolvedAmount,
-        kyber: true,
-        inch: true,
-      },
-    });
-
-    assert.strictEqual(commonPricingAmount, "2654.0");
+        resolveArmBaseFn: resolver,
+        adapterContractFn: adapterFactory(),
+        ...defaults,
+        ladder: "70:3.5,50:2.5",
+      }),
+      /strictly increasing/,
+    );
+    assert.strictEqual(read, false);
   }
 };
 

--- a/test/js/tranchePricing.test.js
+++ b/test/js/tranchePricing.test.js
@@ -1,0 +1,197 @@
+const assert = require("assert");
+const { parseUnits } = require("ethers");
+
+const {
+  computeTranche,
+  computeUtilisationBps,
+  ladderDiscountBps100,
+  ladderMaxBuyPrice,
+  parseLadder,
+  resolveQuoteAmount,
+  scaledInt,
+  shouldRefreshBuyCap,
+} = require("../../src/js/utils/tranchePricing");
+
+const usde = (amount) => parseUnits(amount.toString(), 18);
+const STEP = usde(25000);
+const MIN = usde(25000);
+
+// scaledInt
+assert.strictEqual(scaledInt("2.5", 100, "bps"), 250);
+assert.strictEqual(scaledInt(0.25, 100, "bps"), 25);
+assert.strictEqual(scaledInt("0.7", 100, "u"), 70, "float noise is absorbed");
+assert.strictEqual(scaledInt(0.25, 10000, "tol"), 2500);
+assert.throws(() => scaledInt("2.505", 100, "bps"), /more precision/);
+assert.throws(() => scaledInt("abc", 100, "bps"), /Invalid/);
+assert.throws(() => scaledInt("", 100, "bps"), /Missing/);
+
+// parseLadder
+assert.deepStrictEqual(parseLadder("50:2.5,70:3.5,85:5"), [
+  { uBps: 5000, bps100: 250 },
+  { uBps: 7000, bps100: 350 },
+  { uBps: 8500, bps100: 500 },
+]);
+assert.deepStrictEqual(
+  parseLadder(" 0:3 "),
+  [{ uBps: 0, bps100: 300 }],
+  "a single knot is a flat ladder",
+);
+assert.throws(() => parseLadder(""), /Invalid ladder/);
+assert.throws(() => parseLadder(undefined), /Invalid ladder/);
+assert.throws(() => parseLadder("50:2.5,40:3"), /strictly increasing/);
+assert.throws(() => parseLadder("50:2.5,50:3"), /strictly increasing/);
+assert.throws(() => parseLadder("150:2.5"), /between 0 and 100/);
+assert.throws(() => parseLadder("50:-1"), /must be >= 0/);
+assert.throws(() => parseLadder("50"), /expected "u%:bps"/);
+assert.throws(() => parseLadder("50:2.5:3"), /expected "u%:bps"/);
+assert.throws(() => parseLadder("50:abc"), /Invalid ladder discount/);
+
+// ladderDiscountBps100
+const knots = parseLadder("50:2.5,70:3.5,85:5");
+assert.strictEqual(
+  ladderDiscountBps100(0, knots),
+  250,
+  "flat below first knot",
+);
+assert.strictEqual(ladderDiscountBps100(4999, knots), 250);
+assert.strictEqual(ladderDiscountBps100(5000, knots), 250, "at knot");
+assert.strictEqual(ladderDiscountBps100(6000, knots), 300, "midpoint 50-70");
+assert.strictEqual(ladderDiscountBps100(7000, knots), 350, "at knot");
+assert.strictEqual(ladderDiscountBps100(7750, knots), 425, "midpoint 70-85");
+assert.strictEqual(ladderDiscountBps100(8500, knots), 500, "at knot");
+assert.strictEqual(ladderDiscountBps100(10000, knots), 500, "flat above last");
+assert.strictEqual(
+  ladderDiscountBps100(5100, knots),
+  250,
+  "just above a knot stays on the notch (nearest, not ceil)",
+);
+assert.strictEqual(
+  ladderDiscountBps100(5250, knots),
+  275,
+  "ties round up (2.625 -> 2.75)",
+);
+assert.strictEqual(
+  ladderDiscountBps100(5249, knots),
+  250,
+  "just below the tie rounds down",
+);
+assert.strictEqual(
+  ladderDiscountBps100(6000, knots, 100),
+  300,
+  "custom step of 1 bps",
+);
+assert.strictEqual(
+  ladderDiscountBps100(5500, knots, 100),
+  300,
+  "2.75 with a 1 bps step rounds to 3",
+);
+assert.strictEqual(
+  ladderDiscountBps100(6000, parseLadder("0:3")),
+  300,
+  "single knot is flat everywhere",
+);
+assert.throws(() => ladderDiscountBps100(0, []), /at least one knot/);
+assert.throws(() => ladderDiscountBps100(0, knots, 0), /Invalid ladder step/);
+
+// ladderMaxBuyPrice
+assert.strictEqual(ladderMaxBuyPrice(250), parseUnits("0.99975", 36));
+assert.strictEqual(ladderMaxBuyPrice(275), parseUnits("0.999725", 36));
+assert.strictEqual(ladderMaxBuyPrice(500), parseUnits("0.9995", 36));
+assert.strictEqual(ladderMaxBuyPrice(0), parseUnits("1", 36));
+const crossPrice = parseUnits("0.99996", 36);
+for (let bps100 = 50; bps100 <= 1000; bps100 += 25) {
+  assert.ok(
+    ladderMaxBuyPrice(bps100) < crossPrice,
+    `${bps100 / 100} bps must price below the cross price`,
+  );
+}
+
+// computeUtilisationBps
+assert.strictEqual(computeUtilisationBps(usde(0), usde(100)), 10000);
+assert.strictEqual(computeUtilisationBps(usde(100), usde(0)), 10000);
+assert.strictEqual(computeUtilisationBps(usde(100), usde(100)), 0);
+assert.strictEqual(
+  computeUtilisationBps(usde(101), usde(100)),
+  0,
+  "liquidity above total assets (rounding noise) clamps to 0",
+);
+assert.strictEqual(computeUtilisationBps(usde(30), usde(100)), 7000);
+assert.strictEqual(computeUtilisationBps(usde(30), usde(101)), 7030);
+
+// computeTranche
+const tranche = (liquidity, pctBps = 3500) =>
+  computeTranche({
+    liquidityAssets: usde(liquidity),
+    pctBps,
+    stepWei: STEP,
+    minWei: MIN,
+  });
+assert.strictEqual(tranche(0), 0n, "no liquidity, no tranche");
+assert.strictEqual(tranche(20000), usde(20000), "below min: whole liquidity");
+assert.strictEqual(tranche(25000), usde(25000), "at min: whole liquidity");
+assert.strictEqual(tranche(50000), usde(25000), "17.5k rounds to 25k");
+assert.strictEqual(tranche(200000), usde(75000), "70k rounds to 75k");
+assert.strictEqual(tranche(250000), usde(100000), "87.5k ties up to 100k");
+assert.strictEqual(tranche(249000), usde(75000), "87.15k rounds down");
+assert.strictEqual(tranche(1000000), usde(350000));
+assert.strictEqual(tranche(30000, 10000), usde(25000), "100% rounds to 25k");
+assert.strictEqual(
+  tranche(26000, 10000),
+  usde(25000),
+  "never above liquidity would be 26k -> rounds to 25k",
+);
+assert.strictEqual(
+  computeTranche({
+    liquidityAssets: usde(40000),
+    pctBps: 10000,
+    stepWei: usde(30000),
+    minWei: usde(1000),
+  }),
+  usde(30000),
+  "rounding cannot exceed the liquidity",
+);
+assert.strictEqual(
+  computeTranche({
+    liquidityAssets: usde(46000),
+    pctBps: 10000,
+    stepWei: usde(30000),
+    minWei: usde(1000),
+  }),
+  usde(46000),
+  "rounding up above liquidity is clamped to the liquidity",
+);
+assert.throws(
+  () =>
+    computeTranche({
+      liquidityAssets: usde(100),
+      pctBps: 3500,
+      stepWei: 0n,
+      minWei: MIN,
+    }),
+  /step must be > 0/,
+);
+assert.throws(() => tranche(100, 0), /Invalid tranche percentage/);
+assert.throws(() => tranche(100, 10001), /Invalid tranche percentage/);
+
+// resolveQuoteAmount
+assert.strictEqual(resolveQuoteAmount(0n, usde(1000)), usde(1000));
+assert.strictEqual(resolveQuoteAmount(usde(999), usde(1000)), usde(1000));
+assert.strictEqual(resolveQuoteAmount(usde(75000), usde(1000)), usde(75000));
+
+// shouldRefreshBuyCap
+const refresh = (remaining, target, toleranceBps = 2500) =>
+  shouldRefreshBuyCap({
+    remaining: usde(remaining),
+    target: usde(target),
+    toleranceBps,
+  });
+assert.strictEqual(refresh(100, 100), false, "untouched tranche");
+assert.strictEqual(refresh(76, 100), false, "24% consumed");
+assert.strictEqual(refresh(75, 100), false, "exactly 25% consumed");
+assert.strictEqual(refresh(74, 100), true, "26% consumed");
+assert.strictEqual(refresh(101, 100), true, "tranche shrank below remaining");
+assert.strictEqual(refresh(0, 0), false, "empty ARM, empty tranche");
+assert.strictEqual(refresh(99, 100, 0), true, "zero tolerance is strict");
+assert.strictEqual(refresh(100, 100, 0), false);
+
+console.log("tranchePricing tests passed");


### PR DESCRIPTION
## Summary

- `setPricesEthena --tranche true`: the buy liquidity limit and the aggregator quote size are one tranche of the available liquidity (35% rounded to 25k, min 25k), so the price is quoted for the size actually offered.
- The max buy price follows a utilisation ladder (`--ladder 50:2.5,70:3.5,85:5` bps below NAV, linear, quantised to 0.25 bps) instead of the hand-tuned `--max-buy-price`, which stays as an absolute guard. The aggregator quote can only widen the discount.
- Cap-only updates are throttled: a transaction is sent once 25% of the tranche is consumed or the tranche shrank (`--cap-tolerance`), and an uncapped sell limit decremented by swaps no longer forces one.
- New pure module `src/js/utils/tranchePricing.js`; `ethenaPricing.js` rewritten (was dead code); `--dryrun` added to the action. Opt-in only, other ARMs unchanged.
- `migrations/seed_schedules.sql` is left as on `main` (the seed is a disabled skeleton). The live row in the Talos Postgres is what changes: command `setPricesEthena --network mainnet --tranche true --tolerance 0.3 --max-sell-price 0.99996 --offset 0.6 --fee 0.5 --kyber true` (drops `--buy-amount`, `--amount` and `--max-buy-price`) and cron `*/2 * * * *` (see below). `docs/ACTIONS.md` documents that target schedule.

## Cadence: why every 2 minutes

There is no on-chain watcher yet, so the cron is the only thing that reopens a consumed tranche and moves the ladder after a burst of fills. A static replay of the Jul 21 – Sep 3 fills (506 fills ≥ 100 USDe, 14.7M USDe, liquidity and total assets read at the previous block) gives:

| Delay since the previous fill | Share of volume |
| --- | --- |
| ≤ 1 min | 14% |
| ≤ 2 min | 22% |
| ≤ 5 min | 28% |
| ≤ 10 min | 39% |
| ≤ 20 min | 50% |

After a fill that consumes more than 75% of the tranche, the next fill arrives within 10 minutes in 27% of cases (within 5 minutes in 18%).

Replaying the tranche + ladder logic at different cadences (excess over the remaining tranche counted as blocked, i.e. the aggregator routes the rest elsewhere; "ladder lag" is the discount left on the table because the posted price reflects the utilisation of the last tick):

| Cadence | Blocked excess | Ladder lag | Estimated gain vs 10 min over 44 days |
| --- | --- | --- | --- |
| 10 min | 4.23M | 120 USDe | reference |
| 5 min | 3.90M | 67 USDe | ≈ 150 USDe |
| 2 min | 3.68M | 33 USDe | ≈ 245 USDe |
| 1 min | 3.60M | 26 USDe | ≈ 270 USDe |

Two minutes captures ~90% of the 1-minute benefit (≈ 2,000 USDe/year, ~+0.4 APY point on the current TVL). One minute adds little and risks overlapping runs: a run takes 8s without a transaction and 20–40s with one. The replay is static and pessimistic (blocked flow does not come back), so only the differences between cadences should be read.

## Gas impact: marginal

The cadence does not drive the number of transactions. Transactions are sent when the price moves by more than `--tolerance` (0.3 bps), when the ladder crosses a 0.25 bps notch, or when more than `--cap-tolerance` (25%) of the tranche has been consumed. Measured on the 1,341 `setPrices` transactions since Jul 21 (45k gas, 1.09 gwei median, 50 µETH ≈ $0.125 per transaction at ETH = $2,500):

| | Transactions / day | Gas / day | Gas / year |
| --- | --- | --- | --- |
| Today (`*/10`, strict cap comparison: every swap forces a resend) | 53 | $6.6 | ≈ $2,400 |
| This PR at `*/10` (replay estimate) | 10–20 | $1.3–2.5 | ≈ $450–900 |
| This PR at `*/2` (replay estimate, +2 tx/day for the extra cap refreshes) | 12–22 | $1.5–2.8 | ≈ $550–1,000 |

So the PR lowers the gas bill versus today, and moving from 10 to 2 minutes adds about $90/year against ≈ $2,000/year of extra edge. What does scale with the cadence is the Kyber and RPC call volume (720 runs/day instead of 144), to be checked against the API quotas.

## Verification (refreshed September 18, 2026)

- Merged current `main` (`3355340`), including `@oplabs/talos-client` 0.0.30 and the unlimited-cap fix from #351. Unlimited buy/sell targets do not trigger cap-only updates; tranche tolerance applies only to finite buy caps.
- Pricing regression suites pass: `NODE_PATH=./node_modules/.pnpm/node_modules node --test test/js/tranchePricing.test.js test/js/ethenaPricing.test.js test/js/armPrices.test.js test/js/pricing.test.js`. Covers consumed unlimited limits, finite tranche refreshes, and the exact tolerance boundary.
- `pnpm lint`, targeted Prettier checks, and `pnpm exec tsc --noEmit --typeRoots node_modules/.pnpm/node_modules/@types` pass. Explicit dependency paths match the pnpm layout used for the Docker catalog build.
- `NODE_PATH=./node_modules/.pnpm/node_modules node dump-actions-catalog.cjs` succeeds. All seven tranche flags and `--dryrun` match the Talos #39 whitelist and their expected parameter types.

### Earlier validation (September 3–7; not rerun for this refresh)

- `node test/js/{tranchePricing,ethenaPricing,armPrices,pricing}.test.js`: all pass.
- `pnpm lint`, `pnpm prettier:check` on the changed files: clean.
- Anvil mainnet fork with the operator impersonated: dry-run, real send (buy 0.9997, cap 75k at 59% utilisation), immediate rerun sends nothing; a swap consuming 13% of the tranche sends nothing, a cumulative 36% resends with the cap reset and the ladder moved to 3.25 bps.
- Dynamic replay of Jul 21–Sep 3 fills (not versioned): ladder adds +230 to +400 USDe of edge over the period in the conservative variant; the tranche is neutral at a 10-minute cadence and negative at an hourly one.

## Talos

The new flags must be whitelisted in Talos before operators can set them from the Edit Action dialog: [oplabs/talos#39](https://github.com/oplabs/talos/pull/39) adds `--tranche`, `--tranche-pct`, `--tranche-step`, `--tranche-min`, `--ladder`, `--ladder-step` and `--cap-tolerance` to `EDITABLE_FLAGS` (`--dryrun` was already there). The runner side needs no change beyond rebuilding the arm-oeth image, which regenerates the actions catalog from the hardhat params.

## Rollout

Previously recorded live command (recheck the live row before rollout):

```
cd /app && pnpm hardhat setPricesEthena --network mainnet --tolerance 0.3 --max-buy-price 0.99955 --buy-amount 250000 --max-sell-price 0.99996 --offset 0.6 --fee 0.5 --amount 200000 --kyber true
```

Proposed command (cron `*/2 * * * *`):

```
cd /app && pnpm hardhat setPricesEthena --network mainnet --tranche true --tranche-pct 35 --ladder 50:2.5,70:3.5,85:5 --cap-tolerance 0.25 --tolerance 0.3 --max-sell-price 0.99996 --offset 0.6 --fee 0.5 --kyber true
```

- `--buy-amount 250000` and `--amount 200000` go away: the tranche sets both the on-chain buy limit and the quote size.
- `--max-buy-price 0.99955` (4.5 bps) goes away: it would be tighter than the ladder below ~80% utilisation and make the ladder inert. The ladder already bounds the price between 2.5 and 5 bps below NAV.
- `--tranche-pct`, `--ladder` and `--cap-tolerance` are spelled out even though they are the defaults, so they are visible and editable in Talos; `--tranche-step`, `--tranche-min` (25k) and `--ladder-step` (0.25) stay on their defaults.
- `--tolerance 0.3`, `--max-sell-price 0.99996`, `--offset 0.6`, `--fee 0.5` and `--kyber true` are unchanged.

Steps:

1. Merge oplabs/talos#39 and this PR; wait for the Talos admin and arm-oeth runner image builds to succeed.
2. Deploy both images through the Talos signed release process. This whitelist change is admin-only: no new client release is needed; arm-oeth inherits the current 0.0.30 pin from `main`.
3. Run a parallel schedule with the proposed command plus `--dryrun true` for a few days and verify the quoted sizes, ladder prices, and cap refresh decisions.
4. Switch the `mainnet_set_prices_ethena` row to the proposed command and cron `*/2 * * * *`. Save its actual previous command and cron before changing it so they can be restored for rollback. The seed schedule remains unchanged.

The cadence, replay, and gas estimates above are historical September 3 measurements, not a fresh production replay. This PR refresh does not deploy images or alter the live schedule.
