### PR TITLE
fix(pricing): ignore consumed unlimited swap caps

### DIFF
--- a/src/js/utils/priceUpdate.js
+++ b/src/js/utils/priceUpdate.js
@@ -1,5 +1,7 @@
 const { formatUnits, parseUnits } = require("ethers");
 
+const { MAX_SWAP_LIQUIDITY } = require("./arm");
+
 const capDexAmountBySwapLiquidity = ({
   amount,
   buyLiquidity,
@@ -42,8 +44,10 @@ const resolveDexQuoteAmount = ({
 
 const haveSwapCapsChanged = (baseContext, buyAmount, sellAmount) =>
   baseContext.version === "multiBase" &&
-  (buyAmount !== baseContext.config.buyLiquidityRemaining ||
-    sellAmount !== baseContext.config.sellLiquidityRemaining);
+  ((buyAmount !== MAX_SWAP_LIQUIDITY &&
+    buyAmount !== baseContext.config.buyLiquidityRemaining) ||
+    (sellAmount !== MAX_SWAP_LIQUIDITY &&
+      sellAmount !== baseContext.config.sellLiquidityRemaining));
 
 const exceedsMaxBuyPrice = (targetBuyPrice, maxBuyPrice) =>
   maxBuyPrice !== undefined &&

--- a/test/js/armPrices.test.js
+++ b/test/js/armPrices.test.js
@@ -8,7 +8,7 @@ const {
   resolveDexQuoteAmount,
   shouldUpdatePrices,
 } = require("../../src/js/utils/priceUpdate");
-const { parseSwapCap } = require("../../src/js/utils/arm");
+const { MAX_SWAP_LIQUIDITY, parseSwapCap } = require("../../src/js/utils/arm");
 const { parseUnits } = require("ethers");
 
 assert.strictEqual(
@@ -53,6 +53,36 @@ assert.strictEqual(
   haveSwapCapsChanged(multiBaseContext(10n, 19n), 10n, 20n),
   true,
   "a changed sell amount should trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(
+    multiBaseContext(MAX_SWAP_LIQUIDITY - 10n, MAX_SWAP_LIQUIDITY - 20n),
+    MAX_SWAP_LIQUIDITY,
+    MAX_SWAP_LIQUIDITY,
+  ),
+  false,
+  "consuming unlimited swap liquidity should not trigger an update",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(
+    multiBaseContext(9n, MAX_SWAP_LIQUIDITY - 20n),
+    10n,
+    MAX_SWAP_LIQUIDITY,
+  ),
+  true,
+  "a changed finite cap should still trigger an update when the other cap is unlimited",
+);
+
+assert.strictEqual(
+  haveSwapCapsChanged(
+    multiBaseContext(10n, MAX_SWAP_LIQUIDITY - 20n),
+    10n,
+    MAX_SWAP_LIQUIDITY,
+  ),
+  false,
+  "an unchanged finite cap and consumed unlimited cap should not trigger an update",
 );
 
 assert.strictEqual(


### PR DESCRIPTION
## Summary

Small swaps against the USDC ARM were reducing its remaining liquidity from uint128.max, causing scheduled pricing actions to submit unnecessary setPrices transactions even though prices had not changed.

- Ignore ordinary consumption of swap liquidity when the configured cap is `uint128.max`.
- Prevent scheduled pricing actions from submitting redundant `setPrices` transactions when prices are unchanged.
- Continue triggering updates when explicitly configured finite caps change.
