### PR TITLE
Bump @oplabs/talos-client to 0.0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.7.0"
   },
   "peerDependencies": {
-    "@oplabs/talos-client": "0.0.28"
+    "@oplabs/talos-client": "0.0.29"
   },
   "peerDependenciesMeta": {
     "@oplabs/talos-client": {


### PR DESCRIPTION
Picks up the nonce-queue fix that stops a nonce being rolled back while its transaction is still live on chain (the 2026-09-01 relayer outage), plus the node-signing fallback and seed-file guard that were unpublished since 0.0.28.

Do not merge until oplabs/talos#40 has landed and v0.0.29 is published, since the image build installs this exact version.